### PR TITLE
Introduce new ignore files handling functions

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -429,6 +429,32 @@ function common.match_pattern(text, pattern, ...)
 end
 
 
+---Checks if a path matches one of the given ignore rules.
+---@param path string
+---@param info system.fileinfo
+---@param ignore_rules core.ignore_file_rule[]
+---@return boolean
+function common.match_ignore_rule(path, info, ignore_rules)
+  local basename = common.basename(path)
+  -- replace '\' with '/' for Windows where PATHSEP = '\'
+  path = PLATFORM == "Windows" and path:gsub("\\", "/") or path
+  local fullname = "/" .. path
+  for _, compiled in ipairs(ignore_rules) do
+    local test = compiled.use_path and fullname or basename
+    if compiled.match_dir then
+      if info.type == "dir" and string.match(test .. "/", compiled.pattern) then
+        return true
+      end
+    else
+      if string.match(test, compiled.pattern) then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+
 ---Draws text onto the window.
 ---The function returns the X and Y coordinates of the bottom-right
 ---corner of the text.

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1672,4 +1672,36 @@ function core.deprecation_log(kind)
 end
 
 
+---A pre-processed config.ignore_files entry.
+---@class core.ignore_file_rule
+---A lua pattern.
+---@field pattern string
+---Match a full path including path separators, otherwise match filename only.
+---@field use_path boolean
+---Match directories only.
+---@field match_dir boolean
+
+---Gets a list of pre-processed config.ignore_files patterns for usage in
+---combination of common.match_ignore_rule()
+---@return core.ignore_file_rule[]
+function core.get_ignore_file_rules()
+  local ipatterns = config.ignore_files
+  local compiled = {}
+  -- config.ignore_files could be a simple string...
+  if type(ipatterns) ~= "table" then ipatterns = {ipatterns} end
+  for _, pattern in ipairs(ipatterns) do
+    -- we ignore malformed pattern that raise an error
+    if pcall(string.match, "a", pattern) then
+      table.insert(compiled, {
+        use_path = pattern:match("/[^/$]"), -- contains a slash but not at the end
+        -- An '/' or '/$' at the end means we want to match a directory.
+        match_dir = pattern:match(".+/%$?$"), -- to be used as a boolen value
+        pattern = pattern -- get the actual pattern
+      })
+    end
+  end
+  return compiled
+end
+
+
 return core

--- a/data/plugins/findfile.lua
+++ b/data/plugins/findfile.lua
@@ -66,7 +66,7 @@ local function basedir_files()
         if
           info and info.size <= config.file_size_limit * 1e6
           and
-          not common.match_pattern(file, config.ignore_files)
+          not common.match_ignore_rule(file, info, core.get_ignore_file_rules())
         then
           if info.type ~= "dir" then
             if multiple_projects then
@@ -159,7 +159,7 @@ local function index_files_thread(pathsep, ignore_files, file_size_limit)
             if
               info and info.size <= file_size_limit
               and
-              not commons.match_pattern(directory .. file, ignore_files)
+              not commons.match_ignore_rule(directory..file, info, ignore_files)
             then
               if info.type == "dir" then
                 table.insert(directories, directory .. file)
@@ -213,7 +213,7 @@ local function index_files_coroutine()
 
       local indexing_thread = thread.create(
         "findfile", index_files_thread,
-        PATHSEP, config.ignore_files, config.file_size_limit * 1e6
+        PATHSEP, core.get_ignore_file_rules(), config.file_size_limit * 1e6
       )
 
       local last_time = system.get_time()

--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -270,8 +270,8 @@ local function files_search_thread(tid, options)
           )
           count = count + 1
           if
-            info and not commons.match_pattern(
-              directory .. file, ignore_files
+            info and not commons.match_ignore_rule(
+              directory..file, info, ignore_files
             )
           then
             if info.type == "dir" then
@@ -367,7 +367,7 @@ function ResultsView:begin_search(path, text, search_type, insensitive, whole_wo
         whole_word = whole_word,
         path = path,
         pathsep = PATHSEP,
-        ignore_files = config.ignore_files,
+        ignore_files = core.get_ignore_file_rules(),
         workers = workers,
         file_size_limit = config.file_size_limit * 1e6
       }


### PR DESCRIPTION
Generalized Project class ignore file functions into new core functions that can be used by any plugin:

* core.get_ignore_file_rules()
* common.match_ignore_rule(path, info, ignore_rules)

Adapted findile and projectsearch plugins to use these functions that properly handle Windows path separators, pattern validation and rules.

Removed the original functions from Project class and replaced with generalized functions, also fixed some inconsistencies from the generalized Project functions and make use of relative file path when checking a file against Project:get_file_info().