### PR TITLE
Fix handling of documents Bytes Order Mark (BOM)

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -23,7 +23,7 @@ end
 function Doc:new(filename, abs_filename, new_file)
   self.new_file = new_file
   self.encoding = nil
-  self.convert = false
+  self.bom = nil
   self.binary = false
   self.cache = {}
   self:reset()
@@ -85,25 +85,32 @@ function Doc:set_filename(filename, abs_filename)
 end
 
 
+function Doc:needs_encoding_change()
+  if self.encoding ~= "UTF-8" and self.encoding ~= "ASCII" then
+    return true
+  end
+  return false
+end
+
+
 function Doc:load(filename)
   if not self.encoding then
     local errmsg
-    self.encoding, errmsg = encoding.detect(filename);
+    self.encoding, self.bom, errmsg = encoding.detect(filename);
     if not self.encoding then
       core.error("%s", errmsg)
       self.encoding = "UTF-8"
     end
+  elseif self.bom then
+    self.bom = encoding.get_charset_bom(self.encoding)
   end
-  self.convert = false
-  if self.encoding ~= "UTF-8" and self.encoding ~= "ASCII" then
-    self.convert = true
-  end
+  local convert = self:needs_encoding_change()
   local fp = assert( io.open(filename, "rb") )
   self:reset()
   self.lines = {}
   self.clean_lines = {}
   local i = 1
-  if self.convert then
+  if convert then
     local content = fp:read("*a");
     content = assert(encoding.convert("UTF-8", self.encoding, content, {
       strict = false,
@@ -183,8 +190,10 @@ function Doc:save(filename, abs_filename)
   end
   local fp
   local output = ""
-  if not self.convert then
+  local convert = self:needs_encoding_change()
+  if not convert then
     fp = open_for_writing(abs_filename)
+    if self.bom then fp:write(self.bom) end
     for _, line in ipairs(self.lines) do
       if self.crlf then line = line:gsub("\n", "\r\n") end
       fp:write(line)
@@ -194,15 +203,15 @@ function Doc:save(filename, abs_filename)
       if self.crlf then output = output:gsub("\n", "\r\n") end
   end
   local conversion_error = false
-  if self.convert then
+  if convert then
     local errmsg
     output, errmsg = encoding.convert(self.encoding, "UTF-8", output, {
-      strict = true,
-      handle_to_bom = true
+      strict = true
     })
     if output then
       fp = open_for_writing(abs_filename)
-      fp:write(encoding.get_charset_bom(self.encoding) .. output)
+      if self.bom then fp:write(self.bom) end
+      fp:write(output)
       fp:close()
     else
       conversion_error = true

--- a/data/core/encoding.lua
+++ b/data/core/encoding.lua
@@ -28,21 +28,22 @@ end
 local encoding_detect = encoding.detect
 
 encoding.detect = function(filename)
-  local charset, errmsg = encoding_detect(filename)
+  local charset, bom, errmsg = encoding_detect(filename)
   if not charset then
     local file = io.open(filename, "r")
     if file then
       local content = file:read("*a")
       file:close()
-      local test_encodings = {
+      local test_charsets = {
         "UTF-16LE", "UTF-16BE", "UTF-32LE", "UTF-32BE"
       }
-      for _, encoding in ipairs(test_encodings) do
-        if encoding_convert("UTF-8", encoding, content, {strict = true}) then
-          return encoding
+      for _, from_charset in ipairs(test_charsets) do
+        if encoding_convert("UTF-8", from_charset, content, {strict = true}) then
+          _, bom = encoding.strip_bom(content:sub(1, 32), from_charset)
+          return from_charset, bom
         end
       end
     end
   end
-  return charset, errmsg
+  return charset, bom, errmsg
 end

--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -355,9 +355,10 @@ function StatusView:register_docview_items()
     name = "doc:encoding",
     alignment = StatusView.Item.RIGHT,
     get_item = function()
-      local dv = core.active_view
+      local dv, bom = core.active_view, ""
+      if dv.doc.bom then bom = " (BOM)" end
       return {
-        style.text, dv.doc.encoding or "none"
+        style.text, (dv.doc.encoding or "none"), bom
       }
     end,
     command = function(button)

--- a/docs/api/encoding.lua
+++ b/docs/api/encoding.lua
@@ -73,21 +73,23 @@ encoding = {}
 ---Try and detect the encoding to best of capabilities for given file given or
 ---returns nil and error message on failure.
 ---@param filename string
----@return string | nil charset
----@return string errmsg
+---@return string? charset
+---@return string? bom
+---@return string? errmsg
 function encoding.detect(filename) end
 
 ---
 ---Same as encoding.detect() but for strings.
 ---@param text string
----@return string | nil charset
----@return string errmsg
+---@return string? charset
+---@return string? bom
+---@return string? errmsg
 function encoding.detect_string(text) end
 
 ---@class encoding.convert_options
----@field handle_to_bom boolean @If applicable adds the byte order marks.
----@field handle_from_bom boolean @If applicable strips the byte order marks.
----@field strict boolean @When true fail if errors found.
+---@field handle_to_bom? boolean @If applicable adds the byte order marks.
+---@field handle_from_bom? boolean @If applicable strips the byte order marks.
+---@field strict? boolean @When true fail if errors found.
 
 ---
 ---Converts the given text from one encoding into another.
@@ -95,14 +97,14 @@ function encoding.detect_string(text) end
 ---@param fromcharset encoding.charset
 ---@param text string
 ---@param options? encoding.convert_options
----@return string | nil converted_text
----@return string errmsg
+---@return string? converted_text
+---@return string? errmsg
 function encoding.convert(tocharset, fromcharset, text, options) end
 
 ---
 ---Get the byte order marks for the given charset if applicable.
 ---@param charset encoding.charset
----@return string bom
+---@return string? bom
 function encoding.get_charset_bom(charset) end
 
 ---
@@ -110,4 +112,5 @@ function encoding.get_charset_bom(charset) end
 ---@param text string A string that may contain a byte order marks.
 ---@param charset? encoding.charset Charset to scan, if nil scan all charsets with bom.
 ---@return string cleaned_text
+---@return string? bom The stripped bytes order mark.
 function encoding.strip_bom(text, charset) end


### PR DESCRIPTION
Main feature of these changes is that now we properly save the BOM if the loaded document originally contained one.

Other changes include:

* Updated encoding API functions to also return the BOM:
  - encoding.detect
  - encoding.detect_string
  - encoding.strip_bom
* Return nil on `encoding.get_charset_bom()` if no applicable BOM.
* Updated encoding API Lua docs.
* Introduced `Doc:needs_encoding_conversion()` to simplify conversion logic.
* Introduced three new document bom handling commands:
  - doc:disable-bom
  - doc:enable-bom
  - doc:toggle-bom

These changes should fix #214