### PR TITLE
Document lax param and use on tokenizer ulen calls

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -666,7 +666,7 @@ function Doc:text_input(text, idx)
     if self.overwrite
     and (line1 == line2 and col1 == col2)
     and col1 < #self:get_utf8_line(line1)
-    and text:ulen() == 1 then
+    and text:ulen(nil, nil, true) == 1 then
       self:remove(line1, col1, translate.next_char(self, line1, col1))
     end
 

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -235,10 +235,10 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
       res = p.pattern and { text:ufind((at_start or p.whole_line[p_idx]) and "^" .. code or code, next) }
         or { regex.find(code, text, text:ucharpos(next), (at_start or p.whole_line[p_idx]) and regex.ANCHORED or 0) }
       if p.regex and #res > 0 then -- set correct utf8 len for regex result
-        local char_pos_1 = res[1] > next and string.ulen(text:sub(1, res[1])) or next
-        local char_pos_2 = string.ulen(text:sub(1, res[2]))
+        local char_pos_1 = res[1] > next and string.ulen(text:sub(1, res[1]), nil, nil, true) or next
+        local char_pos_2 = string.ulen(text:sub(1, res[2]), nil, nil, true)
         for i=3,#res do
-          res[i] = string.ulen(text:sub(1, res[i] - 1)) + 1
+          res[i] = string.ulen(text:sub(1, res[i] - 1), nil, nil, true) + 1
         end
         res[1] = char_pos_1
         res[2] = char_pos_2
@@ -264,7 +264,7 @@ function tokenizer.tokenize(incoming_syntax, text, state, resume)
     return table.unpack(res)
   end
 
-  local text_len = text:ulen()
+  local text_len = text:ulen(nil, nil, true)
   local start_time = system.get_time()
   local starting_i = i
   local max_time = math.floor(10000 * (core.co_max_time / 2)) / 10000

--- a/docs/api/string.lua
+++ b/docs/api/string.lua
@@ -1,7 +1,7 @@
 ---@meta
 
 ---UTF-8 equivalent of string.byte
----@param s  string
+---@param s string
 ---@param i? integer
 ---@param j? integer
 ---@return integer
@@ -16,35 +16,38 @@ function string.ubyte(s, i, j) end
 function string.uchar(byte, ...) end
 
 ---UTF-8 equivalent of string.find
----@param s       string
+---@param s string
 ---@param pattern string
----@param init?   integer
----@param plain?  boolean
+---@param init? integer
+---@param plain? boolean
 ---@return integer start
 ---@return integer end
 ---@return ... captured
 function string.ufind(s, pattern, init, plain) end
 
 ---UTF-8 equivalent of string.gmatch
----@param s       string
+---@param s string
 ---@param pattern string
----@param init?   integer
----@return fun():string, ...
+---@param init? integer
+---@return fun():string,...
 function string.ugmatch(s, pattern, init) end
 
 ---UTF-8 equivalent of string.gsub
----@param s       string
+---@param s string
 ---@param pattern string
----@param repl    string|table|function
----@param n       integer
+---@param repl string|table|function
+---@param n integer
 ---@return string
 ---@return integer count
 function string.ugsub(s, pattern, repl, n) end
 
 ---UTF-8 equivalent of string.len
 ---@param s string
+---@param i? integer
+---@param j? integer
+---@param lax? boolean Do not check if string is invalid utf8
 ---@return integer
-function string.ulen(s) end
+function string.ulen(s, i, j, lax) end
 
 ---UTF-8 equivalent of string.lower
 ---@param s string
@@ -52,20 +55,21 @@ function string.ulen(s) end
 function string.ulower(s) end
 
 ---UTF-8 equivalent of string.match
----@param s       string
+---@param s string
 ---@param pattern string
----@param init?   integer
+---@param init? integer
 ---@return string | number captured
 function string.umatch(s, pattern, init) end
 
 ---UTF-8 equivalent of string.reverse
 ---@param s string
+---@param lax? boolean Do not check if string is invalid utf8
 ---@return string
-function string.ureverse(s) end
+function string.ureverse(s, lax) end
 
 ---UTF-8 equivalent of string.sub
----@param s  string
----@param i  integer
+---@param s string
+---@param i integer
 ---@param j? integer
 ---@return string
 function string.usub(s, i, j) end
@@ -76,13 +80,13 @@ function string.usub(s, i, j) end
 function string.uupper(s) end
 
 ---Equivalent to utf8extra.escape()
----@param s  string
+---@param s string
 ---@return string utf8_string
 function string.uescape(s) end
 
 
 ---Equivalent to utf8extra.charpos()
----@param s  string
+---@param s string
 ---@param charpos? integer
 ---@param index? integer
 ---@return integer charpos
@@ -90,7 +94,7 @@ function string.uescape(s) end
 function string.ucharpos(s, charpos, index) end
 
 ---Equivalent to utf8extra.next()
----@param s  string
+---@param s string
 ---@param charpos? integer
 ---@param index? integer
 ---@return integer charpos
@@ -182,14 +186,16 @@ function string.unormalize_nfc(s) end
 function string.uoffset(s, n, i) end
 
 ---Equivalent to utf8.codepoint()
----@param s    string
----@param i?   integer
----@param j?   integer
+---@param s string
+---@param i? integer
+---@param j? integer
+---@param lax? boolean Do not check if string is invalid utf8
 ---@return integer code
 ---@return ...
-function string.ucodepoint(s, i, j) end
+function string.ucodepoint(s, i, j, lax) end
 
 ---Equivalent to utf8.codes()
 ---@param s string
