### PR TITLE
Fix project module sometimes not loading.

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -727,7 +727,7 @@ end
 
 
 function core.load_project_module()
-  local filename = ".pragtical_project.lua"
+  local filename = core.project_absolute_path(".pragtical_project.lua")
   if system.get_file_info(filename) then
     return core.try(function()
       local fn, err = loadfile(filename)


### PR DESCRIPTION
The issue was caused by the introduction of new project handling and the editor not doing a chdir to active project. Instead, we should rely on explicitly generating an absolute path using the current root project.

The issue was reported by @mundusnine