### PR TITLE
Respect multi-byte sequences on SHIFT_JIS ¥ handling

### DIFF
--- a/data/core/encoding.lua
+++ b/data/core/encoding.lua
@@ -9,7 +9,13 @@ encoding.convert = function(tocharset, fromcharset, text, options)
     -- we are insterested on keeping the original to prevent issues on
     -- code that uses escape sequences like '\n', '\r', etc...
     local errmsg
-    text = text:gsub("\\", "{\\\\\\}")
+    -- replace \ with placeholder {\\\} in order to restore it back
+    -- into the original backslash after encoding conversion
+    text = text
+      -- in between characters respecting multi-byte sequences
+      :gsub("([^\x81-\x9f\xe0-\xef])(\\)", "%1{\\\\\\}")
+      -- at beginning of text in case the first character is a \
+      :gsub("^\\", "{\\\\\\}")
     text, errmsg = encoding_convert(tocharset, fromcharset, text, options)
     if text then
       text = text:gsub("%{¥¥¥%}", "\\")


### PR DESCRIPTION
Only perform backslash to placeholder replacement on non multi-byte sequences.

Should fix #201