### PR TITLE
findfile: use project when resolving file path

### DIFF
--- a/data/plugins/findfile.lua
+++ b/data/plugins/findfile.lua
@@ -384,7 +384,9 @@ command.add(nil, {
             end
           end
         end
-        local file = common.home_expand(text)
+        local file = core.projects[1]:absolute_path(
+          common.home_expand(text)
+        )
         if is_file(file) then
           core.root_view:open_doc(core.open_doc(file))
         end


### PR DESCRIPTION
When a single project is open we were wrongly using the currently open file directory to calculate the absolute file path of selected results entry even if currently open file do not belongs to the project.

FindFile plugin goal is to open files related to currently open projects, for extraneous files there is core:open-file.