### PR TITLE
Better restore of window mode/size on startup

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -31,7 +31,8 @@ local function save_session()
   if fp then
     local session = {
       recents = core.recent_projects,
-      window = core.window_size,
+      window = core.window_mode ~= "fullscreen"
+        and table.pack(system.get_window_size(core.window)) or core.window_size,
       window_mode = core.window_mode ~= "fullscreen"
         and core.window_mode or core.prev_window_mode,
       previous_find = core.previous_find,


### PR DESCRIPTION
Changes include:

* Save the window size everytime the window mode changes except on fullscreen (we are interested on window size pre-fullscreen mode only for session restoration purposes).
* On startup delay setting window mode until the window is shown to prevent some issues. These issues include: - Windows OS making the window visible before rendering anything - On wayland not applying the window mode or size properly because the window was still hidden
* Introduced core.prev_window_mode to save the previous window mode when entering fullscreen mode, since we don't want to restore the fullscreen mode on startup.