### PR TITLE
Lower input latency improving co-routine scheduling and tokenizer

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -257,6 +257,14 @@ config.max_clicks = 3
 ---@type boolean
 config.skip_plugins_version = false
 
+---Quiet logging of threads that are taking longer than the maximum time
+---allowed on a per frame iteration basis. Enable only when troubleshooting
+---performance issues, since enabling this may degrade performance.
+---
+---Defaults to false.
+---@type boolean
+config.log_slow_threads = false
+
 ---Increases the performance of the editor and its user.
 ---Do not change this unless you know what you are doing.
 ---

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1391,7 +1391,7 @@ function core.step()
     -- Calculate max allowed coroutines run time based on rendering speed.
     -- verbose formula: (1s - (rendering_speed * config.fps)) / config.fps
     max_time = 1 / config.fps - rendering_speed
-  elseif max_time < 0 then
+  else
     -- If fps rendering dropped from config target we set the max time to
     -- to consume a fourth of the time that would be spent rendering.
     -- For example, if fps dropped from 60 to 25 then we use 1/4 of that time

--- a/data/core/scrollbar.lua
+++ b/data/core/scrollbar.lua
@@ -297,8 +297,8 @@ function Scrollbar:update()
       self.expand_percent = dest
     else
       local rate = 0.3
-      if config.fps ~= 60 or config.animation_rate ~= 1 then
-        local dt = 60 / config.fps
+      if core.fps ~= 60 or config.animation_rate ~= 1 then
+        local dt = 60 / core.fps
         rate = 1 - common.clamp(1 - rate, 1e-8, 1 - 1e-8)^(config.animation_rate * dt)
       end
       self.expand_percent = common.lerp(self.expand_percent, dest, rate)

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -267,11 +267,12 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
   local text_len = text:ulen()
   local start_time = system.get_time()
   local starting_i = i
+  local max_time = math.floor(10000 * (core.co_max_time / 2)) / 10000
   while i <= text_len do
     -- Every 200 chars, check if we're out of time
     if text_len > 200 or i - starting_i > 200 then
       starting_i = i
