### PR TITLE
Fixes #10 by using the scrollbar expanded size

### DIFF
--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -219,9 +219,9 @@ function LineWrapping.draw_guide(docview)
 end
 
 function LineWrapping.update_docview_breaks(docview)
-  local x,y,w,h = docview.v_scrollbar:get_thumb_rect()
+  local scrollbar_width = docview.v_scrollbar.expanded_size or style.expanded_scrollbar_size
   local width = (type(config.plugins.linewrapping.width_override) == "function" and config.plugins.linewrapping.width_override(docview))
-    or config.plugins.linewrapping.width_override or (docview.size.x - docview:get_gutter_width() - w)
+    or config.plugins.linewrapping.width_override or (docview.size.x - docview:get_gutter_width() - scrollbar_width)
   if (not docview.wrapped_settings or docview.wrapped_settings.width == nil or width ~= docview.wrapped_settings.width) then
     docview.scroll.to.x = 0
     LineWrapping.reconstruct_breaks(docview, docview:get_font(), width)


### PR DESCRIPTION
As described on issue #10 the linewrap plugin uses the docview width minus current scrollbar width to calculate the amount of text that can be visible. The scrollbar expand effect causes the wrapped text flow to change everytime the scrollbar is hovered. This commit fixes the issue by substracting from the docview width the full expanded size of the scrollbar.