### PR TITLE
Implement non-numlock keycode suggestions from #72

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -118,7 +118,7 @@ static SDL_HitTestResult SDLCALL hit_test(SDL_Window *window, const SDL_Point *p
   return SDL_HITTEST_NORMAL;
 }
 
-static const char *numpad[] = { "end", "down", "pagedown", "left", "", "right", "home", "up", "pageup", "ins", "delete" };
+static const char *numpad[] = { "end", "down", "pagedown", "left", "clear", "right", "home", "up", "pageup", "insert", "delete" };
 
 static const char *get_key_name(const SDL_Event *e, char *buf) {
   SDL_Scancode scancode = e->key.keysym.scancode;


### PR DESCRIPTION
This PR implements suggestions from mart-on-windows (#72) which are:

* Rename `ins` to `insert` which follows the same convention of the other keys matching already known names for easy keypad navigation.
* Name non-numlock key 5 from empty string to `clear` so it can be bind and use.