### PR TITLE
Use unique guid for the inno setup installer

### DIFF
--- a/scripts/innosetup/innosetup.iss.in
+++ b/scripts/innosetup/innosetup.iss.in
@@ -16,7 +16,7 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; To generate a new GUID, click Tools | Generate GUID inside the InnoSetup IDE.
-AppId={{06761240-D97C-43DE-B9ED-C15F765A2D65}
+AppId={169B5E11-389A-41E3-BC0C-DBB528C67B44}
 
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}


### PR DESCRIPTION
This should prevent conflicting with lite xl installer as reported on discord channel.