### PR TITLE
Check valid line state on retokenization check

### DIFF
--- a/data/core/doc/highlighter.lua
+++ b/data/core/doc/highlighter.lua
@@ -54,7 +54,7 @@ function Highlighter:start()
         retokenized_from and (
           prev_line ~= retokenized_from
           or
-          not (line.resume and #line.text > 200)
+          not (line and line.resume and #line.text > 200)
         )
       then
         prev_line = retokenized_from


### PR DESCRIPTION
When doing the line state verification, check it is a valid before trying to access any of the state fields.