### PR TITLE
Assign a binding to open user module command

### DIFF
--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -3,6 +3,7 @@ local function keymap_macos(keymap)
     ["cmd+shift+p"] = "core:find-command",
     ["cmd+o"] = "core:open-file",
     ["cmd+n"] = "core:new-doc",
+    ["cmd+,"] = "core:open-user-module",
     ["cmd+shift+c"] = "core:change-project-folder",
     ["cmd+shift+o"] = "core:open-project-folder",
     ["cmd+option+r"] = "core:restart",

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -293,6 +293,7 @@ keymap.add_direct {
   ["ctrl+shift+p"] = "core:find-command",
   ["ctrl+o"] = "core:open-file",
   ["ctrl+n"] = "core:new-doc",
+  ["ctrl+,"] = "core:open-user-module",
   ["ctrl+shift+c"] = "core:change-project-folder",
   ["ctrl+shift+o"] = "core:open-project-folder",
   ["ctrl+alt+r"] = "core:restart",


### PR DESCRIPTION
Assigns the binding `cmd+,`on Mac OS X and `ctrl+,` on all other operating systems as a quick way to open the Lua user module.