### PR TITLE
Use a single instance of EmptyView for all Nodes

### DIFF
--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -322,4 +322,17 @@ function EmptyView:update()
   return true
 end
 
+---We store the prealloc instance on the main object to allow overwriting.
+---@type core.emptyview
+EmptyView.prealloc_instance = nil
+
+---Get reference to pre-allocated EmptyView.
+---@return core.emptyview
+function EmptyView.get_instance()
+  if not EmptyView.prealloc_instance  then
+    EmptyView.prealloc_instance  = EmptyView()
+  end
+  return EmptyView.prealloc_instance
+end
+
 return EmptyView

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -16,7 +16,7 @@ function Node:new(type)
   self.views = {}
   self.divider = 0.5
   if self.type == "leaf" then
-    self:add_view(EmptyView())
+    self:add_view(EmptyView.get_instance())
   end
   self.hovered_close = 0
   self.tab_shift = 0
@@ -140,7 +140,7 @@ function Node:remove_view(root, view)
     end
     if locked_size or (self.is_primary_node and not next_primary) then
       self.views = {}
-      self:add_view(EmptyView())
+      self:add_view(EmptyView.get_instance())
     else
       if other == next_primary then
         next_primary = parent
@@ -666,7 +666,7 @@ function Node:close_all_docviews(keep_active)
       -- matter to reattribute the active view because, within the close_all_docviews
       -- top call, the primary node will take the active view anyway.
       -- Set the empty view and takes the active view.
-      self:add_view(EmptyView())
+      self:add_view(EmptyView.get_instance())
     elseif #self.views > 0 and lost_active_view then
       -- In practice we never get there but if a view remain we need
       -- to reset the Node's active view.

--- a/data/plugins/workspace.lua
+++ b/data/plugins/workspace.lua
@@ -3,6 +3,7 @@ local core = require "core"
 local common = require "core.common"
 local DocView = require "core.docview"
 local LogView = require "core.logview"
+local EmptyView = require "core.emptyview"
 
 
 local function workspace_files_for(project_dir)
@@ -125,6 +126,9 @@ local function load_view(t)
       dv.scroll.y, dv.scroll.to.y = t.scroll.y, t.scroll.y
     end
     return dv
+  end
+  if string.find(t.module, "core.emptyview", 1, true) then
+    return EmptyView.get_instance()
   end
   return require(t.module)()
 end


### PR DESCRIPTION
This reduces the amount of EmptyView objects that need to be created by using a single EmptyView instance for all empty nodes.

Not sure if this has repercussions in case more than 1 node with an empty view needs to be rendered each with different sizes, time will tell...