-      if system.get_time() - start_time > 0.008 then
+      if system.get_time() - start_time > max_time then
         -- We're out of time
         push_token(res, "incomplete", string.usub(text, i))
         return res, string.char(0), {

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -271,7 +271,7 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
     -- Every 200 chars, check if we're out of time
     if i - starting_i > 200 then
       starting_i = i
-      if system.get_time() - start_time > 0.5 / config.fps then
+      if system.get_time() - start_time > 0.5 / core.fps then
         -- We're out of time
         push_token(res, "incomplete", string.usub(text, i))
         return res, string.char(0), {

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -269,9 +269,9 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
   local starting_i = i
   while i <= text_len do
     -- Every 200 chars, check if we're out of time
-    if i - starting_i > 200 then
+    if text_len > 200 or i - starting_i > 200 then
       starting_i = i
-      if system.get_time() - start_time > 0.5 / core.fps then
+      if system.get_time() - start_time > 0.008 then
         -- We're out of time
         push_token(res, "incomplete", string.usub(text, i))
         return res, string.char(0), {

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -74,8 +74,8 @@ function View:move_towards(t, k, dest, rate, name)
     t[k] = dest
   else
     rate = rate or 0.5
-    if config.fps ~= 60 or config.animation_rate ~= 1 then
-      local dt = 60 / config.fps
+    if core.fps ~= 60 or config.animation_rate ~= 1 then
+      local dt = 60 / core.fps
       rate = 1 - common.clamp(1 - rate, 1e-8, 1 - 1e-8)^(config.animation_rate * dt)
     end
     t[k] = common.lerp(val, dest, rate)

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -686,6 +686,13 @@ settings.add("Development",
       path = "skip_plugins_version",
       type = settings.type.TOGGLE,
       default = false
+    },
+    {
+      label = "Log Slow Coroutines",
+      description = "Logs those taking more time than allowed.",
+      path = "log_slow_threads",
+      type = settings.type.TOGGLE,
+      default = false
     }
   }
 )


### PR DESCRIPTION
### Changes:

* **set the maximum execution time of co-routines** - per frame iteration based on current frames per second.
* **penalizes co-routines that exceed the max_time** - by setting their waiting time to the same time it took to execute them.
* **Check how much co-routines to run per frame** - on each run_threads iteration we check how many can be run without exceeding the maximum time allowed.
* **Use the avg. runtime of co-routines to yield** - We now keep track of every 1 second cycle in order to see how much time is left for executing co-routine tasks, by using the average execution time of co-routines to decide if we should execute it or skip it until next 1 second cycle. 
* **introduce `core.fps`**  - has the maximum frames per second that are actually possible to render, which can be used to accommodate to frame drops when performing some animations, scrolling, etc...
* **tokenizer: always check time left on long lines** - improves scrolling performance and other areas
* **highlighter: on long lines notify first/last only** - Depending on installed plugins the update_notify call can get
expensive and slow things down. With this change, it is now perform on first and last tokenization procedures, on first call it allows the visible first characters of the line to be updated for correct positioning calculations as plugins that need it. The major drawback is when employing differently sized fonts for token types. This may cause wrong positioning calculations when scrolling, but it is preferred over a laggy code editor. It is not the norm to use different font sizes for token types on files with long lines. Currently only markdown language plugin makes such an use and users that may have done heavy customization to the styling of the token types.
* **Expose co-routines max_time as core.co_max_time** - Introduces core.co_max_time which is the maximum execution time for co-routines on a per frame iteration basis. Can be used by any task to determine how much time it has before yielding.
* **Added new config.log_slow_threads option** - This new configuration option allows monitoring of coroutines that are taking more time to execute than that allowed on a per frame iteration basis. Should help when troubleshooting performance issues.
* **Main loop: burst events procecssing for 3s** - When receiving events we reduce the wait time to match the rendering
speed for the events that follow in order to process them earlier and reduce the input lag.

### Fixes:
* Input lag - ref #140
* Editor responsiveness for cases like lite-xl/lite-xl#1369 (even with plugins enabled)


### Show Case

**Vanilla Lite XL (master branch)**

https://github.com/user-attachments/assets/b0b64d1f-2603-400c-b63b-0a121bce767d 

**Vanilla Pragtical (co-routine improvements)**

https://github.com/user-attachments/assets/4d07a2d1-54ea-4f89-bf27-b91c1827dc81

**Lite XL with Plugins (drawwhitespace, colorpreview, rainbowparens, minimap, indentguide, lsp)**

Becomes unresponsive

**Pragtical with Plugins (drawwhitespace, colorpreview, rainbowparens, minimap, indentguide, lsp and more)**

https://github.com/user-attachments/assets/381d1a01-4f5d-427f-adff-a8a37fe46dea

### Reduced Input Lag Test

https://github.com/user-attachments/assets/f57cf694-fa44-4bce-b693-8ca4a4b2a8fe

**Testing Patch**
```diff
diff --git a/data/core/init.lua b/data/core/init.lua
index 4bd8339c..ed2da295 100644
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1346,11 +1346,14 @@ local cycle_end_time = 0
 ---@type number
 local main_loop_time = 0
 
+local event_start_time = nil
 function core.step()
   -- handle events
   local did_keymap = false
 
+  local is_textinput = false
   for type, a,b,c,d in system.poll_event do
+    is_textinput = type == "textinput"
     if type == "textinput" and did_keymap then
       did_keymap = false
     elseif type == "mousemoved" then
@@ -1405,6 +1408,10 @@ function core.step()
   core.root_view:draw()
   renderer.end_frame()
 
+  if is_textinput then
+    print((system.get_time() - event_start_time) * 1000, "ms")
+  end
+
   rendering_speed = math.max(0.001, system.get_time() - start_time)
 
   if rendering_speed * config.fps < 1 then
@@ -1583,6 +1590,7 @@ function core.run()
       end
     else
       -- run all threads, listen events and perform drawing as needed
+      event_start_time = system.get_time()
       local did_redraw = false
       if not next_step or system.get_time() >= next_step then
         did_redraw = core.step()
```