### PR TITLE
Add cli flag to allow forking editor to background

### DIFF
--- a/data/core/cli.lua
+++ b/data/core/cli.lua
@@ -1,4 +1,4 @@
-local core = "core"
+local core = require "core"
 
 ---@alias core.cli.flag_type
 ---|>'"empty"'   # Does not needs a value
@@ -70,11 +70,8 @@ function cli.register(command, overwrite)
   if not cli.commands[command.command] or overwrite then
     cli.commands[command.command] = command
     cli.commands_count = cli.commands_count + 1
-  elseif core.error then
-    core.error("CLI command '%s' already registered", command.command)
   else
-    print(string.format("CLI command '%s' already registered", command.command))
-    os.exit(1)
+    core.error("CLI command '%s' already registered", command.command)
   end
 end
 
@@ -454,6 +451,11 @@ cli.set_default {
       name = "version",
       short_name = "v",
       description = "Display application version"
+    },
+    {
+      name = "fork",
+      short_name = "f",
+      description = "Fork the editor to the background"
     }
   },
   execute = function(flags, arguments)
@@ -462,6 +464,15 @@ cli.set_default {
         cli.print_help()
       elseif flag.name == "version" then
         print(cli.app_version)
+        os.exit()
+      elseif flag.name == "fork" then
+        local arguments_string = ""
+        for _, argument in ipairs(arguments) do
+          arguments_string = arguments_string
+            .. ' '
+            .. string.format("%q", argument)
+        end
+        system.exec(string.format("%q %s", EXEFILE, arguments_string))
         os.exit()
       end
     end


### PR DESCRIPTION
The new flag `-f` or `--fork` can be used to launch the editor into a separate process when invoking it from a terminal. This returns control back to the terminal wich reverse implements #131 but still tackles the same issue.

Currently explicit `--fork` is easier to implement and requires less code than implicit forking and explicit `--wait`.

![fork-cli-flag](https://github.com/user-attachments/assets/5726f144-70c5-4def-91f0-1613ee48c0a4)
