### PR TITLE
Remove widget submodule in favor of subproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "data/widget"]
-	path = data/widget
-	url = https://github.com/pragtical/widget
-	branch = master

--- a/scripts/run-local
+++ b/scripts/run-local
@@ -73,7 +73,7 @@ copy_pragtical_build () {
     cp "$builddir/src/pragtical" "$bindir"
   fi
   mkdir -p "$datadir/core"
-  for module_name in core compat plugins colors fonts widget; do
+  for module_name in core compat plugins colors fonts; do
     cp -r "data/$module_name" "$datadir"
   done
   if [ -d "subprojects/widget" ]; then


### PR DESCRIPTION
This change removes the git submodule of widget which wasn't been kept up to date in favor of the meson subproject which has been working well and in the same vain of the colors and plugins meson subprojects.

Fixes confusion as in #147