### PR TITLE
Fix for IPC plugin to open relative path

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -444,6 +444,7 @@ function core.init()
   core.visited_files = {}
   core.restart_request = false
   core.quit_request = false
+  core.init_working_dir = system.getcwd()
 
   -- We load core views before plugins that may need them.
   ---@type core.rootview

--- a/data/plugins/ipc.lua
+++ b/data/plugins/ipc.lua
@@ -871,6 +871,7 @@ system.get_time = function()
     if primary_instance and ARGS[2] then
       local open_directory = false
       for i=2, #ARGS do
+        system.chdir(core.init_working_dir)
         local path = system.absolute_path(ARGS[i])
 
         if path then


### PR DESCRIPTION
This fix restores opening of a relative path from within the IPC plugin which was broken by #93