### PR TITLE
Disabled addition of open_ext plugin on CI

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -29,13 +29,14 @@ addons_install() {
   local build_dir="$1"
   local data_dir="$2"
 
+  # Disabled since pragtical can load binary files without crashing
   # Plugins
-  mkdir -p "${data_dir}/plugins"
+  # mkdir -p "${data_dir}/plugins"
 
-  for plugin_name in open_ext; do
-    cp -r "${build_dir}/third/data/plugins/${plugin_name}.lua" \
-      "${data_dir}/plugins/"
-  done
+  # for plugin_name in open_ext; do
+  #   cp -r "${build_dir}/third/data/plugins/${plugin_name}.lua" \
+  #     "${data_dir}/plugins/"
+  # done
 }
 
 get_platform_name() {


### PR DESCRIPTION
Since pragtical can load binary files and handle various encodings and bytes order mark without crashing we are disabling the inclusion of the open_ext plugin on the github CI builds.

Thanks to Vinfall for the observation/suggestion!