### PR TITLE
Fix editor crash on invalid UTF-8

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -82,6 +82,7 @@ function Highlighter:soft_reset()
 end
 
 function Highlighter:invalidate(idx)
+  if self.lines_cleaned[idx] then self.lines_cleaned[idx] = nil end
   self.first_invalid_line = math.min(self.first_invalid_line, idx)
   set_max_wanted_lines(self, math.min(self.max_wanted_line, #self.doc.lines))
 end

--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -25,11 +25,11 @@ function Highlighter:start()
       for i = self.first_invalid_line, max do
         local state = (i > 1) and self.lines[i - 1].state
         local line = self.lines[i]
-        if line and line.resume and (line.init_state ~= state or line.text ~= self.doc:get_line(i)) then
+        if line and line.resume and (line.init_state ~= state or line.text ~= self.doc:get_utf8_line(i)) then
           -- Reset the progress if no longer valid
           line.resume = nil
         end
-        if not (line and line.init_state == state and line.text == self.doc:get_line(i) and not line.resume) then
+        if not (line and line.init_state == state and line.text == self.doc:get_utf8_line(i) and not line.resume) then
           retokenized_from = retokenized_from or i
           self.lines[i] = self:tokenize_line(i, state, line and line.resume)
           if self.lines[i].resume then
@@ -103,7 +103,7 @@ end
 function Highlighter:tokenize_line(idx, state, resume)
   local res = {}
   res.init_state = state
-  res.text = self.doc:get_line(idx)
+  res.text = self.doc:get_utf8_line(idx)
   res.tokens, res.state, res.resume = tokenizer.tokenize(self.doc.syntax, res.text, state, resume)
   return res
 end
@@ -111,7 +111,7 @@ end
 
 function Highlighter:get_line(idx)
   local line = self.lines[idx]
-  if not line or line.text ~= self.doc:get_line(idx) then
+  if not line or line.text ~= self.doc:get_utf8_line(idx) then
     local prev = self.lines[idx - 1]
     line = self:tokenize_line(idx, prev and prev.state)
     self.lines[idx] = line

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -121,7 +121,7 @@ function Doc:load(filename)
       table.insert(self.lines, line .. "\n")
       if not line:uisvalid() then
         self.binary = true
-        self.clean_lines[i] = line:uclean("?", true) .. "\n"
+        self.clean_lines[i] = line:uclean("\26", true) .. "\n"
       end
       self.highlighter.lines[i] = false
       i = i + 1
@@ -494,7 +494,7 @@ local function update_clean_lines(self, line1, line2)
     for i=line1, line2 do
       local clean_text, was_valid = "", true
       if self.lines[i] then
-        clean_text, was_valid = self.lines[i]:uclean("?", true)
+        clean_text, was_valid = self.lines[i]:uclean("\26", true)
       end
       if self.clean_lines[i] then self.clean_lines[i] = nil end
       if not was_valid then self.clean_lines[i] = clean_text end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -72,7 +72,10 @@ function Doc:load(filename)
   if not self.encoding then
     local errmsg
     self.encoding, errmsg = encoding.detect(filename);
-    if not self.encoding then core.error("%s", errmsg) error(errmsg) end
+    if not self.encoding then
+      core.error("%s", errmsg)
+      self.encoding = "UTF-8"
+    end
   end
   self.convert = false
   if self.encoding ~= "UTF-8" and self.encoding ~= "ASCII" then

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -23,6 +23,7 @@ function Doc:new(filename, abs_filename, new_file)
   self.new_file = new_file
   self.encoding = nil
   self.convert = false
+  self.binary = false
   self:reset()
   if filename then
     self:set_filename(filename, abs_filename)
@@ -43,6 +44,14 @@ function Doc:reset()
   self.highlighter = Highlighter(self)
   self.overwrite = false
   self:reset_syntax()
+end
+
+
+function Doc:get_line(idx)
+  if self.binary and self.clean_lines[idx] then
+    return self.clean_lines[idx]
+  end
+  return self.lines[idx]
 end
 
 
@@ -84,6 +93,7 @@ function Doc:load(filename)
   local fp = assert( io.open(filename, "rb") )
   self:reset()
   self.lines = {}
+  self.clean_lines = {}
   local i = 1
   if self.convert then
     local content = fp:read("*a");
@@ -109,6 +119,10 @@ function Doc:load(filename)
         self.crlf = true
       end
       table.insert(self.lines, line .. "\n")
+      if not line:uisvalid() then
+        self.binary = true
+        self.clean_lines[i] = line:uclean("?", true) .. "\n"
+      end
       self.highlighter.lines[i] = false
       i = i + 1
     end
@@ -207,7 +221,7 @@ end
 function Doc:is_dirty()
   if self.new_file then
     if self.filename then return true end
-    return #self.lines > 1 or #self.lines[1] > 1
+    return #self.lines > 1 or #self:get_line(1) > 1
   else
     return self.clean_change_id ~= self:get_change_id()
   end
@@ -367,11 +381,11 @@ end
 function Doc:sanitize_position(line, col)
   local nlines = #self.lines
   if line > nlines then
-    return nlines, #self.lines[nlines]
+    return nlines, #self:get_line(nlines)
   elseif line < 1 then
     return 1, 1
   end
-  return line, common.clamp(col, 1, #self.lines[line])
+  return line, common.clamp(col, 1, #self:get_line(line))
 end
 
 
@@ -386,10 +400,10 @@ local function position_offset_byte(self, line, col, offset)
   col = col + offset
   while line > 1 and col < 1 do
     line = line - 1
-    col = col + #self.lines[line]
+    col = col + #self:get_line(line)
   end
-  while line < #self.lines and col > #self.lines[line] do
-    col = col - #self.lines[line]
+  while line < #self.lines and col > #self:get_line(line) do
+    col = col - #self:get_line(line)
     line = line + 1
   end
   return self:sanitize_position(line, col)
@@ -432,7 +446,7 @@ end
 
 function Doc:get_char(line, col)
   line, col = self:sanitize_position(line, col)
-  return self.lines[line]:sub(col, col)
+  return self:get_line(line):sub(col, col)
 end
 
 
@@ -475,6 +489,19 @@ local function pop_undo(self, undo_stack, redo_stack, modified)
   end
 end
 
+local function update_clean_lines(self, line1, line2)
+  if self.binary then
+    for i=line1, line2 do
+      local clean_text, was_valid = "", true
+      if self.lines[i] then
+        clean_text, was_valid = self.lines[i]:uclean("?", true)
+      end
+      if self.clean_lines[i] then self.clean_lines[i] = nil end
+      if not was_valid then self.clean_lines[i] = clean_text end
+    end
+  end
+end
+
 
 function Doc:raw_insert(line, col, text, undo_stack, time)
   -- split text into lines and merge with line at insertion point
@@ -490,6 +517,8 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
 
   -- splice lines into line array
   common.splice(self.lines, line, 1, lines)
+
+  update_clean_lines(self, line, ((line + #lines - 1) == line) and line or #self.lines)
 
   -- keep cursors where they should be
   for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
@@ -525,6 +554,8 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
 
   -- splice line into line array
   common.splice(self.lines, line1, line_removal + 1, { before .. after })
+
+  update_clean_lines(self, line1, line2 == line1 and line2 or #self.lines)
 
   local merge = false
 
@@ -605,7 +636,7 @@ function Doc:text_input(text, idx)
 
     if self.overwrite
     and (line1 == line2 and col1 == col2)
-    and col1 < #self.lines[line1]
+    and col1 < #self:get_line(line1)
     and text:ulen() == 1 then
       self:remove(line1, col1, translate.next_char(self, line1, col1))
     end

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -35,6 +35,14 @@ config.plugins.drawwhitespace = common.merge({
       char = "\t",
       sub = "»",
     },
+    {
+      char = "\26",
+      sub = "█",
+      show_leading = true,
+      show_trailing = true,
+      show_middle = true,
+      binary_only = true
+    },
   },
 
   config_spec = {
@@ -226,9 +234,13 @@ function DocView:draw_line_text(idx, x, y)
     local cache = {}
 
     local tx
-    local text = self.doc.lines[idx]
+    local text = self.doc:get_line(idx)
 
     for _, substitution in pairs(config.plugins.drawwhitespace.substitutions) do
+      if substitution.binary_only and not self.doc.binary then
+        goto continue
+      end
+
       local char = substitution.char
       local sub = substitution.sub
       local offset = 1
@@ -289,6 +301,7 @@ function DocView:draw_line_text(idx, x, y)
         end
         offset = e + 1
       end
+      ::continue::
     end
     ws_cache[self.doc.highlighter][idx] = cache
   end

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -234,7 +234,7 @@ function DocView:draw_line_text(idx, x, y)
     local cache = {}
 
     local tx
-    local text = self.doc:get_line(idx)
+    local text = self.doc:get_utf8_line(idx)
 
     for _, substitution in pairs(config.plugins.drawwhitespace.substitutions) do
       if substitution.binary_only and not self.doc.binary then

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -72,7 +72,7 @@ local LineWrapping = {}
 
 -- Optimzation function. The tokenizer is relatively slow (at present), and
 -- so if we don't need to run it, should be run sparingly.
-local function spew_tokens(doc, line) if line < math.huge then return math.huge, "normal", doc.lines[line] end end
+local function spew_tokens(doc, line) if line < math.huge then return math.huge, "normal", doc:get_utf8_line(line) end end
 local function get_tokens(doc, line)
   if config.plugins.linewrapping.require_tokenization then
     return doc.highlighter:each_token(line)

--- a/docs/api/string.lua
+++ b/docs/api/string.lua
@@ -152,9 +152,10 @@ function string.uisvalid(s) end
 ---Equivalent to utf8extra.clean()
 ---@param s string
 ---@param replacement_string? string
+---@param non_consecutive? boolean
 ---@return string cleaned_string
 ---@return boolean was_valid
-function string.uclean(s, replacement_string) end
+function string.uclean(s, replacement_string, non_consecutive) end
 
 ---Equivalent to utf8extra.invalidoffset()
 ---@param s string

--- a/docs/api/utf8extra.lua
+++ b/docs/api/utf8extra.lua
@@ -198,13 +198,15 @@ function utf8extra.isvalid(s) end
 ---Replace any invalid UTF-8 byte sequences in s with the replacement string.
 ---if no replacement string is provided, the default is "�" (REPLACEMENT CHARACTER U+FFFD).
 ---Note that any number of consecutive invalid bytes will be replaced by a
----single copy of the replacement string. the 2nd return value is true if the
----original string was already valid (meaning no replacements were made).
+---single copy of the replacement string unless the non_consecutive param is
+---set to true. the 2nd return value is true if the original string was already
+---valid (meaning no replacements were made).
 ---@param s string
 ---@param replacement_string? string
+---@param non_consecutive? boolean
 ---@return string cleaned_string
 ---@return boolean was_valid
-function utf8extra.clean(s, replacement_string) end
+function utf8extra.clean(s, replacement_string, non_consecutive) end
 
 ---Return the byte offset within s of the first invalid UTF-8 byte sequence.
 ---(1 is the first byte of the string.) if s is a valid UTF-8 string, return

--- a/src/api/utf8.c
+++ b/src/api/utf8.c
@@ -1779,6 +1779,7 @@ static int Lutf8_clean(lua_State *L) {
   /* Default replacement string is REPLACEMENT CHARACTER U+FFFD */
   size_t repl_len;
   const char *r = luaL_optlstring(L, 2, "\xEF\xBF\xBD", &repl_len);
+  int continuous = !lua_toboolean(L, 3);
 
   if (lua_gettop(L) > 1) {
     /* Check if replacement string is valid UTF-8 or not */
@@ -1811,6 +1812,7 @@ static int Lutf8_clean(lua_State *L) {
     while (s == invalid) {
       s++;
       invalid = utf8_invalid_offset(s, e);
+      if (!continuous) break;
     }
     if (invalid == NULL) {
       luaL_addlstring(&buff, s, e - s);


### PR DESCRIPTION
* Uses new functionality introduced on lite-xl/lite-xl#1613
* utf8extra.clean function is employed on highlighter to replace invalid UTF-8 sequences on document lines with ~~'�'~~ '\26'
* Adds `non_continous` boolean extra parameter to `utf8extra.clean` to replace all invidividual bytes instead of complete sequences.

## TODO Ideas

* [x] Use utf8extra.isvalid(s)  directly on core.doc to check if opened document is valid utf-8
* [x] If document not valid then perform line cleaning
* [x] Add get_utf8_line() method to core.doc that retrieve the cleaned or original line
* [x] Add internal core.doc flag that indicates if document is binary and lines should be clean

**Screeny of binary file with drawwhitespace replacements**

![binary-file-drawwhitespace](https://github.com/pragtical/pragtical/assets/1702572/9f19e729-4fd1-4765-b521-e088096393c2)
