### PR TITLE
CI: Properly enable ccache for linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.config.arch }} ]]; then
             echo "ARCH=--cross-arch ${{ matrix.config.arch }}" >> "$GITHUB_ENV"

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "/usr/lib/ccache" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
           if [[ $(uname -m) != ${{ matrix.config.arch }} ]]; then
             echo "ARCH=--cross-arch ${{ matrix.config.arch }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
On the ubuntu builders meson doesn't automatically picks up ccache so we need to add its symlinks directory explicitly into the PATH.

We use ccache to speedup the AppImage generation which uses a non portable configuration and thus we recompile it from scratch instead of re-using already built binary and manually reconfiguring the install directories.