### PR TITLE
Enable utf8 module for Lua < 5.3 using utf8extra

### DIFF
--- a/data/core/utf8string.lua
+++ b/data/core/utf8string.lua
@@ -2,36 +2,49 @@
 -- inject utf8 functions to strings
 --------------------------------------------------------------------------------
 
-local utf8 = require "utf8extra"
+string.ubyte = utf8extra.byte
+string.uchar = utf8extra.char
+string.ufind = utf8extra.find
+string.ugmatch = utf8extra.gmatch
+string.ugsub = utf8extra.gsub
+string.ulen = utf8extra.len
+string.ulower = utf8extra.lower
+string.umatch = utf8extra.match
+string.ureverse = utf8extra.reverse
+string.usub = utf8extra.sub
+string.uupper = utf8extra.upper
 
-string.ubyte = utf8.byte
-string.uchar = utf8.char
-string.ufind = utf8.find
-string.ugmatch = utf8.gmatch
-string.ugsub = utf8.gsub
-string.ulen = utf8.len
-string.ulower = utf8.lower
-string.umatch = utf8.match
-string.ureverse = utf8.reverse
-string.usub = utf8.sub
-string.uupper = utf8.upper
+string.uescape = utf8extra.escape
+string.ucharpos = utf8extra.charpos
+string.unext = utf8extra.next
+string.uinsert = utf8extra.insert
+string.uremove = utf8extra.remove
+string.uwidth = utf8extra.width
+string.uwidthindex = utf8extra.widthindex
+string.utitle = utf8extra.title
+string.ufold = utf8extra.fold
+string.uncasecmp = utf8extra.ncasecmp
+string.uisvalid = utf8extra.isvalid
+string.uclean = utf8extra.clean
+string.uinvalidoffset = utf8extra.invalidoffset
+string.uisnfc = utf8extra.isnfc
+string.unormalize_nfc = utf8extra.normalize_nfc
 
-string.uescape = utf8.escape
-string.ucharpos = utf8.charpos
-string.unext = utf8.next
-string.uinsert = utf8.insert
-string.uremove = utf8.remove
-string.uwidth = utf8.width
-string.uwidthindex = utf8.widthindex
-string.utitle = utf8.title
-string.ufold = utf8.fold
-string.uncasecmp = utf8.ncasecmp
-string.uisvalid = utf8.isvalid
-string.uclean = utf8.clean
-string.uinvalidoffset = utf8.invalidoffset
-string.uisnfc = utf8.isnfc
-string.unormalize_nfc = utf8.normalize_nfc
+string.uoffset = utf8extra.offset
+string.ucodepoint = utf8extra.codepoint
+string.ucodes = utf8extra.codes
 
-string.uoffset = utf8.offset
-string.ucodepoint = utf8.codepoint
-string.ucodes = utf8.codes
+--------------------------------------------------------------------------------
+-- Inject utf8 module to lua < 5.3
+--------------------------------------------------------------------------------
+
+if not utf8 then
+  utf8 = {
+    charpattern = utf8extra.charpattern,
+    char = utf8extra.char,
+    codes = utf8extra.codes,
+    codepoint = utf8extra.codepoint,
+    len = utf8extra.len,
+    offset = utf8extra.offset
+  }
+end

--- a/docs/api/utf8extra.lua
+++ b/docs/api/utf8extra.lua
@@ -45,11 +45,6 @@ function utf8extra.gmatch(s, pattern, init) end
 ---@return integer count
 function utf8extra.gsub(s, pattern, repl, n) end
 
----UTF-8 equivalent of string.len
----@param s string
----@return integer
-function utf8extra.len(s) end
-
 ---UTF-8 equivalent of string.lower
 ---@param s string
 ---@return string
@@ -237,5 +232,67 @@ function utf8extra.isnfc(s) end
 ---@return boolean was_n
 function utf8extra.normalize_nfc(s) end
 
+--------------------------------------------------------------------------------
+-- Lua utf8 compatible functions and fields
+--------------------------------------------------------------------------------
+
+---A string pattern which matches exactly one UTF-8 byte sequence, assuming
+---that the subject is a valid UTF-8 string. can be "[\0-\x7F\xC2-\xF4][\x80-\xBF]*"
+---on lua > 5.2 or "[%z\1-\x7F\xC2-\xF4][\x80-\xBF]*" otherwise.
+---@type string
+utf8extra.charpattern = "[%z\1-\x7F\xC2-\xF4][\x80-\xBF]*"
+
+---Receives zero or more integers, converts each one to its corresponding
+---UTF-8 byte sequence and returns a string with the concatenation of all
+---these sequences.
+---@param ...? integer
+---@return string
+function utf8extra.char(...) end
+
+---Returns values so that the construction:
+---```lua
+---for p, c in utf8.codes(s) do body end
+---```
+---will iterate over all characters in string s, with p being the position
+---(in bytes) and c the code point of each character. It raises an error if
+---it meets any invalid byte sequence.
+function utf8extra.codes(s) end
+
+---Returns the codepoints (as integers) from all characters in s that start
+---between byte position i and j (both included). The default for i is 1 and
+---for j is i. It raises an error if it meets any invalid byte sequence.
+---@param s string
+---@param i? integer
+---@param j? integer
+---@return fun():integer, ...
+function utf8extra.codepoint(s, i, j) end
+
+---Returns the number of UTF-8 characters in string s that start between
+---positions i and j (both inclusive). The default for i is 1 and for j is -1.
+---If it finds any invalid byte sequence, returns a false value plus the
+---position of the first invalid byte.
+---@param s string
+---@param i? integer
+---@param j? integer
+---@return integer?
+---@return integer?
+function utf8extra.len(s, i, j) end
+
+---Returns the position (in bytes) where the encoding of the n-th character
+---of s (counting from position i) starts. A negative n gets characters before
+---position i. The default for i is 1 when n is non-negative and #s + 1
+---otherwise, so that utf8.offset(s, -n) gets the offset of the n-th character
+---from the end of the string. If the specified character is neither in the
+---subject nor right after its end, the function returns nil.
+---
+---As a special case, when n is 0 the function returns the start of the
+---encoding of the character that contains the i-th byte of s.
+---
+---This function assumes that s is a valid UTF-8 string.
+---@param s string
+---@param n integer
+---@param i? integer
+---@return integer?
+function utf8extra.offset(s, n, i) end
 
 return utf8extra


### PR DESCRIPTION
This also adds missing documentation for utf8extra equivalent utf8 compatibility functions.