### PR TITLE
Bundle plugin manager as a meson subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The name of the editor is a mixture of the words `pragmatic` and `practical`,
 two words that properly define our development approach as follows:
 
 * Government through practice and action rather than theory and speculation.
-* Willingness to see the context of actual use cases and not only idealistic ideals. 
+* Willingness to see the context of actual use cases and not only idealistic ideals.
 
 As a result [we believe](https://github.com/pragtical/pragtical/issues/6#issuecomment-1581650875) that new features introduced through pull requests should
 be evaluated by taking a practical approach, without going into lengthy idealistic
@@ -112,7 +112,7 @@ the build:
 ```sh
 meson setup --buildtype=release --prefix <prefix> build
 meson compile -C build
-DESTDIR="$(pwd)/pragtical" meson install --skip-subprojects -C build
+DESTDIR="$(pwd)/pragtical" meson install -C build
 ```
 
 where `<prefix>` might be one of `/`, `/usr` or `/opt`, the default is `/`.
@@ -121,7 +121,7 @@ To build a bundle application on macOS:
 ```sh
 meson setup --buildtype=release --Dbundle=true --prefix / build
 meson compile -C build
-DESTDIR="$(pwd)/Pragtical.app" meson install --skip-subprojects -C build
+DESTDIR="$(pwd)/Pragtical.app" meson install -C build
 ```
 
 Please note that the package is relocatable to any prefix and the option prefix

--- a/meson.build
+++ b/meson.build
@@ -215,7 +215,7 @@ if not get_option('source-only')
 endif
 
 #===============================================================================
-# Check for X11 existance to detect scale factor when video driver is x11
+# Check for X11 existence to detect scale factor when video driver is x11
 #===============================================================================
 if cc.find_library('X11', required : false).found()
     pragtical_cargs += '-DX11_FOUND'
@@ -277,70 +277,32 @@ foreach data_module : data_dirs
     install_subdir(join_paths('data', data_module), install_dir : pragtical_datadir)
 endforeach
 
-# Pull in widgets if neccesary
+# Pull in widgets if necessary
 fs = import('fs')
 if not fs.exists('data/widget/init.lua')
-    widget_path = subproject('widget').get_variable('widget_path')
-    install_subdir(
-        widget_path,
-        strip_directory : true,
-        install_dir : join_paths(pragtical_datadir, 'widget'),
-        exclude_files : ['meson.build', '.meson-subproject-wrap-hash.txt'],
-        exclude_directories : ['.git']
-    )
+    subproject('widget', default_options: ['data_dir='+pragtical_datadir])
 endif
 
 # Pull extra colors
 if get_option('extra_colors')
-    colors_path = subproject('colors').get_variable('colors_path')
-    install_subdir(join_paths(colors_path, 'colors'), install_dir : pragtical_datadir)
+    subproject('colors', default_options: ['data_dir='+pragtical_datadir])
 endif
 
 # Pull extra languages
 if get_option('extra_languages')
-    unix_shell = find_program('sh', required: false).found()
-    is_msvc = meson.get_compiler('c').get_id() == 'msvc'
-    if (host_machine.system() == 'windows' and not unix_shell) or is_msvc
-        unix_shell = false
-        shell_command = find_program('cmd', required: false)
+    subproject('plugins', default_options: ['data_dir='+pragtical_datadir])
+endif
+
+# Include the plugin manager
+if get_option('ppm')
+    ppm_prefer_static = ''
+    if get_option('wrap_mode') == 'forcefallback'
+        ppm_prefer_static = 'prefer_static=true'
     endif
-
-    if unix_shell or shell_command.found()
-        plugins_path = subproject('plugins').get_variable('plugins_path')
-
-        if unix_shell
-            list_command = run_command(
-                'sh', '-c', 'ls ' + plugins_path + '/plugins/language_*',
-                check: true
-            )
-        else
-            list_command = run_command(
-                'cmd', '/C', 'dir /b/s ' + plugins_path + '\\plugins\\language_*',
-                check: true
-            )
-        endif
-
-        sources = list_command.stdout().strip().split('\n')
-
-        # We need to do this because meson sandbox rules will not allow
-        # us to call install_data() from a subproject file :(
-        fs = import('fs')
-        if fs.is_dir('extra_languages')
-            if unix_shell
-                run_command('rm', '-rf', 'extra_languages', check: true)
-            else
-                run_command('rd', '/s', '/q', 'extra_languages', check: true)
-            endif
-        endif
-        run_command('mkdir', 'extra_languages', check: true)
-        foreach source : sources
-            run_command('cp', source,  'extra_languages', check: true)
-        endforeach
-        install_subdir('extra_languages',
-            strip_directory : true,
-            install_dir : join_paths(pragtical_datadir, 'plugins')
-        )
-    endif
+    subproject(
+        'ppm',
+        default_options: ['data_dir='+pragtical_datadir, ppm_prefer_static]
+    )
 endif
 
 configure_file(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,4 +7,5 @@ option('arch_tuple', type : 'string', value : '', description: 'Specify a custom
 option('use_system_lua', type : 'boolean', value : false, description: 'Prefer System Lua over the meson wrap')
 option('extra_colors', type : 'boolean', value : true, description: 'Include additional colors')
 option('extra_languages', type : 'boolean', value : true, description: 'Include additional language plugins')
+option('ppm', type : 'boolean', value : true, description: 'Include the plugin manager')
 option('jit', type : 'boolean', value : true, description: 'Use luajit')

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -134,7 +134,7 @@ generate_appimage() {
 
   echo "Creating Pragtical.AppDir..."
 
-  DESTDIR="$(realpath Pragtical.AppDir)" meson install --skip-subprojects -C ${BUILD_DIR}
+  DESTDIR="$(realpath Pragtical.AppDir)" meson install --skip-subprojects="freetype2,pcre2" -C ${BUILD_DIR}
   mv AppRun Pragtical.AppDir/
   # These could be symlinks but it seems they doesn't work with AppimageLauncher
   cp resources/icons/logo.svg Pragtical.AppDir/pragtical.svg

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -37,16 +37,16 @@ main() {
   fi
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6 lua5.3
+    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6 libmbedtls-dev lua5.3
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install bash ninja sdl2 lua
+    brew install bash ninja sdl2 lua mbedtls mbedtls@2
     pip3 install meson
     cd ~; npm install appdmg; cd -
     ~/node_modules/appdmg/bin/appdmg.js --version
   elif [[ "$OSTYPE" == "msys" ]]; then
     pacman --noconfirm -S \
-      ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2,lua} unzip
+      ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2,mbedtls,lua} unzip
   fi
 }
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -37,16 +37,16 @@ main() {
   fi
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6
+    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6 lua5.3
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install bash ninja sdl2
+    brew install bash ninja sdl2 lua
     pip3 install meson
     cd ~; npm install appdmg; cd -
     ~/node_modules/appdmg/bin/appdmg.js --version
   elif [[ "$OSTYPE" == "msys" ]]; then
     pacman --noconfirm -S \
-      ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2} unzip
+      ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2,lua} unzip
   fi
 }
 

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -46,7 +46,7 @@ main() {
     ~/node_modules/appdmg/bin/appdmg.js --version
   elif [[ "$OSTYPE" == "msys" ]]; then
     pacman --noconfirm -S \
-      ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,ntldd,pkg-config,mesa,freetype,pcre2,SDL2,mbedtls,lua} unzip
+      ${MINGW_PACKAGE_PREFIX}-{ca-certificates,gcc,meson,ninja,cmake,ntldd,pkg-config,mesa,freetype,pcre2,SDL2,mbedtls,lua} unzip
   fi
 }
 

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -191,7 +191,7 @@ main() {
 
   rm -rf "${dest_dir}"
 
-  DESTDIR="$(pwd)/${dest_dir}" meson install --skip-subprojects -C "${build_dir}"
+  DESTDIR="$(pwd)/${dest_dir}" meson install --skip-subprojects="freetype2,pcre2" -C "${build_dir}"
 
   local data_dir="$(pwd)/${dest_dir}/data"
   local exe_file="$(pwd)/${dest_dir}/pragtical"

--- a/subprojects/libgit2.wrap
+++ b/subprojects/libgit2.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/libgit2/libgit2.git
+revision = main
+depth = 1

--- a/subprojects/libzip.wrap
+++ b/subprojects/libzip.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/nih-at/libzip.git
+revision = head
+depth = 1

--- a/subprojects/mbedtls.wrap
+++ b/subprojects/mbedtls.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/Mbed-TLS/mbedtls.git
+revision = mbedtls-2.28.3
+depth = 1

--- a/subprojects/microtar.wrap
+++ b/subprojects/microtar.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/rxi/microtar.git
+revision = head
+depth = 1
+patch_directory = microtar
+
+[provide]
+microtar = microtar_dep

--- a/subprojects/packagefiles/colors/meson.build
+++ b/subprojects/packagefiles/colors/meson.build
@@ -1,4 +1,3 @@
-project('colors', version: 'GIT', license : 'MIT')
+project('colors', version: 'GIT', license: 'MIT')
 
-# Expose colors subproject path so it can be installed from main project
-colors_path = meson.current_source_dir()
+install_subdir('colors', install_dir: get_option('data_dir'))

--- a/subprojects/packagefiles/colors/meson_options.txt
+++ b/subprojects/packagefiles/colors/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/microtar/meson.build
+++ b/subprojects/packagefiles/microtar/meson.build
@@ -1,0 +1,8 @@
+project('microtar', 'c', version: 'GIT')
+
+microtar_lib = static_library('microtar', files('src/microtar.c'))
+
+microtar_dep = declare_dependency(
+    link_whole: [microtar_lib],
+    include_directories: ['src']
+)

--- a/subprojects/packagefiles/plugins/meson.build
+++ b/subprojects/packagefiles/plugins/meson.build
@@ -1,4 +1,30 @@
-project('plugins', version: 'GIT', license : 'MIT')
+project('plugins', version: 'GIT', license: 'MIT')
 
-# Expose plugins subproject path so it can be installed from main project
-plugins_path = meson.current_source_dir()
+# Check for valid shell
+unix_shell = find_program('sh', required: false).found()
+is_msvc = meson.get_compiler('c').get_id() == 'msvc'
+if (host_machine.system() == 'windows' and not unix_shell) or is_msvc
+    unix_shell = false
+    shell_command = find_program('cmd', required: false)
+endif
+
+# Install applicable language files if shell found
+if unix_shell or shell_command.found()
+    if unix_shell
+        list_command = run_command(
+            'sh', '-c', 'ls ' + 'plugins/language_*',
+            check: true
+        )
+    else
+        list_command = run_command(
+            'cmd', '/C', 'dir /b/s ' + 'plugins\\language_*',
+            check: true
+        )
+    endif
+
+    sources = list_command.stdout().strip().split('\n')
+
+    install_data(sources,
+        install_dir: join_paths(get_option('data_dir'), 'plugins')
+    )
+endif

--- a/subprojects/packagefiles/plugins/meson_options.txt
+++ b/subprojects/packagefiles/plugins/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -100,21 +100,35 @@ else
         build_shared = 'OFF'
     endif
 
+    inc_dirs = []
+    link_args = []
+    extra_deps = []
+    
+    if host_machine.system() == 'darwin'
+        link_args += ['-framework', 'Security', '-framework', 'Foundation']
+        extra_deps += cc.find_library('iconv')
+    endif
+
     # zlib
     zlib_options = cmake.subproject_options()
     zlib_options.add_cmake_defines({
         'CMAKE_BUILD_TYPE': build_type,
         'BUILD_SHARED_LIBS': 'OFF',
+        'CMAKE_OSX_DEPLOYMENT_TARGET': '10.11'
     })
     zlib_options.set_install(false)
 
-    zlib_dep = cmake.subproject('zlib', options: zlib_options).dependency('zlibstatic')
+    zlib = cmake.subproject('zlib', options: zlib_options)
+    zlib_dep = zlib.dependency('zlibstatic')
+
+    inc_dirs += zlib.include_directories('zlibstatic')
 
     # mbedtls
     mbedtls_options = cmake.subproject_options()
     mbedtls_options.add_cmake_defines({
         'CMAKE_BUILD_TYPE': build_type,
         'BUILD_SHARED_LIBS': 'OFF',
+        'CMAKE_OSX_DEPLOYMENT_TARGET': '10.11',
         'ENABLE_TESTING': 'OFF',
         'ENABLE_PROGRAMS': 'OFF',
         'CMAKE_C_FLAGS': '-DMBEDTLS_MD4_C=1 -w',
@@ -125,12 +139,15 @@ else
     mbedtls_dep = mbedtls.dependency('mbedtls')
     mbedx509_dep = mbedtls.dependency('mbedx509')
     mbedcrypto_dep = mbedtls.dependency('mbedcrypto')
+    
+    inc_dirs += mbedtls.include_directories('mbedtls')
 
     # libzip
     libzip_options = cmake.subproject_options()
     libzip_options.add_cmake_defines({
         'CMAKE_BUILD_TYPE': build_type,
         'BUILD_SHARED_LIBS': 'OFF',
+        'CMAKE_OSX_DEPLOYMENT_TARGET': '10.11',
         'BUILD_TOOLS': 'OFF',
         'BUILD_EXAMPLES': 'OFF',
         'BUILD_DOC': 'OFF',
@@ -146,13 +163,17 @@ else
     })
     libzip_options.set_install(false)
 
-    libzip_dep = cmake.subproject('libzip', options: libzip_options).dependency('zip')
+    libzip = cmake.subproject('libzip', options: libzip_options)
+    libzip_dep = libzip.dependency('zip')
+
+    inc_dirs += libzip.include_directories('zip')
 
     # libgit2
     libgit2_options = cmake.subproject_options()
     libgit2_options.add_cmake_defines({
         'CMAKE_BUILD_TYPE': build_type,
         'BUILD_SHARED_LIBS': 'OFF',
+        'CMAKE_OSX_DEPLOYMENT_TARGET': '10.11',
         'BUILD_TESTS': 'OFF',
         'BUILD_CLI': 'OFF',
         'REGEX_BACKEND': 'builtin',
@@ -166,19 +187,22 @@ else
     libgit2_options.set_install(false)
 
     libgit2 = cmake.subproject('libgit2', options: libgit2_options)
-    libgit2_dep = libgit2.dependency('libgit2')
-    libgit2_ntlmclient_dep = libgit2.dependency('ntlmclient')
-    libtgit2_libgit2package_dep = libgit2.dependency('libgit2package')
+    libgit2_deps = []
+    libgit2_deps += libgit2.dependency('libgit2')
+    libgit2_deps += libgit2.dependency('libgit2package')
+    
+    libgit2_deps += libgit2.dependency('ntlmclient')
 
     executable(
         'ppm',
         files('src/ppm.c') + ppm_lua_c,
+        link_args: link_args,
+        include_directories: inc_dirs,
         dependencies: [
             zlib_dep, libzip_dep,
             mbedtls_dep, mbedx509_dep, mbedcrypto_dep,
-            libgit2_ntlmclient_dep, libtgit2_libgit2package_dep, libgit2_dep,
             lua_dep, microtar_dep
-        ],
+        ] + libgit2_deps + extra_deps,
         c_args: ['-DPPM_STATIC'],
         install: true,
         install_dir: join_paths(get_option('data_dir'), 'plugins/plugin_manager')
@@ -189,3 +213,4 @@ install_subdir(
     'plugins/plugin_manager',
     install_dir: join_paths(get_option('data_dir'), 'plugins')
 )
+

--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -1,0 +1,191 @@
+project('ppm',
+    ['c'],
+    version : 'GIT',
+    license : 'PPM',
+    meson_version : '>= 0.60'
+)
+
+cc = meson.get_compiler('c')
+
+lua_exe = find_program('lua')
+
+ppm_lua_c = configure_file(
+    capture: false,
+    command: [lua_exe, '-e', 'f = string.dump(assert(loadfile("@INPUT0@"))) io.open("@OUTPUT0@", "wb"):write("unsigned char ppm_luac[] = \"" .. f:gsub(".", function (c) return string.format("\\\x%02X",string.byte(c)) end) .. "\";unsigned int ppm_luac_len = " .. #f .. ";")'],
+    input: files('src/ppm.lua'),
+    output: 'ppm.lua.c'
+)
+
+# Special checking for lua dependency due to distro differences
+lua_names = [
+    'lua5.4', # Debian
+    'lua-5.4', # FreeBSD
+    'lua',    # Fedora
+]
+
+foreach lua : lua_names
+    last_lua = (lua == lua_names[-1] or get_option('wrap_mode') == 'forcefallback')
+    lua_dep = dependency(lua, fallback: last_lua ? ['lua', 'lua_dep'] : [], required : false,
+        version: '>= 5.4',
+        default_options: ['default_library=static', 'line_editing=disabled', 'interpreter=false']
+    )
+    if lua_dep.found()
+        break
+    endif
+
+    if last_lua
+        # If we could not find lua on the system and fallbacks are disabled
+        # try the compiler as a last ditch effort, since Lua has no official
+        # pkg-config support.
+        lua_dep = cc.find_library('lua', required : true)
+    endif
+endforeach
+
+# Search the rest of dependencies
+microtar_dep = subproject('microtar').get_variable('microtar_dep')
+
+if get_option('wrap_mode') != 'forcefallback'
+    zlib_dep = dependency('zlib')
+    mbedtls_dep = dependency('mbedtls', version: '<3', required: false)
+    libgit2_dep = dependency('libgit2')
+    libzip_dep = dependency('libzip')
+
+    if not mbedtls_dep.found()
+        # Using has_headers to distinguish between mbedtls2 and mbedtls3
+        _mbedtls_dep = cc.find_library('mbedtls', has_headers: 'mbedtls/net.h', required: false)
+        if _mbedtls_dep.found()
+            mbedtls_dep = [
+                _mbedtls_dep,
+                cc.find_library('mbedx509'),
+                cc.find_library('mbedcrypto'),
+            ]
+        else
+            # In some cases we need to manually specify where to find mbedtls2
+            message('Using fallback mbedtls definition')
+            mbedtls_dep = declare_dependency(
+                include_directories: ['/usr/include/mbedtls2/'],
+                link_args: ['-L/usr/lib/mbedtls2', '-lmbedtls', '-lmbedx509', '-lmbedcrypto']
+            )
+        endif
+    endif
+
+    executable(
+        'ppm',
+        files('src/ppm.c') + ppm_lua_c,
+        dependencies: [
+            zlib_dep, mbedtls_dep, libgit2_dep, libzip_dep, lua_dep, microtar_dep
+        ],
+        c_args: ['-DPPM_STATIC'],
+        install: true,
+        install_dir: join_paths(get_option('data_dir'), 'plugins/plugin_manager')
+    )
+else
+    cmake = import('cmake')
+
+    build_type = 'Release'
+    if get_option('buildtype') == 'debug'
+        build_type = 'Debug'
+    endif
+
+    if meson.get_compiler('c').get_id() != 'msvc'
+        INC='-I'
+        LIB='-L'
+    else
+        INC='/I'
+        LIB='/LIBPATH:'
+    endif
+
+    build_shared = 'ON'
+    if get_option('default_library') == 'static'
+        build_shared = 'OFF'
+    endif
+
+    # zlib
+    zlib_options = cmake.subproject_options()
+    zlib_options.add_cmake_defines({
+        'CMAKE_BUILD_TYPE': build_type,
+        'BUILD_SHARED_LIBS': 'OFF',
+    })
+    zlib_options.set_install(false)
+
+    zlib_dep = cmake.subproject('zlib', options: zlib_options).dependency('zlibstatic')
+
+    # mbedtls
+    mbedtls_options = cmake.subproject_options()
+    mbedtls_options.add_cmake_defines({
+        'CMAKE_BUILD_TYPE': build_type,
+        'BUILD_SHARED_LIBS': 'OFF',
+        'ENABLE_TESTING': 'OFF',
+        'ENABLE_PROGRAMS': 'OFF',
+        'CMAKE_C_FLAGS': '-DMBEDTLS_MD4_C=1 -w',
+    })
+    mbedtls_options.set_install(false)
+
+    mbedtls = cmake.subproject('mbedtls', options: mbedtls_options)
+    mbedtls_dep = mbedtls.dependency('mbedtls')
+    mbedx509_dep = mbedtls.dependency('mbedx509')
+    mbedcrypto_dep = mbedtls.dependency('mbedcrypto')
+
+    # libzip
+    libzip_options = cmake.subproject_options()
+    libzip_options.add_cmake_defines({
+        'CMAKE_BUILD_TYPE': build_type,
+        'BUILD_SHARED_LIBS': 'OFF',
+        'BUILD_TOOLS': 'OFF',
+        'BUILD_EXAMPLES': 'OFF',
+        'BUILD_DOC': 'OFF',
+        'ENABLE_COMMONCRYPTO': 'OFF',
+        'ENABLE_GNUTLS': 'OFF',
+        'ENABLE_OPENSSL': 'OFF',
+        'ENABLE_BZIP2': 'OFF',
+        'ENABLE_LZMA': 'OFF',
+        'ENABLE_ZSTD': 'OFF',
+        'CMAKE_C_FLAGS':
+            INC + meson.source_root() / 'subprojects' / 'mbedtls' / 'include '
+            + LIB + meson.build_root() / 'subprojects' / 'mbedtls' / '__CMake_build'
+    })
+    libzip_options.set_install(false)
+
+    libzip_dep = cmake.subproject('libzip', options: libzip_options).dependency('zip')
+
+    # libgit2
+    libgit2_options = cmake.subproject_options()
+    libgit2_options.add_cmake_defines({
+        'CMAKE_BUILD_TYPE': build_type,
+        'BUILD_SHARED_LIBS': 'OFF',
+        'BUILD_TESTS': 'OFF',
+        'BUILD_CLI': 'OFF',
+        'REGEX_BACKEND': 'builtin',
+        'USE_SSH': 'OFF',
+        'USE_HTTPS': 'mbedTLS',
+        'CMAKE_C_FLAGS':
+            INC + meson.source_root() / 'subprojects' / 'mbedtls' / 'include '
+            + LIB + meson.build_root() / 'subprojects' / 'mbedtls' / '__CMake_build '
+            + LIB + meson.build_root() / 'subprojects' / 'libzip' / '__CMake_build'
+    })
+    libgit2_options.set_install(false)
+
+    libgit2 = cmake.subproject('libgit2', options: libgit2_options)
+    libgit2_dep = libgit2.dependency('libgit2')
+    libgit2_ntlmclient_dep = libgit2.dependency('ntlmclient')
+    libtgit2_libgit2package_dep = libgit2.dependency('libgit2package')
+
+    executable(
+        'ppm',
+        files('src/ppm.c') + ppm_lua_c,
+        dependencies: [
+            zlib_dep, libzip_dep,
+            mbedtls_dep, mbedx509_dep, mbedcrypto_dep,
+            libgit2_ntlmclient_dep, libtgit2_libgit2package_dep, libgit2_dep,
+            lua_dep, microtar_dep
+        ],
+        c_args: ['-DPPM_STATIC'],
+        install: true,
+        install_dir: join_paths(get_option('data_dir'), 'plugins/plugin_manager')
+    )
+endif
+
+install_subdir(
+    'plugins/plugin_manager',
+    install_dir: join_paths(get_option('data_dir'), 'plugins')
+)

--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -103,7 +103,7 @@ else
     inc_dirs = []
     link_args = []
     extra_deps = []
-    
+
     if host_machine.system() == 'darwin'
         link_args += ['-framework', 'Security', '-framework', 'Foundation']
         extra_deps += cc.find_library('iconv')
@@ -139,7 +139,7 @@ else
     mbedtls_dep = mbedtls.dependency('mbedtls')
     mbedx509_dep = mbedtls.dependency('mbedx509')
     mbedcrypto_dep = mbedtls.dependency('mbedcrypto')
-    
+
     inc_dirs += mbedtls.include_directories('mbedtls')
 
     # libzip
@@ -190,8 +190,10 @@ else
     libgit2_deps = []
     libgit2_deps += libgit2.dependency('libgit2')
     libgit2_deps += libgit2.dependency('libgit2package')
-    
-    libgit2_deps += libgit2.dependency('ntlmclient')
+    if host_machine.system() != 'windows'
+        libgit2_deps += libgit2.dependency('ntlmclient')
+    endif
+
 
     executable(
         'ppm',
@@ -213,4 +215,3 @@ install_subdir(
     'plugins/plugin_manager',
     install_dir: join_paths(get_option('data_dir'), 'plugins')
 )
-

--- a/subprojects/packagefiles/ppm/meson_options.txt
+++ b/subprojects/packagefiles/ppm/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/packagefiles/widget/meson.build
+++ b/subprojects/packagefiles/widget/meson.build
@@ -1,4 +1,9 @@
 project('widget', version: 'GIT', license : 'MIT')
 
-# Expose widget subproject path so it can be installed from main project
-widget_path = meson.current_source_dir()
+install_subdir(
+    '.',
+    strip_directory: true,
+    install_dir: join_paths(get_option('data_dir'), 'widget'),
+    exclude_files: ['meson.build', '.meson-subproject-wrap-hash.txt'],
+    exclude_directories: ['.git']
+)

--- a/subprojects/packagefiles/widget/meson_options.txt
+++ b/subprojects/packagefiles/widget/meson_options.txt
@@ -1,0 +1,1 @@
+option('data_dir', type : 'string', value : '/', description: 'Data directory of installation')

--- a/subprojects/ppm.wrap
+++ b/subprojects/ppm.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/pragtical/plugin-manager.git
+revision = head
+depth = 1
+patch_directory = ppm

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/madler/zlib.git
+revision = head
+depth = 1


### PR DESCRIPTION
* Adds ppm as a subproject and all related dependencies as cmake subprojects
* ppm is built statically on forcefallback mode except for the usual libm, libc stuff...
* Use subprojects: colors, plugins,widget,ppm for file installing which should be the proper way, to disable other subprojects one can use `--skip-subprojects="freetype2,pcre2"` on the `meson install` step.
* Updated scripts to skip projects that should not be installed
* Removed `--skip-subprojects` from readme file, better instructions to be added later...

#33 implements this functionality without using cmake subprojects because meson doesn't supports linking against self provided cmake subproject dependencies.