### PR TITLE
Return actual scale on get_scale() for macOS too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,6 @@ cc = meson.get_compiler('c')
 
 pragtical_includes = []
 pragtical_cargs = ['-DSDL_MAIN_HANDLED', '-DPCRE2_STATIC']
-# On macos we need to use the SDL renderer to support retina displays
 if get_option('renderer')
     pragtical_cargs += '-DPRAGTICAL_USE_SDL_RENDERER'
 endif

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -583,7 +583,6 @@ static int f_get_scale(lua_State *L) {
   }
 
   float scale = 1.0;
-#ifndef __APPLE__
   char* env_scale = NULL;
   float system_scale = 0;
 #if _WIN32
@@ -620,11 +619,10 @@ static int f_get_scale(lua_State *L) {
   ) {
     scale = system_scale;
   }
-#endif /* __APPLE__ */
   got_initial_scale = true;
   lua_pushnumber(L, scale);
   return 1;
-#endif
+#endif /* PRAGTICAL_USE_SDL_RENDERER */
 }
 
 static int f_set_window_title(lua_State *L) {


### PR DESCRIPTION
`system.get_scale()` always returned 1.0 (except the first time it was called which was a bug :D), since older macOS builds always had the renderer turned on and scaling was performed internally. That is not the case anymore and the software renderer needs to know current display scale when the displaychanged event is emitted.

This should fix the latest issue reported on #34 of UI elements getting too small when switching from:

retina -> external display -> back to retina

Basically system.get_scale properly returned 2.0 the first time the editor was started, then returned 1.0 when changing to external display and 1.0 when returning back to the retina display causing ui to get small.