### PR TITLE
Alert by default of changes in autoreload plugin

### DIFF
--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -7,7 +7,7 @@ local Doc = require "core.doc"
 local DirWatch = require "core.dirwatch"
 
 config.plugins.autoreload = common.merge({
-  always_show_nagview = false,
+  always_show_nagview = true,
   config_spec = {
     name = "Autoreload",
     {
@@ -16,7 +16,7 @@ config.plugins.autoreload = common.merge({
         .. "externally even if you haven't modified it.",
       path = "always_show_nagview",
       type = "toggle",
-      default = false
+      default = true
     }
   }
 }, config.plugins.autoreload)


### PR DESCRIPTION
Set config.plugins.autoreload.always_show_nagview to true as the default option to always ask the user before auto-reloading a file that has changed externally.

Fixes #81