### PR TITLE
Auto chdir to project depending on active document

### DIFF
--- a/data/core/project.lua
+++ b/data/core/project.lua
@@ -74,6 +74,24 @@ function Project:normalize_path(filename)
 end
 
 
+---Checks if the given path belongs to the project.
+---@param path string
+---@return boolean
+function Project:path_belongs_to(path)
+  if not common.is_absolute_path(path) then
+    path = common.normalize_path(self.path .. PATHSEP .. path)
+    if not path or not system.get_file_info(path) then
+      return false
+    end
+    return true
+  end
+  if common.path_belongs_to(path, self.path) then
+    return true
+  end
+  return false
+end
+
+
 local function fileinfo_pass_filter(info, ignore_compiled)
   if info.size >= config.file_size_limit * 1e6 then return false end
   local basename = common.basename(info.filename)

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -1,7 +1,7 @@
 -- this file is used by pragtical to setup the Lua environment when starting
 VERSION = "@PROJECT_VERSION@"
 MOD_VERSION_MAJOR = 3
-MOD_VERSION_MINOR = 4
+MOD_VERSION_MINOR = 5
 MOD_VERSION_PATCH = 0
 MOD_VERSION_STRING = string.format("%d.%d.%d", MOD_VERSION_MAJOR, MOD_VERSION_MINOR, MOD_VERSION_PATCH)
 

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -194,6 +194,12 @@ function system.rmdir(path) end
 function system.chdir(path) end
 
 ---
+---Get the current working directory.
+---
+---@return string directory Current working directgory.
+function system.getcwd() end
+
+---
 ---Truncates a file to a set length.
 ---
 ---@param file file* A file handle returned by io.open().

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -797,6 +797,24 @@ static int f_chdir(lua_State *L) {
 }
 
 
+static int f_getcwd(lua_State* L) {
+  #ifdef _WIN32
+    wchar_t buffer[MAX_PATH];
+    if (!_wgetcwd(buffer, sizeof(buffer)))
+      return luaL_error(L, "error getcwd: %s", strerror(errno));
+    char *utf8_buffer = utfconv_wctoutf8(buffer);
+    lua_pushstring(L, utf8_buffer);
+    free(utf8_buffer);
+  #else
+    char buffer[PATH_MAX];
+    if (!getcwd(buffer, sizeof(buffer)))
+      return luaL_error(L, "error getcwd: %s", strerror(errno));
+    lua_pushstring(L, buffer);
+  #endif
+  return 1;
+}
+
+
 static int f_list_dir(lua_State *L) {
   const char *path = luaL_checkstring(L, 1);
 
@@ -1423,6 +1441,7 @@ static const luaL_Reg lib[] = {
   { "show_fatal_error",    f_show_fatal_error    },
   { "rmdir",               f_rmdir               },
   { "chdir",               f_chdir               },
+  { "getcwd",              f_getcwd              },
   { "ftruncate",           f_ftruncate           },
   { "mkdir",               f_mkdir               },
   { "list_dir",            f_list_dir            },


### PR DESCRIPTION
This change better supports plugins like the terminal without them having to implement current project path detection. When editing files not part of the root project the system will automatically chdir to their current parent directory.

Other changes include:

* added system.getcwd():string
* added core.current_project(filename?:string):core.project
* added Project:path_belongs_to(path):boolean
* increased the mod minor version as a result of newly introduced functions