### PR TITLE
Scale plugin zoom code command and bindings

### DIFF
--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -7,8 +7,6 @@ local keymap = require "core.keymap"
 local style = require "core.style"
 
 config.plugins.scale = common.merge({
-  -- The method used to apply the scaling: "code", "ui"
-  mode = "ui",
   -- Toggle auto detection of system scale.
   autodetect = true,
   -- Default scale applied at startup.
@@ -20,6 +18,7 @@ config.plugins.scale = common.merge({
 local scale_steps = 0.05
 
 local current_scale = 1
+local current_code_scale = 1
 local user_scale = tonumber(os.getenv("PRAGTICAL_SCALE"))
 local default_scale = DEFAULT_SCALE
 
@@ -45,26 +44,18 @@ local function set_scale(scale)
   local s = scale / current_scale
   current_scale = scale
 
-  if config.plugins.scale.mode == "ui" then
-    SCALE = scale
+  SCALE = scale
 
-    style.padding.x               = style.padding.x               * s
-    style.padding.y               = style.padding.y               * s
-    style.divider_size            = style.divider_size            * s
-    style.scrollbar_size          = style.scrollbar_size          * s
-    style.expanded_scrollbar_size = style.expanded_scrollbar_size * s
-    style.caret_width             = style.caret_width             * s
-    style.tab_width               = style.tab_width               * s
+  style.padding.x               = style.padding.x               * s
+  style.padding.y               = style.padding.y               * s
+  style.divider_size            = style.divider_size            * s
+  style.scrollbar_size          = style.scrollbar_size          * s
+  style.expanded_scrollbar_size = style.expanded_scrollbar_size * s
+  style.caret_width             = style.caret_width             * s
+  style.tab_width               = style.tab_width               * s
 
-    for _, name in ipairs {"font", "big_font", "icon_font", "icon_big_font", "code_font"} do
-      style[name]:set_size(s * style[name]:get_size())
-    end
-  else
-    style.code_font:set_size(s * style.code_font:get_size())
-  end
-
-  for name, font in pairs(style.syntax_fonts) do
-    style.syntax_fonts[name]:set_size(s * font:get_size())
+  for _, name in ipairs {"font", "big_font", "icon_font", "icon_big_font"} do
+    style[name]:set_size(s * style[name]:get_size())
   end
 
   -- restore scroll positions
@@ -80,20 +71,57 @@ local function set_scale(scale)
   core.redraw = true
 end
 
+local function set_scale_code(scale)
+  if current_code_scale == scale then return end
+
+  scale = common.clamp(scale, 0.2, 6)
+
+  local s = scale / current_code_scale
+  current_code_scale = scale
+
+  style.code_font:set_size(s * style.code_font:get_size())
+  for name, font in pairs(style.syntax_fonts) do
+    style.syntax_fonts[name]:set_size(s * font:get_size())
+  end
+
+  core.redraw = true
+end
+
 local function get_scale()
   return current_scale
 end
 
 local function res_scale()
   set_scale(default_scale)
+  if current_scale == current_code_scale then
+    set_scale_code(default_scale)
+  end
 end
 
 local function inc_scale()
   set_scale(current_scale + scale_steps)
+  set_scale_code(current_code_scale + scale_steps)
 end
 
 local function dec_scale()
   set_scale(current_scale - scale_steps)
+  set_scale_code(current_code_scale - scale_steps)
+end
+
+local function get_scale_code()
+  return current_code_scale
+end
+
+local function res_scale_code()
+  set_scale_code(default_scale)
+end
+
+local function inc_scale_code()
+  set_scale_code(current_code_scale + scale_steps)
+end
+
+local function dec_scale_code()
+  set_scale_code(current_code_scale - scale_steps)
 end
 
 if default_scale ~= config.plugins.scale.default_scale then
@@ -109,17 +137,6 @@ local first_on_apply_scale = user_scale and true or false
 config.plugins.scale.config_spec = {
   name = "Scale",
   {
-    label = "Mode",
-    description = "The method used to apply the scaling.",
-    path = "mode",
-    type = "selection",
-    default = "ui",
-    values = {
-      {"Everything", "ui"},
-      {"Code Only", "code"}
-    }
-  },
-  {
     label = "Autodetect Scale",
     description = "Keeps the scale equal to display, ignored on startup if PRAGTICAL_SCALE is set.",
     path = "autodetect",
@@ -129,8 +146,10 @@ config.plugins.scale.config_spec = {
       if not first_on_apply_scale then
         if not enabled then
           set_scale(config.plugins.scale.default_scale)
+          set_scale_code(config.plugins.scale.default_scale)
         else
           set_scale(default_scale)
+          set_scale_code(default_scale)
         end
       end
     end
@@ -157,12 +176,13 @@ config.plugins.scale.config_spec = {
       if config.plugins.scale.autodetect then return end
       if value ~= current_scale then
         set_scale(value)
+        set_scale_code(value)
       end
     end
   },
   {
     label = "Use MouseWheel",
-    description = "Allow using CTRL + MouseWheel for changing the scale.",
+    description = "Allow using CTRL [+ SHIFT] + MouseWheel for changing the scale.",
     path = "use_mousewheel",
     type = "toggle",
     default = true,
@@ -170,11 +190,15 @@ config.plugins.scale.config_spec = {
       if enabled then
         keymap.add {
           ["ctrl+wheelup"] = "scale:increase",
-          ["ctrl+wheeldown"] = "scale:decrease"
+          ["ctrl+wheeldown"] = "scale:decrease",
+          ["ctrl+shift+wheelup"] = "scale:increase-code",
+          ["ctrl+shift+wheeldown"] = "scale:decrease-code"
         }
       else
         keymap.unbind("ctrl+wheelup", "scale:increase")
         keymap.unbind("ctrl+wheeldown", "scale:decrease")
+        keymap.unbind("ctrl+shift+wheelup", "scale:increase-code")
+        keymap.unbind("ctrl+shift+wheeldown", "scale:decrease-code")
       end
     end
   }
@@ -182,21 +206,32 @@ config.plugins.scale.config_spec = {
 
 
 command.add(nil, {
-  ["scale:reset"   ] = function() res_scale() end,
+  ["scale:reset"] = function() res_scale() end,
   ["scale:decrease"] = function() dec_scale() end,
-  ["scale:increase"] = function() inc_scale() end,
+  ["scale:increase"] = function() inc_scale() end
+})
+
+command.add("core.docview", {
+  ["scale:reset-code"] = function() res_scale_code() end,
+  ["scale:decrease-code"] = function() dec_scale_code() end,
+  ["scale:increase-code"] = function() inc_scale_code() end,
 })
 
 keymap.add {
   ["ctrl+0"] = "scale:reset",
   ["ctrl+-"] = "scale:decrease",
-  ["ctrl+="] = "scale:increase"
+  ["ctrl+="] = "scale:increase",
+  ["ctrl+shift+0"] = "scale:reset-code",
+  ["ctrl+shift+-"] = "scale:decrease-code",
+  ["ctrl+shift+="] = "scale:increase-code"
 }
 
 if config.plugins.scale.use_mousewheel then
   keymap.add {
     ["ctrl+wheelup"] = "scale:increase",
-    ["ctrl+wheeldown"] = "scale:decrease"
+    ["ctrl+wheeldown"] = "scale:decrease",
+    ["ctrl+shift+wheelup"] = "scale:increase-code",
+    ["ctrl+shift+wheeldown"] = "scale:decrease-code"
   }
 end
 
@@ -205,6 +240,7 @@ end
 -- late from within lua, so we can't detect scale earlier
 if current_scale ~= default_scale or user_scale then
   set_scale(user_scale or default_scale)
+  set_scale_code(user_scale or default_scale)
 end
 
 return {
@@ -212,5 +248,10 @@ return {
   ["get"] = get_scale,
   ["increase"] = inc_scale,
   ["decrease"] = dec_scale,
-  ["reset"] = res_scale
+  ["reset"] = res_scale,
+  ["set_code"] = set_scale_code,
+  ["get_code"] = get_scale_code,
+  ["increase_code"] = inc_scale_code,
+  ["decrease_code"] = dec_scale_code,
+  ["reset_code"] = res_scale_code
 }


### PR DESCRIPTION
Now `ctrl+shift+mousewheel[up|down]` or `ctrl+shift+[-|=|0]` can be used to only zoom the code of the editor. The scale mode was removed and scaling with `ctr+mousewheel` and friends will always change scale of entire interface.

**Preview:**

https://github.com/user-attachments/assets/49100d73-8142-4b14-8924-ab47f5e2dd6b