### PR TITLE
Revert utilization of newer heap type SegmentHeap

### DIFF
--- a/resources/windows/pragtical.exe.manifest.in
+++ b/resources/windows/pragtical.exe.manifest.in
@@ -30,7 +30,6 @@
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
-      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </windowsSettings>
   </application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">


### PR DESCRIPTION
Testing showed (thanks to @takase1121) that the new heap type introduced on windows 10 is not as great as been sold (at least for our use case). Performance can degrade for some operations and memory usage doesn't seems so different.