### PR TITLE
If all documents are closed chdir to root project

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1356,6 +1356,9 @@ function core.step()
       table.remove(core.docs, i)
       doc:on_close()
       core.collect_garbage = true
+      if #core.docs == 0 then
+        system.chdir(core.projects[1].path)
+      end
     end
   end
 


### PR DESCRIPTION
Since we chdir to currently opened file directory for compatibility with some plugins, and for the open file command to pickup current file directory, we need to chdir back to root project when all files are closed.