### PR TITLE
Better support the different supported runtimes

### DIFF
--- a/src/api/api.h
+++ b/src/api/api.h
@@ -5,10 +5,8 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-#ifdef LUA_JIT
 /* compatibility layer: https://github.com/keplerproject/lua-compat-5.3 */
 #include "compat/compat-5.3.h"
-#endif
 
 #define API_TYPE_FONT "Font"
 #define API_TYPE_THREAD "Thread"

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1144,7 +1144,7 @@ static void* api_require(const char* symbol) {
     P(typename), P(xmove), S(luaopen_base), S(luaopen_debug), S(luaopen_io),
     S(luaopen_math), S(luaopen_os), S(luaopen_package), S(luaopen_string),
     S(luaopen_table), S(api_load_libs), P(newuserdatauv), P(getiuservalue),
-    P(setiuservalue),
+    P(setiuservalue), S(LUA_REGISTRYINDEX),
     #endif
     #if LUA_VERSION_NUM == 502 || LUA_VERSION_NUM == 503 || LUA_VERSION_NUM == 504
     U(buffinitsize), U(checkversion_), U(execresult), U(fileresult),
@@ -1155,6 +1155,8 @@ static void* api_require(const char* symbol) {
     P(rawgetp), P(rawlen), P(rawsetp), P(setglobal), P(tointegerx),
     P(tonumberx), P(upvalueid), P(upvaluejoin), P(version), P(yieldk),
     S(luaopen_coroutine),
+    /* From macros to functions */
+    U(bufflen), U(buffaddr), U(addchar), U(addsize), U(buffsub), U(prepbuffer),
     #endif
     #if LUA_VERSION_NUM == 501 || LUA_VERSION_NUM == 502 || LUA_VERSION_NUM == 503
     P(newuserdata),
@@ -1191,7 +1193,8 @@ static void* api_require(const char* symbol) {
     P(rawgetp), P(rawsetp), P(setglobal), P(tointegerx), P(tonumberx),
     P(upvalueid), P(upvaluejoin), P(version), P(geti), P(isinteger),
     P(isyieldable), P(rotate), P(seti), P(stringtonumber), P(getuservalue),
-    P(setuservalue), U(typeerror),
+    P(setuservalue), U(typeerror), U(buffinitsize), U(bufflen), U(buffaddr),
+    U(addchar), U(addsize), U(buffsub), U(addstring), U(pushresultsize),
     #endif
   };
   for (size_t i = 0; i < sizeof(nodes) / sizeof(lua_function_node); ++i) {

--- a/src/compat/compat-5.3.c
+++ b/src/compat/compat-5.3.c
@@ -739,10 +739,57 @@ COMPAT53_API void luaL_addvalue (luaL_Buffer_53 *B) {
 }
 
 
-void luaL_pushresult (luaL_Buffer_53 *B) {
+COMPAT53_API void luaL_pushresult (luaL_Buffer_53 *B) {
   lua_pushlstring(B->L2, B->ptr, B->nelems);
   if (B->ptr != B->b.buffer)
     lua_replace(B->L2, -2); /* remove userdata buffer */
+}
+
+COMPAT53_API void lua_setglobal (lua_State *L, const char* s) {
+  lua_setfield(L, LUA_GLOBALSINDEX, s);
+}
+
+COMPAT53_API void lua_getglobal (lua_State *L, const char* s) {
+  lua_getfield(L, LUA_GLOBALSINDEX, s);
+}
+
+COMPAT53_API char* luaL_buffinitsize (lua_State *L, luaL_Buffer_53 *B, size_t s) {
+  luaL_buffinit(L, B);
+  return luaL_prepbuffsize(B, s);
+}
+
+COMPAT53_API char* luaL_prepbuffer (luaL_Buffer_53 *B) {
+  return luaL_prepbuffsize(B, LUAL_BUFFERSIZE);
+}
+
+COMPAT53_API size_t luaL_bufflen (luaL_Buffer_53 *B) {
+  return B->nelems;
+}
+
+COMPAT53_API char* luaL_buffaddr (luaL_Buffer_53 *B) {
+  return B->ptr;
+}
+
+COMPAT53_API void luaL_addchar (luaL_Buffer_53 *B, char c) {
+  if(B->nelems >= B->capacity) luaL_prepbuffsize(B, 1);
+  B->ptr[B->nelems++] = c;
+}
+
+COMPAT53_API void luaL_addsize (luaL_Buffer_53 *B, size_t s) {
+  B->nelems += s;
+}
+
+COMPAT53_API void luaL_buffsub (luaL_Buffer_53 *B, size_t s) {
+  B->nelems -= s;
+}
+
+COMPAT53_API void luaL_addstring (luaL_Buffer_53 *B, const char* s) {
+  luaL_addlstring(B, s, strlen(s));
+}
+
+COMPAT53_API void luaL_pushresultsize (luaL_Buffer_53 *B, size_t s) {
+  luaL_addsize(B, s);
+  luaL_pushresult(B);
 }
 
 
@@ -966,6 +1013,38 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 
 
 
+/* declarations for Lua 5.2, 5.3 and 5.4 */
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 504
+
+COMPAT53_API char* luaL_prepbuffer (luaL_Buffer *B) {
+  return luaL_prepbuffsize(B, LUAL_BUFFERSIZE);
+}
+
+COMPAT53_API size_t luaL_bufflen (luaL_Buffer *B) {
+  return B->n;
+}
+
+COMPAT53_API char* luaL_buffaddr (luaL_Buffer *B) {
+  return B->b;
+}
+
+COMPAT53_API void luaL_addchar (luaL_Buffer *B, char c) {
+  ((void)((B)->n < (B)->size || luaL_prepbuffsize((B), 1)), \
+   ((B)->b[(B)->n++] = (c)));
+}
+
+COMPAT53_API void luaL_addsize (luaL_Buffer *B, size_t s) {
+  B->n += s;
+}
+
+COMPAT53_API void luaL_buffsub (luaL_Buffer *B, size_t s) {
+  B->n -= s;
+}
+
+#endif /* Lua 5.2, 5.3 and 5.4 */
+
+
+
 /* definitions for Lua 5.1, 5.2 and 5.3 */
 #if defined( LUA_VERSION_NUM ) && LUA_VERSION_NUM <= 503
 
@@ -1034,14 +1113,6 @@ COMPAT53_API int lua_setiuservalue(lua_State* L, int idx, int n)
 /* LuaJIT missing implementations */
 #if LUA_JIT
 COMPAT53_API void lua_setlevel (lua_State *from, lua_State *to) {}
-
-COMPAT53_API void lua_setglobal (lua_State *L, const char* s) {
-  lua_setfield(L, LUA_GLOBALSINDEX, s);
-}
-
-COMPAT53_API void lua_getglobal (lua_State *L, const char* s) {
-  lua_getfield(L, LUA_GLOBALSINDEX, s);
-}
 #endif
 
 

--- a/src/compat/compat-5.3.h
+++ b/src/compat/compat-5.3.h
@@ -236,30 +236,47 @@ COMPAT53_API void luaL_addvalue (luaL_Buffer_53 *B);
 #define luaL_pushresult COMPAT53_CONCAT(COMPAT53_PREFIX, _pushresult_53)
 COMPAT53_API void luaL_pushresult (luaL_Buffer_53 *B);
 
+#undef lua_setglobal
+#define lua_setglobal COMPAT53_CONCAT(COMPAT53_PREFIX, _setglobal)
+COMPAT53_API void lua_setglobal (lua_State *L, const char *s);
+
+#undef lua_getglobal
+#define lua_getglobal COMPAT53_CONCAT(COMPAT53_PREFIX, _getglobal)
+COMPAT53_API void lua_getglobal (lua_State* L, const char* s);
+
 #undef luaL_buffinitsize
-#define luaL_buffinitsize(L, B, s) \
-  (luaL_buffinit((L), (B)), luaL_prepbuffsize((B), (s)))
+#define luaL_buffinitsize COMPAT53_CONCAT(COMPAT53_PREFIX, _buffinitsize)
+COMPAT53_API char* luaL_buffinitsize (lua_State *L, luaL_Buffer_53 *B, size_t s);
 
 #undef luaL_prepbuffer
-#define luaL_prepbuffer(B) \
-  luaL_prepbuffsize((B), LUAL_BUFFERSIZE)
+#define luaL_prepbuffer COMPAT53_CONCAT(COMPAT53_PREFIX, _prepbuffer)
+COMPAT53_API char* luaL_prepbuffer (luaL_Buffer_53 *B);
+
+#define luaL_bufflen COMPAT53_CONCAT(COMPAT53_PREFIX, _bufflen)
+COMPAT53_API size_t luaL_bufflen (luaL_Buffer_53 *B);
+
+#define luaL_buffaddr COMPAT53_CONCAT(COMPAT53_PREFIX, _buffaddr)
+COMPAT53_API char* luaL_buffaddr (luaL_Buffer_53 *B);
 
 #undef luaL_addchar
-#define luaL_addchar(B, c) \
-  ((void)((B)->nelems < (B)->capacity || luaL_prepbuffsize((B), 1)), \
-   ((B)->ptr[(B)->nelems++] = (c)))
+#define luaL_addchar COMPAT53_CONCAT(COMPAT53_PREFIX, _addchar)
+COMPAT53_API void luaL_addchar (luaL_Buffer_53 *B, char c);
 
 #undef luaL_addsize
-#define luaL_addsize(B, s) \
-  ((B)->nelems += (s))
+#define luaL_addsize COMPAT53_CONCAT(COMPAT53_PREFIX, _addsize)
+COMPAT53_API void luaL_addsize (luaL_Buffer_53 *B, size_t s);
+
+#undef luaL_buffsub
+#define luaL_buffsub COMPAT53_CONCAT(COMPAT53_PREFIX, _buffsub)
+COMPAT53_API void luaL_buffsub (luaL_Buffer_53 *B, size_t s);
 
 #undef luaL_addstring
-#define luaL_addstring(B, s) \
-  luaL_addlstring((B), (s), strlen((s)))
+#define luaL_addstring COMPAT53_CONCAT(COMPAT53_PREFIX, _addstring)
+COMPAT53_API void luaL_addstring (luaL_Buffer_53 *B, const char* s);
 
 #undef luaL_pushresultsize
-#define luaL_pushresultsize(B, s) \
-  (luaL_addsize((B), (s)), luaL_pushresult((B)))
+#define luaL_pushresultsize COMPAT53_CONCAT(COMPAT53_PREFIX, _pushresultsize)
+COMPAT53_API void luaL_pushresultsize (luaL_Buffer_53 *B, size_t s);
 
 #if defined(LUA_COMPAT_APIINTCASTS)
 #define lua_pushunsigned(L, n) \
@@ -343,6 +360,48 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 #endif /* Lua 5.1 and Lua 5.2 */
 
 
+/* declarations for Lua 5.2, 5.3 and 5.4 */
+#if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM >= 502 && LUA_VERSION_NUM <= 504
+
+#ifdef luaL_prepbuffer
+  #undef luaL_prepbuffer
+#endif
+#define luaL_prepbuffer COMPAT53_CONCAT(COMPAT53_PREFIX, _prepbuffer)
+COMPAT53_API char* luaL_prepbuffer (luaL_Buffer *B);
+
+#ifdef luaL_bufflen
+  #undef luaL_bufflen
+#endif
+#define luaL_bufflen COMPAT53_CONCAT(COMPAT53_PREFIX, _bufflen)
+COMPAT53_API size_t luaL_bufflen (luaL_Buffer *B);
+
+#ifdef luaL_buffaddr
+  #undef luaL_buffaddr
+#endif
+#define luaL_buffaddr COMPAT53_CONCAT(COMPAT53_PREFIX, _buffaddr)
+COMPAT53_API char* luaL_buffaddr (luaL_Buffer *B);
+
+#ifdef luaL_addchar
+  #undef luaL_addchar
+#endif
+#define luaL_addchar COMPAT53_CONCAT(COMPAT53_PREFIX, _addchar)
+COMPAT53_API void luaL_addchar (luaL_Buffer *B, char c);
+
+#ifdef luaL_addsize
+  #undef luaL_addsize
+#endif
+#define luaL_addsize COMPAT53_CONCAT(COMPAT53_PREFIX, _addsize)
+COMPAT53_API void luaL_addsize (luaL_Buffer *B, size_t s);
+
+#ifdef luaL_buffsub
+  #undef luaL_buffsub
+#endif
+#define luaL_buffsub COMPAT53_CONCAT(COMPAT53_PREFIX, _buffsub)
+COMPAT53_API void luaL_buffsub (luaL_Buffer *B, size_t s);
+
+#endif /* Lua 5.2, 5.3 and 5.4 */
+
+
 /* declarations for Lua 5.1, 5.2 and 5.3 */
 #if defined(LUA_VERSION_NUM) && LUA_VERSION_NUM < 504
 
@@ -362,14 +421,6 @@ COMPAT53_API int lua_setiuservalue (lua_State* L, int idx, int n);
 /* LuaJIT missing implementations */
 #if LUA_JIT
 #define lua_setlevel COMPAT53_CONCAT(COMPAT53_PREFIX, _setlevel)
-
-#undef lua_setglobal /* On luajit this is a macro so we undefine it */
-#define lua_setglobal COMPAT53_CONCAT(COMPAT53_PREFIX, _setglobal)
-COMPAT53_API void lua_setglobal (lua_State *L, const char *s);
-
-#undef lua_getglobal /* On luajit this is a macro so we undefine it */
-#define lua_getglobal COMPAT53_CONCAT(COMPAT53_PREFIX, _getglobal)
-COMPAT53_API void lua_getglobal (lua_State* L, const char* s);
 #endif
 
 


### PR DESCRIPTION
Currently LuaJIT and PUC Lua 5.4 has some runtime differences that were not tackled by the pragtical_plugin_api.h which provides to native plugins the ability to run using the same Lua runtime that was linked to the editor.

This changes expose some buffer handling macros as functions for both LuaJIT and PUC Lua to resolve this issue. It also exports the LUA_REGISTRYINDEX macro as a "constant", since this value differs between LuaJIT and PUC Lua 5.4 causing segmentation faults and other related crashes.

The changes on this commit are an effort to support building ltreesitter (needed by Evergreen plugin) using the plugin_api mode, in order to support both LuaJIT and Lua 5.4 runtimes.