### PR TITLE
Check doc is still in view before autoreloading it

### DIFF
--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -72,8 +72,12 @@ local core_set_active_view = core.set_active_view
 function core.set_active_view(view)
   core_set_active_view(view)
   if core.active_view.doc and changed[core.active_view.doc] then
+    local doc = core.active_view.doc
     core.add_thread(function()
-      autoreload_doc(core.active_view.doc)
+      -- validate doc in case the active view rapidly changed
+      if doc == core.active_view.doc then
+        autoreload_doc(doc)
+      end
     end)
   end
 end


### PR DESCRIPTION
This prevent issues when the active view is rapidly changed.