### PR TITLE
Explicitly added missing headers

### DIFF
--- a/src/api/encoding.c
+++ b/src/api/encoding.c
@@ -4,6 +4,7 @@
 #include <lualib.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <string.h>
 #include <uchardet.h>
 
 #ifdef _WIN32

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
+#include <math.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "api.h"


### PR DESCRIPTION
Some headers that were implicitly included with SDL are now missing with sdl2-compat so we include them.