### PR TITLE
Disable assert on font resizing to allow fonts scanning.

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -434,7 +434,17 @@ static void font_render_glyph(RenFont* font, unsigned int codepoint) {
     if (!set->surface || metric->x1 > set->surface->w || metric->y1 > set->surface->h) {
       // resize the glyphset with exact pixel sizing
       font_allocate_glyphset(font, glyphset_idx, false);
-      assert(metric->x1 <= set->surface->w && metric->y1 <= set->surface->h);
+      if (metric->x1 > set->surface->w || metric->y1 > set->surface->h)
+        fprintf(
+          stderr,
+          "Warning: font '%s' at glyphset '%d' not properly resized to "
+          "exact pixel sizing. X1: %d -> W: %d, Y1: %d -> H: %d\n",
+          font->path, glyphset_idx,
+          metric->x1, set->surface->w,
+          metric->y1, set->surface->h
+        );
+      // Disable the assert for now since fonts causing this would be rarely used...
+      // assert(metric->x1 <= set->surface->w && metric->y1 <= set->surface->h);
     }
 
     // blit the bitmap onto the surface


### PR DESCRIPTION
There is an assert that is triggered when the metrics of a font are bigger than the target surface to prevent buffer overwriting, since this only seems to happens in some exotic fonts we disable it until a proper fix is implemented.

This bug is caused by the merged PR lite-xl/lite-xl#1543

Fonts triggering the issue:

```
'/usr/share/fonts/noto/NotoSerifDivesAkuru-Regular.ttf' | X1: 6 -> W: 12, Y1: 12 -> H: 11
'/usr/share/fonts/noto/NotoSerifDivesAkuru-Regular.ttf' | X1: 5 -> W: 12, Y1: 12 -> H: 11
'/usr/share/fonts/noto/NotoSerifDivesAkuru-Regular.ttf' | X1: 5 -> W: 12, Y1: 12 -> H: 11
'/usr/share/fonts/noto/NotoSerifTest-Regular.ttf' | X1: 6 -> W: 12, Y1: 9 -> H: 8
'/usr/share/fonts/noto/NotoSerifTest-Regular.ttf' | X1: 5 -> W: 12, Y1: 9 -> H: 8
'/usr/share/fonts/noto/NotoSerifTest-Regular.ttf' | X1: 5 -> W: 12, Y1: 9 -> H: 8
'/usr/share/fonts/noto/NotoSansKawi-Bold.ttf' | X1: 6 -> W: 12, Y1: 9 -> H: 8
'/usr/share/fonts/noto/NotoSansKawi-Bold.ttf' | X1: 5 -> W: 12, Y1: 9 -> H: 8
'/usr/share/fonts/noto/NotoSansKawi-Bold.ttf' | X1: 5 -> W: 12, Y1: 9 -> H: 8
```