### PR TITLE
Use wayland by default if possible on linux

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -126,6 +126,16 @@ int main(int argc, char **argv) {
   }
 #endif
 
+#ifdef __linux__
+  /* Use wayland by default if SDL_VIDEODRIVER not set and session type wayland */
+  if (getenv("SDL_VIDEODRIVER") == NULL) {
+    const char *session_type = getenv("XDG_SESSION_TYPE");
+    if (session_type && strcmp(session_type, "wayland") == 0) {
+      SDL_SetHint(SDL_HINT_VIDEODRIVER, "wayland");
+    }
+  }
+#endif
+
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
     fprintf(stderr, "Error initializing sdl: %s", SDL_GetError());
     exit(1);


### PR DESCRIPTION
Set the video driver backend to wayland by default if SDL_VIDEODRIVER not set and session type wayland.

Motivation from #189 to prevent unnecessary X11 issues when running on Wayland.