### PR TITLE
Don't trust weak table keys to clean cached items

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -21,6 +21,7 @@ function Highlighter:start()
   core.add_thread(function()
     local views = #core.get_views_referencing_doc(self.doc)
     while self.first_invalid_line <= self.max_wanted_line do
+      if not self.doc then return end
       local max = math.min(self.first_invalid_line + 40, self.max_wanted_line)
       local retokenized_from
       for i = self.first_invalid_line, max do

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -818,6 +818,11 @@ end
 
 -- For plugins to get notified when a document is closed
 function Doc:on_close()
+  -- this shouldn't be needed but we do it to better hint the gc to collect
+  self.highlighter.doc = nil
+  self.highlighter.lines = nil
+  self.highlighter = nil
+
   core.log_quiet("Closed doc \"%s\"", self:get_name())
 end
 

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -450,6 +450,7 @@ function core.init()
   core.restart_request = false
   core.quit_request = false
   core.init_working_dir = system.getcwd()
+  core.collect_garbage = false
 
   -- We load core views before plugins that may need them.
   ---@type core.rootview
@@ -1354,6 +1355,7 @@ function core.step()
     if #core.get_views_referencing_doc(doc) == 0 then
       table.remove(core.docs, i)
       doc:on_close()
+      core.collect_garbage = true
     end
   end
 
@@ -1493,6 +1495,10 @@ function core.run()
         next_step = next_step or (now + next_frame)
         system.sleep(math.min(next_frame, time_to_wake))
       end
+    end
+    if core.collect_garbage then
+      collectgarbage("collect")
+      core.collect_garbage = false
     end
   end
 end

--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -808,6 +808,7 @@ end
 --
 local on_text_input = RootView.on_text_input
 local on_text_remove = Doc.remove
+local on_doc_close = Doc.on_close
 local update = RootView.update
 local draw = RootView.draw
 
@@ -826,6 +827,11 @@ Doc.remove = function(self, line1, col1, line2, col2)
       show_autocomplete()
     end
   end
+end
+
+Doc.on_close = function(self)
+  on_doc_close(self)
+  if cache[self] then cache[self] = nil end
 end
 
 RootView.update = function(...)

--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -2,6 +2,7 @@
 
 local core = require "core"
 local style = require "core.style"
+local Doc = require "core.doc"
 local DocView = require "core.docview"
 local common = require "core.common"
 local command = require "core.command"
@@ -355,6 +356,12 @@ function DocView:draw_line_text(idx, x, y)
   end
 
   return draw_line_text(self, idx, x, y)
+end
+
+local doc_on_close = Doc.on_close
+function Doc:on_close()
+  doc_on_close(self)
+  if ws_cache[self.highlighter] then ws_cache[self.highlighter] = nil end
 end
 
 

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -340,6 +340,12 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   end
 end
 
+local old_doc_on_close = Doc.on_close
+function Doc:on_close()
+  old_doc_on_close(self)
+  if open_files[self] then open_files[self] = nil end
+end
+
 local old_doc_update = DocView.update
 function DocView:update()
   old_doc_update(self)


### PR DESCRIPTION
Various core plugins that implement some caching rely on weak table keys of core.doc to cache content, with the idea that once the document is closed the cached content will be cleaned. The reality is that sometimes it can take a really long time until the garbage collector decides that the key is no longer been referenced and the cache data is kept longer than needed.

For this reason we now listen for Doc:on_close events and clean the cache immediately, applicable plugins are:

* autocomplete
* autoreload
* detectindent
* drawwhitespace
* linewrapping

These changes introduce a new `core.collect_garbage` flag that when set to true will queue a call to `collectgarbage('collect')`. Currently it is been employed each time a document is closed in an effort to reduce memory consumption.

We also remove the highlighter reference to the doc when closing a doc to mitigate a circular reference issue.

Lastly, now the autoreload and detectindent plugins are applied to visible documents only.