### PR TITLE
Autoreload: prevent infinite check loop on save

### DIFF
--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -134,6 +134,9 @@ Doc.load = function(self, ...)
 end
 
 Doc.save = function(self, ...)
+  -- prevent watch loop since DirWatch:check will unwatch/watch the file when
+  -- it is saved causing an infinite check loop if we don't unwatch it first
+  if times[self] then watch:unwatch(self.abs_filename) times[self] = nil end
   local res = save(self, ...)
   -- if starting with an unsaved document with a filename.
   if #core.get_views_referencing_doc(self) > 0 then


### PR DESCRIPTION
The infinite watch loop occurs on backends like inotify where DirWatch:check will unwatch/watch the file on each check. If the change event is triggered twice in a row we get an infinite loop. Unwatching before save is required to prevent this issue.

This was the cause why unwatch/watch was previously disabled. Re-enabled on #193 because it is actually needed... Totally forgot why it was disabled in the first place and the doc explanation wasn't the real cause xD (and this explanation may not be either)