### PR TITLE
Increase mod version from 3.3.1 to 3.4.0

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -1,8 +1,8 @@
 -- this file is used by pragtical to setup the Lua environment when starting
 VERSION = "@PROJECT_VERSION@"
 MOD_VERSION_MAJOR = 3
-MOD_VERSION_MINOR = 3
-MOD_VERSION_PATCH = 1
+MOD_VERSION_MINOR = 4
+MOD_VERSION_PATCH = 0
 MOD_VERSION_STRING = string.format("%d.%d.%d", MOD_VERSION_MAJOR, MOD_VERSION_MINOR, MOD_VERSION_PATCH)
 
 DEFAULT_SCALE = system.get_scale()


### PR DESCRIPTION
Previously, system.setenv was introduced without incrementing the mod version which would allow plugins to properly target this function. Also these other changes merit a modversion bump:

* get_partial_symbol() publicly exposed on autocomplete plugin which is been used by the LSP plugin
* renderer.font.get_metadata() now can be called as a method