### PR TITLE
Improvements to core.visited_files handling

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -118,6 +118,12 @@ config.max_tabs = 8
 ---@type integer
 config.max_visible_commands = 10
 
+---The maximum amount of recent files to keep on history.
+---
+---The default is 5.
+---@type integer
+config.max_visited_files = 5
+
 ---Shows/hides the tab bar when there is only one tab open.
 ---
 ---The tab bar is always shown by default.

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -116,6 +116,7 @@ end
 
 
 function core.open_project(project)
+  core.visited_files = {}
   local project = core.set_project(project)
   core.root_view:close_all_docviews()
   reload_customizations()
@@ -983,6 +984,10 @@ function core.set_visited(filename)
     end
   end
   table.insert(core.visited_files, 1, filename)
+  if #core.visited_files > config.max_visited_files then
+    local remove = #core.visited_files - config.max_visited_files
+    common.splice(core.visited_files, config.max_visited_files, remove)
+  end
 end
 
 
@@ -997,8 +1002,8 @@ function core.set_active_view(view)
       return
     end
     core.next_active_view = nil
-    if view.doc and view.doc.filename then
-      core.set_visited(view.doc.filename)
+    if view.doc and view.doc.abs_filename then
+      core.set_visited(view.doc.abs_filename)
     end
     core.last_active_view = core.active_view
     core.active_view = view

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -386,6 +386,14 @@ settings.add("User Interface",
       min = 1
     },
     {
+      label = "Maximum Recent Files",
+      description = "The maximum amount of recently visited files to keep on history.",
+      path = "max_visited_files",
+      type = settings.type.NUMBER,
+      default = 5,
+      min = 1
+    },
+    {
       label = "Always Show Tabs",
       description = "Shows tabs even if a single document is opened.",
       path = "always_show_tabs",


### PR DESCRIPTION
* The maximum amount of visited files is configurable with config.max_visited_files to prevent indefinite addition of visited files
* Visited files are cleared when opening a different project
* We now use the absolute path instead of relative to prevent issues with multiple project directories
* config.max_visited_files added to settings ui plugin
* save and restore core.visited_files on the workspace plugin for each project