### PR TITLE
Multiproject handling for statusview doc:file

### DIFF
--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -99,11 +99,11 @@ local StatusViewItem = Object:extend()
 ---follows it.
 ---@field separator? core.statusview.item.separator
 
----Flag to tell the item should me aligned on left side of status bar.
+---Flag to tell the item should be aligned on left side of status bar.
 ---@type integer
 StatusViewItem.LEFT = 1
 
----Flag to tell the item should me aligned on right side of status bar.
+---Flag to tell the item should be aligned on right side of status bar.
 ---@type integer
 StatusViewItem.RIGHT = 2
 
@@ -203,10 +203,24 @@ function StatusView:register_docview_items()
     alignment = StatusView.Item.LEFT,
     get_item = function()
       local dv = core.active_view
+      local filename
+      if #core.projects > 1 and dv.doc.abs_filename then
+        local project, is_open, belongs = core.current_project(
+          dv.doc.abs_filename
+        )
+        if project and is_open and belongs then
+          filename = common.basename(project.path)
+            .. PATHSEP
+            .. common.relative_path(project.path, dv.doc.abs_filename)
+        end
+      end
+      if not filename then
+        filename = common.home_encode(dv.doc:get_name())
+      end
       return {
         dv.doc:is_dirty() and style.accent or style.text, style.icon_font, "f",
-        style.dim, style.font, self.separator2, style.text,
-        dv.doc.filename and style.text or style.dim, common.home_encode(dv.doc:get_name())
+        style.dim, style.font, self.separator2,
+        dv.doc.filename and style.text or style.dim, filename
       }
     end
   })


### PR DESCRIPTION
This change prepends the project name to the shown file path when more than one project is open, this allows easily identifying which project the file belongs to without having to display the full file path eg:

* Project 1: README.md -> pragtical/README.md
* Project 2: ~/Development/GitHub/scm/README.md -> scm/README.md

If only one project is open the previous behaviour is kept of only showing the filename or home encoded full path on foreign files.

Before:

![doc-file-before](https://github.com/pragtical/pragtical/assets/1702572/4179e61c-81d0-46a5-ada9-f343020db04d)

After:

![doc-file-after](https://github.com/pragtical/pragtical/assets/1702572/e9dcde99-e240-42d0-8b91-dfc8a14af14a)
