### PR TITLE
Removed no longer needed microtar subproject

### DIFF
--- a/subprojects/microtar.wrap
+++ b/subprojects/microtar.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-url = https://github.com/rxi/microtar.git
-revision = head
-depth = 1
-patch_directory = microtar
-
-[provide]
-microtar = microtar_dep

--- a/subprojects/packagefiles/microtar/meson.build
+++ b/subprojects/packagefiles/microtar/meson.build
@@ -1,8 +1,0 @@
-project('microtar', 'c', version: 'GIT')
-
-microtar_lib = static_library('microtar', files('src/microtar.c'))
-
-microtar_dep = declare_dependency(
-    link_whole: [microtar_lib],
-    include_directories: ['src']
-)

--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -51,8 +51,13 @@ elif get_option('wrap_mode') != 'forcefallback'
         endif
     endforeach
 
+    microtar_lib = static_library('microtar', files('lib/microtar/src/microtar.c'))
+    microtar_dep = declare_dependency(
+        link_whole: [microtar_lib],
+        include_directories: ['lib/microtar/src']
+    )
+
     # Search the rest of dependencies
-    microtar_dep = subproject('microtar').get_variable('microtar_dep')
     zlib_dep = dependency('zlib')
     mbedtls_dep = dependency('mbedtls', version: '<3', required: false)
     libgit2_dep = dependency('libgit2')


### PR DESCRIPTION
The plugin manager now ships a customized version of microtar as part of its source tree.