### PR TITLE
Process TitleView button actions on mouse release

### DIFF
--- a/data/core/titleview.lua
+++ b/data/core/titleview.lua
@@ -102,9 +102,8 @@ function TitleView:draw_window_controls()
 end
 
 
-function TitleView:on_mouse_pressed(button, x, y, clicks)
-  local caught = TitleView.super.on_mouse_pressed(self, button, x, y, clicks)
-  if caught then return end
+function TitleView:on_mouse_released(button, x, y)
+  TitleView.super.on_mouse_released(self, button, x, y)
   core.set_active_view(core.last_active_view)
   if self.hovered_item then
     self.hovered_item.action()


### PR DESCRIPTION
Processing the button actions on mouse pressed can cause conflicts with dragging so instead perform them on release which is also the way it should be.