### PR TITLE
Better matching of placeholder chars (_) on lua

### DIFF
--- a/data/plugins/language_lua.lua
+++ b/data/plugins/language_lua.lua
@@ -373,8 +373,11 @@ syntax.add {
       type = { "keyword", "normal", "keyword2", "normal", "operator", "normal", "function" }
     },
     -- Placeholder
-    { pattern = "_%s*(),",
-      type = { "operator", "normal" }
+    { pattern = "%f[%g]_%f[%G,%)]",
+      type = "operator"
+    },
+    { pattern = "%f[^,%(]_%f[%G,%)]",
+      type = "operator"
     },
     -- Function calls
     { pattern = "[%a_][%w_]+()%s*%f[(\"'{]", type = { "function", "normal" } },


### PR DESCRIPTION
This change betters handle matching of placeholder chars, the given example now is better matched by the lua syntax plugin:

```lua
for _, _, value in some_iterator_that_returns_3() do
  -- ...
end
```