### PR TITLE
Use cmalloc instead of malloc on render init

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -713,7 +713,7 @@ RenWindow* ren_init(SDL_Window *win) {
     fprintf(stderr, "internal font error when starting the application\n");
     return NULL;
   }
-  RenWindow* window_renderer = malloc(sizeof(RenWindow));
+  RenWindow* window_renderer = calloc(1, sizeof(RenWindow));
 
   window_renderer->window = win;
   renwin_init_surface(window_renderer);


### PR DESCRIPTION
This prevent crashes when null checking to free non initialized elements that are not set to zero by malloc.