### PR TITLE
Restore support for tokenizer empty matches with subsyntax

### DIFF
--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -339,8 +339,9 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
     for n, p in ipairs(current_syntax.patterns) do
       local find_results = { find_text(text, p, i, true, false) }
       if find_results[1] then
-        -- Check for patterns successfully matching nothing
-        if find_results[1] > find_results[2] then
+        -- Check for patterns successfully matching nothing but allows
+        -- those that delegate the result to a subsyntax
+        if find_results[1] > find_results[2] and not p.syntax then
           report_bad_pattern(core.warn, current_syntax, n,
               "Pattern successfully matched, but nothing was captured.")
         -- Check for patterns with mismatching number of `types`


### PR DESCRIPTION
This change restore supports for patterns that don't capture anything but delegate the matched result to a child subsyntax.

An Example:

```lua
-- Function parameters
{
  regex = {
    "(?="
      .. "(?:local)?\\s*"
      .. "(?:function\\s*)"
      .. "(?:[a-zA-Z_][a-zA-Z0-9_\\.\\:]*\\s*)?"
      .. "\\("
    .. ")",
    "\\)"
  },
  type = "normal",
  syntax = {
    patterns = {
      { pattern = "%.%.%.", type = "operator" },
      { pattern = "[%a_][%w_]*%s*(),%s*",
        type = { "operator", "normal" }
      },
      { pattern = "[%a_][%w_]*%s*%f[%s)]",
        type = "operator"
      },
      { pattern = "%.()[%a_][%w_]*()%s*%f[(]",
        type = { "normal", "function", "normal" }
      },
      { pattern = "[%a_][%w_]*()%s*%f[(]",
        type = { "function", "normal" }
      },
      { pattern = "%.()[%a_][%w_]*",
        type = { "normal", "symbol" }
      },
      { pattern = "[%a_][%w_]*",
        type = "symbol"
      },
    },
    symbols = {
      ["local"] = "keyword",
      ["function"] = "keyword",
      ["self"] = "keyword2"
    }
  }
}
```