### PR TITLE
Added PerMonitor dpi awareness to windows manifest

### DIFF
--- a/resources/windows/pragtical.exe.manifest.in
+++ b/resources/windows/pragtical.exe.manifest.in
@@ -2,9 +2,10 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
     type="win32"
-    name="Pragtical.Pragtical.Pragtical"
+    name="pragtical"
     version="@PROJECT_ASSEMBLY_VERSION@"
   />
+  <description>Practical and Pragmatic Code Editor</description>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
@@ -24,13 +25,14 @@
           />
       </dependentAssembly>
   </dependency>
-
-  <asmv3:application xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
-    </asmv3:windowsSettings>
-  </asmv3:application>
-
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </windowsSettings>
+  </application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!--The ID below indicates application support for Windows Vista -->


### PR DESCRIPTION
This change prevents the window getting automatically scaled by the operating system when user changes the system scale while the editor is open, which causes the interface to become blurry.

Some other changes include:

* Set the active code page to UTF-8 (win 10+)
* Enable more modern/efficient heap that reduces memory usage (win 10+)

References:

* https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
* https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process