### PR TITLE
autocomplete: strip punctuations from partials

### DIFF
--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -446,6 +446,11 @@ local function update_suggestions()
     end
   end
 
+  -- when triggered manually and first character is a punctuation, it causes
+  -- none of the items to match if they don't also start with the punctuation,
+  -- we remove the punctuations to ensure results with plugins like lsp
+  if triggered_manually then partial = partial:gsub("^%p+", "") end
+
   -- fuzzy match, remove duplicates and store
   items = common.fuzzy_match(items, partial, false)
   local j = 1


### PR DESCRIPTION
When triggered manually and first character is a punctuation, it causes none of the items to match if they don't also contain the punctiation. We remove the punctuations to ensure results with plugins like lsp will match even if the don't contain the starting punctuation symbol.

This solves issues in languages like C/C++ where # causes lsp to return a list of snippets as follows:

* if
* ifndef
* include

Without this change non of the items would match.