### PR TITLE
Make the input latency reduction toggleable

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -265,6 +265,13 @@ config.skip_plugins_version = false
 ---@type boolean
 config.log_slow_threads = false
 
+---When enabled, background tasks are processed more aggressively by waiting
+---less for system events when events are received. Disable this option to
+---reduce CPU usage.
+---
+---Defaults to true.
+config.lower_input_latency = true
+
 ---Increases the performance of the editor and its user.
 ---Do not change this unless you know what you are doing.
 ---

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1599,7 +1599,7 @@ function core.run()
             local cursor_time_to_wake = dt + 1 / core.fps
             next_step = now + cursor_time_to_wake
           end
-          local b = burst_events > now and rendering_speed or 1
+          local b = (config.lower_input_latency and burst_events > now) and rendering_speed or 1
           if system.wait_event(math.min(next_step - now, time_to_wake, b)) then
             next_step = nil
             -- burst event processing speed to reduce input lag

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -658,6 +658,13 @@ settings.add("Editor",
       path = "scroll_past_end",
       type = settings.type.TOGGLE,
       default = true
+    },
+    {
+      label = "Lower Input Latency",
+      description = "Reduce input latency by processing background tasks more aggressively, may use more CPU.",
+      path = "lower_input_latency",
+      type = settings.type.TOGGLE,
+      default = true
     }
   }
 )


### PR DESCRIPTION
Since the reduction in input latency is achieved by more rapidly processing background tasks when events are received, it can result on momentary higher cpu usage when moving mouse or typing.

This change introduces a toggle to disable this behavior if desired by user to reduce cpu usage.