### PR TITLE
Basic doc/docview cache for better performance

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -97,6 +97,7 @@ end
 
 function Highlighter:update_notify(line, n)
   -- plugins can hook here to be notified that lines have been retokenized
+  self.doc:clear_cache(line, n)
 end
 
 
@@ -122,8 +123,8 @@ function Highlighter:get_line(idx)
 end
 
 
-function Highlighter:each_token(idx)
-  return tokenizer.each_token(self:get_line(idx).tokens)
+function Highlighter:each_token(idx, scol)
+  return tokenizer.each_token(self:get_line(idx).tokens, scol)
 end
 
 

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -25,6 +25,7 @@ function Doc:new(filename, abs_filename, new_file)
   self.encoding = nil
   self.convert = false
   self.binary = false
+  self.cache = {}
   self:reset()
   if filename then
     self:set_filename(filename, abs_filename)
@@ -511,6 +512,20 @@ local function update_clean_lines(self, line1, line2)
 end
 
 
+function Doc:clear_cache(l, n)
+  for _, cache in pairs(self.cache) do
+    local lines = l + n
+    for ln=l-1, lines do
+      local line = ln + 1
+      if cache[line] then
+        cache[line] = nil
+      end
+      if line == lines then break end
+    end
+  end
+end
+
+
 function Doc:raw_insert(line, col, text, undo_stack, time)
   -- split text into lines and merge with line at insertion point
   local lines = split_lines(text)
@@ -543,6 +558,7 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
 
   -- update highlighter and assure selection is in bounds
   self.highlighter:insert_notify(line, #lines - 1)
+  self:clear_cache(line, #lines - 1)
   self:sanitize_selection()
 end
 
@@ -604,6 +620,7 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
 
   -- update highlighter and assure selection is in bounds
   self.highlighter:remove_notify(line1, line_removal)
+  self:clear_cache(line1, line_removal)
   self:sanitize_selection()
 end
 

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -389,16 +389,28 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
 end
 
 
-local function iter(t, i)
-  i = i + 2
-  local type, text = t[i], t[i+1]
-  if type then
-    return i, type, text
+function tokenizer.each_token(t, scol)
+  local tcount, start, col = #t, 1, nil
+  if scol then
+    local ccol = 1
+    for i=1, tcount, 2 do
+      local text = t[i+1]
+      local len = #text
+      if scol <= (ccol + len - 1) then
+        start = i
+        col = scol - ccol + 1
+        break
+      end
+      ccol = ccol + len + 1
+    end
   end
-end
-
-function tokenizer.each_token(t)
-  return iter, t, -1
+  return coroutine.wrap(function()
+    for i=start, tcount, 2 do
+      local type, text = t[i], t[i+1]
+      if col then text = string.sub(text, col) col = nil end
+      coroutine.yield(i, type, text)
+    end
+  end)
 end
 
 


### PR DESCRIPTION
Currently, DocView:get_col_x_offset() is an expensive operation when used on long lines. Plugins that use it extensively like: drawwhitespace, colorpreview or selectionhighlight, cause the editor to hang or not respond when dealing with huge lines.
    
Some example of files that cause the editor to hang are minified css or javascript files. While no one would casually edit these files it is totally normal to open them while inspecting a codebase.
    
For this reason a basic cache system is introduced caching the values returned by such functions when necessary. Another slow function can be DocView:get_x_offset_col(), so this change leverages the caching performed on col_x_offset to perform faster x_offset_col and keep it simple.
    
Beside adding the data cache, this work also introduces the ability of getting each token starting from a specific column on the line. This feature reduces the amount of iterations needed to calculate a column position since we can resume from a specific column.

Before:

https://github.com/pragtical/pragtical/assets/1702572/c9984ccb-3ff4-4ba6-a6af-ceb398faa67d

After:


https://github.com/pragtical/pragtical/assets/1702572/c72ab71b-9c3d-458e-83a9-c03140cb4a83

