### PR TITLE
When scale changes rescale item sizes on LogView

### DIFF
--- a/data/core/logview.lua
+++ b/data/core/logview.lua
@@ -122,6 +122,12 @@ function LogView:on_mouse_pressed(button, px, py, clicks)
 end
 
 
+function LogView:on_scale_change()
+  -- reset item sizes
+  item_height_result = {}
+end
+
+
 function LogView:update()
   local item = core.log_items[#core.log_items]
   if self.last_item ~= item then


### PR DESCRIPTION
This ensures that log items are properly sized each time the interface is rescaled.