### PR TITLE
Added adaptive sizing to autocomplete plugin

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -445,6 +445,8 @@ end
 ---@param h number
 ---@return number x_advance
 ---@return number y_advance
+---@return number x
+---@return number y
 function common.draw_text(font, color, text, align, x,y,w,h)
   local tw, th = font:get_width(text), font:get_height()
   if align == "center" then
@@ -453,7 +455,7 @@ function common.draw_text(font, color, text, align, x,y,w,h)
     x = x + (w - tw)
   end
   y = common.round(y + (h - th) / 2)
-  return renderer.draw_text(font, text, x, y, color), y + th
+  return renderer.draw_text(font, text, x, y, color), y + th, x, y
 end
 
 


### PR DESCRIPTION
This change handles the issue reported on lite-xl/lite-xl-lsp#82 about the suggestions box becoming too wide to be visible when the symbols text is too large.

Instead of delegating the responsability to plugins making use of the autocomplete API we tackle the issue directly on the plugin itself by performing the required calculations to resize the suggestions box and truncate items text when needed.

### Preview

https://github.com/pragtical/pragtical/assets/1702572/09e69438-c765-4d31-a9b0-8e7bc1756057