### PR TITLE
Add ui config to toggle the treeview toolbar

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -1049,6 +1049,18 @@ config.plugins.treeview.config_spec = {
     end
   },
   {
+    label = "Show Toolbar",
+    description = "Show or hide the treeview toolbar.",
+    path = "show_toolbar",
+    type = "toggle",
+    default = true,
+    on_apply = function (value)
+    	if toolbar_view.visible ~= value then
+    	  toolbar_view:toggle_visible()
+    	end
+    end
+  },
+  {
     label = "Show Hidden",
     description = "Show hidden files and directories.",
     path = "show_hidden",


### PR DESCRIPTION
This new config allows easily disabling the treeview toolbar at startup.

https://github.com/pragtical/pragtical/assets/1702572/bd27b5ca-a052-4f2e-a719-7ab7dcffd3b9

