### PR TITLE
Allow console output when running on PowerShell

### DIFF
--- a/data/core/cli.lua
+++ b/data/core/cli.lua
@@ -105,7 +105,13 @@ end
 ---@param color "red" | "green" | "yellow" | "purple" | "blue" | "liteblue" | "gray"
 ---@return string colorized_text
 function cli.colorize(text, color)
-  if os.getenv("SHELL") or PLATFORM ~= "Windows" then
+  if
+    -- Mostly any standard shell
+    os.getenv("SHELL") or PLATFORM ~= "Windows"
+    or
+    -- Windows 10+
+    os.getenv("ProgramFiles")
+  then
     if color == "green" then
       return "\27[92m"..text.."\27[0m"
     elseif color == "red" then

--- a/src/main.c
+++ b/src/main.c
@@ -117,12 +117,32 @@ int main(int argc, char **argv) {
    *      https://stackoverflow.com/q/17111308
   */
   if (
-    !getenv("SHELL") && (getenv("ComSpec") || getenv("COMSPEC"))
+    !getenv("SHELL")
+    &&
+    (
+      /* Command Prompt */
+      getenv("ComSpec") || getenv("COMSPEC")
+      ||
+      /* PowerShell */
+      (getenv("PSExecutionPolicy") && getenv("PSExecutionPolicy") != NULL)
+    )
     &&
     AttachConsole(ATTACH_PARENT_PROCESS)
   ) {
     freopen("CONOUT$", "w", stdout);
     freopen("CONOUT$", "w", stderr);
+
+    /* Enable ANSI escape codes in Windows 10 and later */
+    OSVERSIONINFO osvi;
+    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    if (GetVersionEx(&osvi)) {
+      if (osvi.dwMajorVersion >= 10) {
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        DWORD mode;
+        GetConsoleMode(hConsole, &mode);
+        SetConsoleMode(hConsole, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+      }
+    }
   }
 #endif
 


### PR DESCRIPTION
This change also enables ANSI escape codes in Windows 10 and later to allow colored text output and other goodies.