### PR TITLE
Check tokenizer state to prevent issues with evergreen

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -455,12 +455,14 @@ local commands = {
         -- Use the previous line state, as it will be the state
         -- of the beginning of the current line
         local state = dv.doc.highlighter:get_line(line1 - 1).state
-        local syntaxes = tokenizer.extract_subsyntaxes(dv.doc.syntax, state)
-        -- Go through all the syntaxes until the first with `block_comment` defined
-        for _, s in pairs(syntaxes) do
-          if s.block_comment then
-            current_syntax = s
-            break
+        if state then
+          local syntaxes = tokenizer.extract_subsyntaxes(dv.doc.syntax, state)
+          -- Go through all the syntaxes until the first with `block_comment` defined
+          for _, s in pairs(syntaxes) do
+            if s.block_comment then
+              current_syntax = s
+              break
+            end
           end
         end
       end
@@ -487,12 +489,14 @@ local commands = {
         -- Use the previous line state, as it will be the state
         -- of the beginning of the current line
         local state = dv.doc.highlighter:get_line(line1 - 1).state
-        local syntaxes = tokenizer.extract_subsyntaxes(dv.doc.syntax, state)
-        -- Go through all the syntaxes until the first with comments defined
-        for _, s in pairs(syntaxes) do
-          if s.comment or s.block_comment then
-            current_syntax = s
-            break
+        if state then
+          local syntaxes = tokenizer.extract_subsyntaxes(dv.doc.syntax, state)
+          -- Go through all the syntaxes until the first with comments defined
+          for _, s in pairs(syntaxes) do
+            if s.comment or s.block_comment then
+              current_syntax = s
+              break
+            end
           end
         end
       end

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -810,11 +810,13 @@ function Doc:get_symbol_pattern()
   local current_syntax = self.syntax
   if current_syntax and line > 1 then
     local state = self.highlighter:get_line(line - 1).state
-    local syntaxes = tokenizer.extract_subsyntaxes(current_syntax, state)
-    for _, s in pairs(syntaxes) do
-      if s.symbol_pattern then
-        current_syntax = s
-        break
+    if state then
+      local syntaxes = tokenizer.extract_subsyntaxes(current_syntax, state)
+      for _, s in pairs(syntaxes) do
+        if s.symbol_pattern then
+          current_syntax = s
+          break
+        end
       end
     end
   end
@@ -836,11 +838,13 @@ function Doc:get_non_word_chars(symbol)
   local current_syntax = self.syntax
   if current_syntax and line > 1 then
     local state = self.highlighter:get_line(line - 1).state
-    local syntaxes = tokenizer.extract_subsyntaxes(current_syntax, state)
-    for _, s in pairs(syntaxes) do
-      if s[non_word_chars] then
-        current_syntax = s
-        break
+    if state then
+      local syntaxes = tokenizer.extract_subsyntaxes(current_syntax, state)
+      for _, s in pairs(syntaxes) do
+        if s[non_word_chars] then
+          current_syntax = s
+          break
+        end
       end
     end
   end


### PR DESCRIPTION
Some core functionality depends on checking current document subsyntax to determine proper syntax attributes. This isn't provided by evergreen which causes errors so we check if the state Is set before trying to iterate it.