### PR TITLE
Handle conversion of \ to ¥ as reported on #94

### DIFF
--- a/data/core/encoding.lua
+++ b/data/core/encoding.lua
@@ -1,0 +1,20 @@
+-- Patches encoding library to fix known encoding issues
+
+local encoding_convert = encoding.convert
+
+encoding.convert = function(tocharset, fromcharset, text, options)
+  if fromcharset == "SHIFT_JIS" then
+    -- on Japanese \ is shown as Yen sign ¥, iconv do this conversion
+    -- which is problematic because it changes the original codepoint,
+    -- we are insterested on keeping the original to prevent issues on
+    -- code that uses escape sequences like '\n', '\r', etc...
+    local errmsg
+    text = text:gsub("\\", "{\\\\\\}")
+    text, errmsg = encoding_convert(tocharset, fromcharset, text, options)
+    if text then
+      text = text:gsub("%{¥¥¥%}", "\\")
+    end
+    return text, errmsg
+  end
+  return encoding_convert(tocharset, fromcharset, text, options)
+end

--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -60,6 +60,7 @@ end)
 table.pack = table.pack or pack or function(...) return {...} end
 table.unpack = table.unpack or unpack
 
+require "core.encoding"
 require "core.utf8string"
 require "core.process"
 


### PR DESCRIPTION
For historical reasons iconv automatically replaces every \ with a Yen (¥) symbol when performing conversion from the Shift_JIS encoding. When opening source files this behaviour is undesired so we revert back every ¥ to a back slash.

Japanese fonts already provide the replacement for \ into a Yen.

Fixes #94