### PR TITLE
Syntax files symbol_pattern, non_word_chars props

### DIFF
--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -237,11 +237,11 @@ command.add("core.docview!", {
     local first = ""
     if doc():has_selection() then
       local text = doc():get_text(doc():get_selection())
-      first = text:match(config.symbol_pattern) or ""
+      first = text:match(doc():get_symbol_pattern()) or ""
     end
     replace("Symbol", first, function(text, old, new)
       local n = 0
-      local res = text:gsub(config.symbol_pattern, function(sym)
+      local res = text:gsub(doc():get_symbol_pattern(), function(sym)
         if old == sym then
           n = n + 1
           return new

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -742,5 +742,25 @@ function Doc:on_close()
   core.log_quiet("Closed doc \"%s\"", self:get_name())
 end
 
+---Get the lua pattern used to match symbols on a document.
+---@return string
+function Doc:get_symbol_pattern()
+  return (self.syntax and self.syntax.symbol_pattern)
+    and self.syntax.symbol_pattern or config.symbol_pattern
+end
+
+---Get a string of characters not belonging to a word.
+---
+---Note: when setting `symbol` param to true the string of characters will be
+---retrieved from the document current syntax `symbol_non_word_chars` property
+---if available, otherwise will fallback to `config.non_word_chars`.
+---@param symbol boolean Indicates if non word characters are for a symbol
+---@return string
+function Doc:get_non_word_chars(symbol)
+  local non_word_chars = symbol and "symbol_non_word_chars" or "non_word_chars"
+  return (self.syntax and self.syntax[non_word_chars])
+    and self.syntax[non_word_chars] or config.non_word_chars
+end
+
 
 return Doc

--- a/data/core/doc/translate.lua
+++ b/data/core/doc/translate.lua
@@ -1,5 +1,4 @@
 local common = require "core.common"
-local config = require "core.config"
 
 -- functions for translating a Doc position to another position these functions
 -- can be passed to Doc:move_to|select_to|delete_to()
@@ -7,8 +6,8 @@ local config = require "core.config"
 local translate = {}
 
 
-local function is_non_word(char)
-  return config.non_word_chars:find(char, nil, true)
+local function is_non_word(doc, char)
+  return doc:get_non_word_chars():find(char, nil, true)
 end
 
 
@@ -33,7 +32,7 @@ function translate.previous_word_start(doc, line, col)
   while line > 1 or col > 1 do
     local l, c = doc:position_offset(line, col, -1)
     local char = doc:get_char(l, c)
-    if prev and prev ~= char or not is_non_word(char) then
+    if prev and prev ~= char or not is_non_word(doc, char) then
       break
     end
     prev, line, col = char, l, c
@@ -47,7 +46,7 @@ function translate.next_word_end(doc, line, col)
   local end_line, end_col = translate.end_of_doc(doc, line, col)
   while line < end_line or col < end_col do
     local char = doc:get_char(line, col)
-    if prev and prev ~= char or not is_non_word(char) then
+    if prev and prev ~= char or not is_non_word(doc, char) then
       break
     end
     line, col = doc:position_offset(line, col, 1)
@@ -61,7 +60,7 @@ function translate.start_of_word(doc, line, col)
   while true do
     local line2, col2 = doc:position_offset(line, col, -1)
     local char = doc:get_char(line2, col2)
-    if is_non_word(char)
+    if is_non_word(doc, char)
     or line == line2 and col == col2 then
       break
     end
@@ -75,7 +74,7 @@ function translate.end_of_word(doc, line, col)
   while true do
     local line2, col2 = doc:position_offset(line, col, 1)
     local char = doc:get_char(line, col)
-    if is_non_word(char)
+    if is_non_word(doc, char)
     or line == line2 and col == col2 then
       break
     end

--- a/data/plugins/language_css.lua
+++ b/data/plugins/language_css.lua
@@ -5,6 +5,8 @@ syntax.add {
   name = "CSS",
   files = { "%.css$" },
   block_comment = { "/*", "*/" },
+  symbol_pattern = "[%a_%-#%.][%w_%-]*",
+  symbol_non_word_chars = " \t\n/\\()\"':,;<>~!@$%^&*|+=[]{}`?",
   patterns = {
     { pattern = "\\.",                type = "normal"   },
     { pattern = "//.*",               type = "comment"  },


### PR DESCRIPTION
Added the ability of overwriting the default `config.symbol_pattern` and `config.non_word_chars` from language files by using the following properties:

* symbol_pattern
* non_word_chars
* symbol_non_word_chars - used by autocomplete plugin to detect the starting of a symbol when translating from current cursor position

This change will allow languages like css that support the `-` as part of a symbol name to define custom symbols pattern and non word characters for better autocompletion and lsp behavior.

Before and after demonstration with applied custom symbols pattern and non word chars to css language:

Before

https://github.com/pragtical/pragtical/assets/1702572/4ff9f8b8-ea7b-44b9-a4ef-9c4eafa3c6b0

After

https://github.com/pragtical/pragtical/assets/1702572/be9f710a-4397-42af-af59-a81e87738bf9

