### PR TITLE
Fix meson.build for when dirmonitor_backend is specified

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -44,6 +44,7 @@ if get_option('dirmonitor_backend') == ''
     endif
 else
     dirmonitor_backend = get_option('dirmonitor_backend')
+    pragtical_sources += 'api/dirmonitor/' + dirmonitor_backend + '.c'
 endif
 
 message('dirmonitor_backend: @0@'.format(dirmonitor_backend))


### PR DESCRIPTION
Fix failing to build when meson is configured with `-Ddirmonitor_backend=<backend)`

Alternative would be to put the line
```raw
pragtical_sources += 'api/dirmonitor/' + dirmonitor_backend + '.c'
```
as a common action after (instead of inside) `if get_option('dirmonitor_backend') == ''`