### PR TITLE
Add /usr/local/bin to PATH on Mac OS X

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -75,13 +75,15 @@ end
 -- On Mac OS X package managers like brew install binaries into /usr/local/bin
 -- but this location is not globally added to the PATH environment variable.
 if PLATFORM == "Mac OS X" then
-  local local_bin_path = "/usr/local/bin"
+  local path_list = {"/usr/local/sbin", "/usr/local/bin"}
   local system_path = os.getenv("PATH")
-  if system_path and not system_path:match(local_bin_path) then
-    local path_info = system.get_file_info(local_bin_path)
-    if path_info and path_info.type == "dir" then
-      system_path = local_bin_path .. ":" .. system_path
-      system.setenv("PATH", system_path)
+  for _, local_bin_path in ipairs(path_list) do
+    if system_path and not system_path:match(local_bin_path) then
+      local path_info = system.get_file_info(local_bin_path)
+      if path_info and path_info.type == "dir" then
+        system_path = local_bin_path .. ":" .. system_path
+        system.setenv("PATH", system_path)
+      end
     end
   end
 end

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -70,3 +70,18 @@ local appimage_owd = os.getenv("OWD")
 if os.getenv("APPIMAGE") and appimage_owd then
   system.chdir(appimage_owd)
 end
+
+-- Manually add /usr/local/bin to the PATH environment variable if needed.
+-- On Mac OS X package managers like brew install binaries into /usr/local/bin
+-- but this location is not globally added to the PATH environment variable.
+if PLATFORM == "Mac OS X" then
+  local local_bin_path = "/usr/local/bin"
+  local system_path = os.getenv("PATH")
+  if system_path and not system_path:match(local_bin_path) then
+    local path_info = system.get_file_info(local_bin_path)
+    if path_info and path_info.type == "dir" then
+      system_path = local_bin_path .. ":" .. system_path
+      system.setenv("PATH", system_path)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the issue reported on issue [85](https://github.com/pragtical/pragtical/issues/85) within the editor, instead of relying on plugins adding the missing binaries PATH.

Fixes #85 