----@return fun():integer, integer
-function string.ucodes(s) end
+---@param lax? boolean Do not check if string is invalid utf8
+---@return fun():integer,integer
+function string.ucodes(s, lax) end

--- a/docs/api/utf8extra.lua
+++ b/docs/api/utf8extra.lua
@@ -5,7 +5,7 @@
 utf8extra = {}
 
 ---UTF-8 equivalent of string.byte
----@param s  string
+---@param s string
 ---@param i? integer
 ---@param j? integer
 ---@return integer
@@ -13,27 +13,27 @@ utf8extra = {}
 function utf8extra.byte(s, i, j) end
 
 ---UTF-8 equivalent of string.find
----@param s       string
+---@param s string
 ---@param pattern string
----@param init?   integer
----@param plain?  boolean
+---@param init? integer
+---@param plain? boolean
 ---@return integer start
 ---@return integer end
 ---@return ... captured
 function utf8extra.find(s, pattern, init, plain) end
 
 ---UTF-8 equivalent of string.gmatch
----@param s       string
+---@param s string
 ---@param pattern string
----@param init?   integer
+---@param init? integer
 ---@return fun():string, ...
 function utf8extra.gmatch(s, pattern, init) end
 
 ---UTF-8 equivalent of string.gsub
----@param s       string
+---@param s string
 ---@param pattern string
----@param repl    string|table|function
----@param n       integer
+---@param repl string|table|function
+---@param n integer
 ---@return string
 ---@return integer count
 function utf8extra.gsub(s, pattern, repl, n) end
@@ -44,20 +44,21 @@ function utf8extra.gsub(s, pattern, repl, n) end
 function utf8extra.lower(s) end
 
 ---UTF-8 equivalent of string.match
----@param s       string
+---@param s string
 ---@param pattern string
----@param init?   integer
+---@param init? integer
 ---@return string | number captured
 function utf8extra.match(s, pattern, init) end
 
 ---UTF-8 equivalent of string.reverse
 ---@param s string
+---@param lax? boolean Do not check if string is invalid utf8
 ---@return string
-function utf8extra.reverse(s) end
+function utf8extra.reverse(s, lax) end
 
 ---UTF-8 equivalent of string.sub
----@param s  string
----@param i  integer
+---@param s string
+---@param i integer
 ---@param j? integer
 ---@return string
 function utf8extra.sub(s, i, j) end
@@ -81,7 +82,7 @@ function utf8extra.upper(s) end
 ---print(u"%123%u123%{123}%u{123}%xABC%x{ABC}")
 ---print(u"%%123%?%d%%u")
 ---```
----@param s  string
+---@param s string
 ---@return string utf8_string
 function utf8extra.escape(s) end
 
@@ -90,7 +91,7 @@ function utf8extra.escape(s) end
 ---charpos will be calculated, by add/subtract UTF-8 char index to current
 ---charpos. in all cases, it returns a new char position, and code point
 ---(a number) at this position.
----@param s  string
+---@param s string
 ---@param charpos? integer
 ---@param index? integer
 ---@return integer charpos
@@ -107,7 +108,7 @@ function utf8extra.charpos(s, charpos, index) end
 ---charpos and index is given, a new charpos will be calculated, by add/subtract
 ---UTF-8 char offset to current charpos. in all case, it return a new char
 ---position (in bytes), and code point (a number) at this position.
----@param s  string
+---@param s string
 ---@param charpos? integer
 ---@param index? integer
 ---@return integer charpos
@@ -249,7 +250,10 @@ function utf8extra.char(...) end
 ---will iterate over all characters in string s, with p being the position
 ---(in bytes) and c the code point of each character. It raises an error if
 ---it meets any invalid byte sequence.
-function utf8extra.codes(s) end
+---@param s string
+---@param lax? boolean Do not check if string is invalid utf8
+---@return fun():integer,integer
+function utf8extra.codes(s, lax) end
 
 ---Returns the codepoints (as integers) from all characters in s that start
 ---between byte position i and j (both included). The default for i is 1 and
@@ -257,8 +261,9 @@ function utf8extra.codes(s) end
 ---@param s string
 ---@param i? integer
 ---@param j? integer
----@return fun():integer, ...
-function utf8extra.codepoint(s, i, j) end
+---@param lax? boolean Do not check if string is invalid utf8
+---@return fun():integer,...
+function utf8extra.codepoint(s, i, j, lax) end
 
 ---Returns the number of UTF-8 characters in string s that start between
 ---positions i and j (both inclusive). The default for i is 1 and for j is -1.
@@ -267,9 +272,10 @@ function utf8extra.codepoint(s, i, j) end
 ---@param s string
 ---@param i? integer
 ---@param j? integer
+---@param lax? boolean Do not check if string is invalid utf8
 ---@return integer?
 ---@return integer?
-function utf8extra.len(s, i, j) end
+function utf8extra.len(s, i, j, lax) end
 
 ---Returns the position (in bytes) where the encoding of the n-th character
 ---of s (counting from position i) starts. A negative n gets characters before


### PR DESCRIPTION
These changes document the lax param used on some of the utf8extra functions which allows not checking if a string is valid utf8. Skipping this check gives a bit better performance so we use it on the tokenizer ulen() calls since we are always passing utf8 valid strings.

### Testing Benchmark:

```lua
local value = string.rep("hoáélaéáásd", 10000, " ");

common.bench("ulen", function()
  for i=1, 10000 do
    value:ulen(nil, nil)
  end
end)

common.bench("ulen lax", function()
  for i=1, 10000 do
    value:ulen(nil, nil, true)
  end
end)
```

**Result:**

```
*** ulen             : 3160.357ms 18962.14%
*** ulen lax         :  795.085ms 4770.51%
```