### PR TITLE
Respect config.file_size_limit on some components

### DIFF
--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -96,6 +96,7 @@ local function files_search_thread(tid, options)
   local pathsep = options.pathsep or "/"
   local ignore_files = options.ignore_files or {}
   local workers = options.workers or 2
+  local file_size_limit = options.file_size_limit or (10 * 1e6)
 
   ---A thread that waits for filenames to search the given text. If the given
   ---filename is "{{stop}}" then the thread will finish and exit.
@@ -275,7 +276,7 @@ local function files_search_thread(tid, options)
           then
             if info.type == "dir" then
               table.insert(directories, directory .. file)
-            else
+            elseif info.size <= file_size_limit then
               filename_channels[current_worker]:push(dir_path .. pathsep .. file)
               current_worker = current_worker + 1
               if current_worker > workers then current_worker = 1 end
@@ -367,7 +368,8 @@ function ResultsView:begin_search(path, text, search_type, insensitive, whole_wo
         path = path,
         pathsep = PATHSEP,
         ignore_files = config.ignore_files,
-        workers = workers
+        workers = workers,
+        file_size_limit = config.file_size_limit * 1e6
       }
     )
     ---@type thread.Channel[]

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -209,7 +209,17 @@ settings.add("General",
       type = settings.type.NUMBER,
       default = 10,
       min = 1,
-      max = 50
+      max = 50,
+      on_apply = function()
+        for _, project in ipairs(core.projects) do
+          project:compile_ignore_files()
+        end
+        core.add_thread(function()
+          if treeview then
+            treeview.cache = {}
+          end
+        end)
+      end
     },
     {
       label = "Ignore Files",


### PR DESCRIPTION
This PR adds various checks on editor components to respect config.file_size_limit and prevents opening huge files which aren't well supported by the editor yet. Changes include:

* Refresh treeview on settings gui file_size_limit change
* Respect file_size_limit on findfile plugin
* Respect file_size_limit on projectsearch plugin
* Respect file_size_limit on core.open_doc

This PR is related to #59

Edit: open file command still shows files that exceed the file_size_limit but I left that for navigation purposes since core.open_doc will now check the file_size_limit and prevent opening the file when it exceeds the limit