### PR TITLE
Build the plugin manager statically for msys

### DIFF
--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -14,8 +14,9 @@ endif
 
 is_msys = false
 
-if host_machine.system() == 'windows' and meson.get_compiler('c').get_id() == 'gcc'
-    gcc_command = ['gcc', '-v']
+ccid = meson.get_compiler('c').get_id()
+if host_machine.system() == 'windows' and (ccid == 'gcc' or ccid == 'clang')
+    gcc_command = [ccid, '-v']
     gcc_command_out = run_command(gcc_command, check: true)
     gcc_out = gcc_command_out.stderr().to_lower()
     gcc_out += ' ' + gcc_command_out.stdout().to_lower()

--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -12,9 +12,21 @@ else
     arch_tuple = '@0@-@1@'.format(target_machine.cpu_family(), target_machine.system())
 endif
 
+is_msys = false
+
+if host_machine.system() == 'windows' and meson.get_compiler('c').get_id() == 'gcc'
+    gcc_command = ['gcc', '-v']
+    gcc_command_out = run_command(gcc_command, check: true)
+    gcc_out = gcc_command_out.stderr().to_lower()
+    gcc_out += ' ' + gcc_command_out.stdout().to_lower()
+    if gcc_out.contains('msys')
+        is_msys = true
+    endif
+endif
+
 if meson.get_compiler('c').get_id() == 'msvc'
     message('MSVC compiler not supported, use MSYS to build.')
-elif get_option('wrap_mode') != 'forcefallback'
+elif get_option('wrap_mode') != 'forcefallback' and not is_msys
     cc = meson.get_compiler('c')
 
     lua_exe = find_program('lua')


### PR DESCRIPTION
This change is needed because msys doesn't ships mbedtls2. In order to easily fix the issue of pragtical failing to build with default meson flags under msys2 we just perform a whole static build of the plugin manager for this environment.

Fixes #74