### PR TITLE
Added custom symbols to language c and cpp

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -11,6 +11,8 @@ syntax.add {
   files = { "%.c$" },
   comment = "//",
   block_comment = { "/*", "*/" },
+  symbol_pattern = "[%a_#][%w_]*",
+  symbol_non_word_chars = " \t\n/\\()\"':,.;<>~!@$%^&*|+=[]{}`?-",
   patterns = {
     { pattern = "//.*",                  type = "comment" },
     { pattern = { "/%*", "%*/" },        type = "comment" },
@@ -134,4 +136,3 @@ syntax.add {
     ["#pragma"] = "keyword",
   },
 }
-

--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -15,6 +15,8 @@ syntax.add {
   },
   comment = "//",
   block_comment = { "/*", "*/" },
+  symbol_pattern = "[%a_#][%w_]*",
+  symbol_non_word_chars = " \t\n/\\()\"':,.;<>~!@$%^&*|+=[]{}`?-",
   patterns = {
     { pattern = "//.*",                     type = "comment"  },
     { pattern = { "/%*", "%*/" },           type = "comment"  },


### PR DESCRIPTION
This allows matching symbols like #include or #ifndef so plugins like autocomplete can provide a list of the available keywords.