### PR TITLE
Use project version as mods version

### DIFF
--- a/data/core/start.lua
+++ b/data/core/start.lua
@@ -1,8 +1,8 @@
 -- this file is used by pragtical to setup the Lua environment when starting
 VERSION = "@PROJECT_VERSION@"
-MOD_VERSION_MAJOR = 3
-MOD_VERSION_MINOR = 5
-MOD_VERSION_PATCH = 0
+MOD_VERSION_MAJOR = tonumber("@MOD_VERSION_MAJOR@")
+MOD_VERSION_MINOR = tonumber("@MOD_VERSION_MINOR@")
+MOD_VERSION_PATCH = tonumber("@MOD_VERSION_PATCH@")
 MOD_VERSION_STRING = string.format("%d.%d.%d", MOD_VERSION_MAJOR, MOD_VERSION_MINOR, MOD_VERSION_PATCH)
 
 DEFAULT_SCALE = 1.0

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('pragtical',
     ['c'],
-    version : '3.4.4',
+    version : '3.5.0',
     license : 'MIT',
     meson_version : '>= 0.56',
     default_options : [
@@ -10,6 +10,7 @@ project('pragtical',
 )
 
 version = meson.project_version()
+mod_version = version.split('.')
 
 #===============================================================================
 # System dependency settings
@@ -64,6 +65,9 @@ conf_data.set('PROJECT_BUILD_DIR', meson.current_build_dir())
 conf_data.set('PROJECT_SOURCE_DIR', meson.current_source_dir())
 conf_data.set('PROJECT_VERSION', version)
 conf_data.set('PROJECT_ASSEMBLY_VERSION', meson.project_version() + '.0')
+conf_data.set('MOD_VERSION_MAJOR', mod_version[0])
+conf_data.set('MOD_VERSION_MINOR', mod_version[1])
+conf_data.set('MOD_VERSION_PATCH', mod_version[2])
 
 #===============================================================================
 # Compiler Settings


### PR DESCRIPTION
Since we are following a semver approach to versioning it is much easier to just use a single version number that represents both, the project version and the mods version.

Taken from https://semver.org/ and for reference:

1. MAJOR version when you make incompatible API changes
2. MINOR version when you add functionality in a backward compatible manner
3. PATCH version when you make backward compatible bug fixes