### PR TITLE
Improvements to c/c++ language plugins

### DIFF
--- a/data/plugins/language_c.lua
+++ b/data/plugins/language_c.lua
@@ -28,6 +28,7 @@ syntax.add {
     { pattern = "[%+%-=/%*%^%%<>!~|&]",  type = "operator" },
     { pattern = "##",                    type = "operator" },
     { pattern = "struct%s()[%a_][%w_]*", type = {"keyword", "keyword2"} },
+    { pattern = "enum%s()[%a_][%w_]*",   type = {"keyword", "keyword2"} },
     { pattern = "union%s()[%a_][%w_]*",  type = {"keyword", "keyword2"} },
     -- static declarations
     { pattern = "static()%s+()inline",
@@ -39,15 +40,25 @@ syntax.add {
     { pattern = "static()%s+()[%a_][%w_]*",
       type = { "keyword", "normal", "literal" }
     },
-    -- match function type declarations
-    { pattern = "[%a_][%w_]*()%*+()%s+()[%a_][%w_]*%f[%(]",
-      type = { "literal", "operator", "normal", "function" }
+    -- match single line type declarations (exclude keywords)
+    { pattern = "^%s*_?%u[%u_][%u%d_]*%s*\n", -- skip uppercase constants
+      type = "number"
     },
-    { pattern = "[%a_][%w_]*()%s+()%*+()[%a_][%w_]*%f[%(]",
-      type = { "literal", "normal", "operator", "function" }
+    { pattern = "^%s*()[%a_][%w_]*()%s*%*+()%s*\n", -- pointer
+      type = { "normal", "literal", "operator", "normal" }
     },
-    { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*%f[%(]",
-      type = { "literal", "normal", "function" }
+    { pattern = "^%s*()[%a_][%w_]*()%s*\n", -- non-pointer
+      type = { "normal", "literal", "normal" }
+    },
+    -- match function type declarations (exclude keywords)
+    { pattern = "[%a_][%w_]*()%*+()%s+()[%a_][%w_]*()%s*%f[%(]",
+      type = { "literal", "operator", "normal", "function", "normal" }
+    },
+    { pattern = "[%a_][%w_]*()%s+()%*+()[%a_][%w_]*()%s*%f[%(]",
+      type = { "literal", "normal", "operator", "function", "normal" }
+    },
+    { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*()%s*%f[%(]",
+      type = { "literal", "normal", "function", "normal" }
     },
     -- match variable type declarations
     { pattern = "[%a_][%w_]*()%*+()%s+()[%a_][%w_]*",
@@ -59,6 +70,9 @@ syntax.add {
     { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*()%s*()[;,%[%)]",
       type = { "literal", "normal", "normal", "normal", "normal" }
     },
+    { pattern = "^%s*()[%a_][%w_]*()%s+[%a_][%w_]*()%s*\n",
+      type = { "normal", "literal", "normal", "normal" }
+    },
     { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*()%s*()=",
       type = { "literal", "normal", "normal", "normal", "operator" }
     },
@@ -69,13 +83,16 @@ syntax.add {
       type = { "literal", "normal", "operator", "normal" }
     },
     -- Uppercase constants of at least 2 chars in len
+    { pattern = "_?%u[%u_][%u%d_]*%s*%f[%(]", -- when used as function
+      type = "number"
+    },
     { pattern = "_?%u[%u_][%u%d_]*%f[%s%+%*%-%.%)%]}%?%^%%=/<>~|&;:,!]",
       type = "number"
     },
     -- Magic constants
     { pattern = "__[%u%l]+__",           type = "number"   },
-    -- all other functions
-    { pattern = "[%a_][%w_]*%f[(]",      type = "function" },
+    -- all other functions (excludes keywords)
+    { pattern = "[%a_][%w_]*()%s*%f[(]", type = {"function", "normal"} },
     -- Macros
     { pattern = "^%s*#%s*define%s+()[%a_][%a%d_]*",
       type = { "keyword", "symbol" }

--- a/data/plugins/language_cpp.lua
+++ b/data/plugins/language_cpp.lua
@@ -34,6 +34,7 @@ syntax.add {
     { pattern = "##",                       type = "operator" },
     { pattern = "struct%s()[%a_][%w_]*",    type = {"keyword", "keyword2"} },
     { pattern = "class%s()[%a_][%w_]*",     type = {"keyword", "keyword2"} },
+    { pattern = "enum%s()[%a_][%w_]*",      type = {"keyword", "keyword2"} },
     { pattern = "union%s()[%a_][%w_]*",     type = {"keyword", "keyword2"} },
     { pattern = "namespace%s()[%a_][%w_]*", type = {"keyword", "keyword2"} },
     -- static declarations
@@ -62,15 +63,47 @@ syntax.add {
         "literal", "normal", "operator"
       }
     },
+    -- match single line type declarations (exclude keywords)
+    { pattern = "^%s*_?%u[%u_][%u%d_]*%s*\n", -- skip uppercase constants
+      type = "number"
+    },
+    { pattern = "^%s*()[%a_][%w_]*()%s*&()%s*\n", -- reference
+      type = { "normal", "literal", "operator", "normal" }
+    },
+    { pattern = "^%s*()[%a_][%w_]*()%s*%*+()%s*\n", -- pointer
+      type = { "normal", "literal", "operator", "normal" }
+    },
+    { pattern = "^%s*()[%a_][%w_]*()%s*\n", -- non-pointer
+      type = { "normal", "literal", "normal" }
+    },
     -- match function type declarations
-    { pattern = "[%a_][%w_]*()%*+()%s+()[%a_][%w_]*%f[%(]",
-      type = { "literal", "operator", "normal", "function" }
+    { pattern = "[%a_][%w_]*()%*+()%s+()[%a_][%w_]*()%s*%f[%(]",
+      type = { "literal", "operator", "normal", "function", "normal" }
     },
-    { pattern = "[%a_][%w_]*()%s+()%*+()[%a_][%w_]*%f[%(]",
-      type = { "literal", "normal", "operator", "function" }
+    { pattern = "[%a_][%w_]*()%s+()%*+()[%a_][%w_]*()%s*%f[%(]",
+      type = { "literal", "normal", "operator", "function", "normal" }
     },
-    { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*%f[%(]",
-      type = { "literal", "normal", "function" }
+    { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*()%s*%f[%(]",
+      type = { "literal", "normal", "function", "normal" }
+    },
+    -- match generic variable type declarations (eg: vector<int> myvector)
+    { regex = "^\\s*[\\p{L}_][\\p{L}\\d_]*(?=(?:<.*>\\s*[\\*&]*\\s*\n))",
+      type = "literal"
+    },
+    { regex = "[\\p{L}_][\\p{L}\\d_]*(?=(?:<.*>\\s*\\*+\\s+[\\p{L}_][\\p{L}\\d_]*))",
+      type = "literal"
+    },
+    { regex = "[\\p{L}_][\\p{L}\\d_]*(?=(?:<.*>\\s*&\\s+[\\p{L}_][\\p{L}\\d_]*))",
+      type = "literal"
+    },
+    { regex = "[\\p{L}_][\\p{L}\\d_]*(?=(?:<.*>\\s+\\*+\\s*[\\p{L}_][\\p{L}\\d_]*))",
+      type = "literal"
+    },
+    { regex = "[\\p{L}_][\\p{L}\\d_]*(?=(?:<.*>\\s+&\\s*[\\p{L}_][\\p{L}\\d_]*))",
+      type = "literal"
+    },
+    { regex = "[\\p{L}_][\\p{L}\\d_]*(?=(?:<.*>\\s+[\\p{L}_][\\p{L}\\d_]*))",
+      type = "literal"
     },
     -- match variable type declarations
     { pattern = "[%a_][%w_]*()%*+()%s+()[%a_][%w_]*",
@@ -81,6 +114,9 @@ syntax.add {
     },
     { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*()%s*()[;,%[%)]",
       type = { "literal", "normal", "normal", "normal", "normal" }
+    },
+    { pattern = "^%s*()[%a_][%w_]*()%s+[%a_][%w_]*()%s*\n",
+      type = { "normal", "literal", "normal", "normal" }
     },
     { pattern = "[%a_][%w_]*()%s+()[%a_][%w_]*()%s*()=",
       type = { "literal", "normal", "normal", "normal", "operator" }
@@ -96,13 +132,16 @@ syntax.add {
       type = { "literal", "normal", "operator" }
     },
     -- Uppercase constants of at least 2 chars in len
+    { pattern = "_?%u[%u_][%u%d_]*%s*%f[%(]", -- when used as function
+      type = "number"
+    },
     { pattern = "_?%u[%u_][%u%d_]*%f[%s%+%*%-%.%)%]}%?%^%%=/<>~|&;:,!]",
       type = "number"
     },
     -- Magic constants
     { pattern = "__[%u%l]+__",              type = "number"   },
     -- all other functions
-    { pattern = "[%a_][%w_]*%f[(]",         type = "function" },
+    { pattern = "[%a_][%w_]*()%s*%f[(]",    type = {"function", "normal"} },
     -- Macros
     { pattern = "^%s*#%s*define%s+()[%a_][%a%d_]*",
       type = { "keyword", "symbol" }


### PR DESCRIPTION
* Match enum names same as with structs and unions
* Match single line type declarations to better match code like:
```c
custome_type*
function_name (type *param_name)
{
  /*...*/
}
```
* Added matching of single line param declaration without modifiers
* Allow spaces between function name and parameters list
* Also distinguish upper case constants when used as function calls
* Added matching of generic type declarations

Before and After preview:

![before_after](https://github.com/user-attachments/assets/f2752757-5dab-45f7-9716-5f826afbed11)
