### PR TITLE
Perform collectgarbage step instead of collect

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1537,6 +1537,28 @@ local run_threads = coroutine.wrap(function()
 end)
 
 
+-- Override default collectgarbage function to prevent users from performing
+-- a system stalling garbage collection, instead a new forcecollect option
+-- can be used.
+local collectgarbage_lua = collectgarbage
+
+---This function is a generic interface to the garbage collector.
+---It performs different functions according to its first argument, `opt`.
+---@param opt? gcoptions | "forcecollect"
+---@param ... any
+---@return any
+function collectgarbage(opt, ...)
+  local ret
+  if not opt or opt == "collect" then
+    ret = collectgarbage_lua("step", 10*1024)
+  elseif opt == "forcecollect" then
+    ret = collectgarbage_lua("collect")
+  else
+    ret = collectgarbage_lua(opt, ...)
+  end
+  return ret
+end
+
 function core.run()
   scale = require "plugins.scale"
   local next_step

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -742,6 +742,51 @@ settings.add("Status Bar",
   }
 )
 
+settings.add("Advanced",
+  {
+    {
+      label = "Garbage Collector Pause",
+      description = "How many times ram has to increase after last clean in order to reclean. Lower value makes GC more aggressive but may cause stuttering.",
+      path = "gc_pause",
+      type = settings.type.NUMBER,
+      default = 2,
+      min = 1,
+      max = 10,
+      step = 0.1,
+      set_value = function(value)
+        return common.clamp(value, 1, 10)
+      end,
+      on_apply = function(value)
+        if LUA_VERSION < 5.4 then
+          collectgarbage("setpause", value*100)
+        else
+          collectgarbage("incremental", value*100, 0, 0)
+        end
+      end
+    },
+    {
+      label = "Garbage Collector Step Multiplier",
+      description = "How many times faster to run the collector in relation to allocations. Higher value makes GC more aggressive but may cause stuttering.",
+      path = "gc_step_multiplier",
+      type = settings.type.NUMBER,
+      default = 2,
+      min = 1,
+      max = 10,
+      step = 0.1,
+      set_value = function(value)
+        return common.clamp(value, 1, 10)
+      end,
+      on_apply = function(value)
+        if LUA_VERSION < 5.4 then
+          collectgarbage("setstepmul", value*100)
+        else
+          collectgarbage("incremental", 0, value*100, 0)
+        end
+      end
+    },
+  }
+)
+
 ---Retrieve from given config the associated value using the given path.
 ---@param conf table
 ---@param path string


### PR DESCRIPTION
This commit overrides the collectgarbage lua function to replace `collect` calls with a `step` to reduce system stuttering caused by miss use of this option. A forcecollect option was introduced in case it is explicitly needed to force a full garbage collection.

This change also adds a new Advanced pane settings with two new options to allow configuring the garbage collector pause and step multiplier values. Making these values less aggressive should result on better editor responsiveness with the downside of longer higher memory usage time spans.

![20250306-175109](https://github.com/user-attachments/assets/9de6ea72-6678-4260-b172-67883f47e235)
