### PR TITLE
Adjust scale retrieveal on startup

### DIFF
--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -17,8 +17,8 @@ config.plugins.scale = common.merge({
 
 local scale_steps = 0.05
 
-local current_scale = 1
-local current_code_scale = 1
+local current_scale = SCALE
+local current_code_scale = SCALE
 local user_scale = tonumber(os.getenv("PRAGTICAL_SCALE"))
 local default_scale = DEFAULT_SCALE
 
@@ -235,12 +235,10 @@ if config.plugins.scale.use_mousewheel then
   }
 end
 
--- on startup rescale if default scale not 1
--- this is needed now because the main window is initialized
--- late from within lua, so we can't detect scale earlier
-if current_scale ~= default_scale or user_scale then
-  set_scale(user_scale or default_scale)
-  set_scale_code(user_scale or default_scale)
+-- Apply custom PRAGTICAL_SCALE if set by user
+if user_scale then
+  set_scale(user_scale)
+  set_scale_code(user_scale)
 end
 
 return {

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -76,10 +76,13 @@ function system.wait_event(timeout) end
 function system.set_cursor(type) end
 
 ---
----Retrieve a sane scale value using current desktop resolution.
+---Retrieve current system scale for the given window. When the SDL renderer
+---is enabled this function always returns 1 since scaling is peformed internally.
+---
+---@param window renwindow
 ---
 ---@return number scale
-function system.get_scale() end
+function system.get_scale(window) end
 
 ---
 ---Change the window title.


### PR DESCRIPTION
Since new renwindow api (that allows initializing windows directly  Lua) the main window creation was moved to core.init but, the scale detection code was still been performed before. This meant that loading the default system style was using the incorrect scale causing issues that would only be resolved by manually re-scaling the interface.

Tried to wrongly fix the issue by delegating the responsibility to the scale plugin but that wasn't the correct solution (didn't notice what explained on first paragraph until later :sweat:). Now we defer style loading until main window is created and the default system scale properly detected, this ensures that the correct scale is set before performing any style calculations that rely on it.

Now besides updating scale on the displaychanged event it also updates it when the window is resized, but we limited the amount of scale checks on resize to prevent crashes on X11.

Hopefully this changes finally tackles the freaking scale issues :smile:  (sorry to people at #34)

~~Forgot to adjust this code for v3.4.3 :(~~ (the issue was deeper than I initially thought, anyways what are releases for...)