### PR TITLE
Use PRAGTICAL_USERDIR instead of HOME on run-local

### DIFF
--- a/scripts/run-local
+++ b/scripts/run-local
@@ -113,7 +113,7 @@ run_pragtical () {
     if [ ! -z ${run_windows+x} ]; then
       USERPROFILE="$userdir" exec "$bindir/pragtical" "${pargs[@]:1}"
     else
-      HOME="$userdir" exec "$bindir/pragtical" "${pargs[@]:1}"
+      PRAGTICAL_USERDIR="$userdir" exec "$bindir/pragtical" "${pargs[@]:1}"
     fi
   fi
 }


### PR DESCRIPTION
This change prevents issue with XDG_CONFIG_HOME overwriting the desired userdir since it has priority over HOME.