### PR TITLE
Fix invalid size given to _wgetcwd

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -809,9 +809,10 @@ static int f_chdir(lua_State *L) {
 static int f_getcwd(lua_State* L) {
   #ifdef _WIN32
     wchar_t buffer[MAX_PATH];
-    if (!_wgetcwd(buffer, sizeof(buffer)))
+    if (!_wgetcwd(buffer, MAX_PATH))
       return luaL_error(L, "error getcwd: %s", strerror(errno));
     char *utf8_buffer = utfconv_wctoutf8(buffer);
+    if (utf8_buffer == NULL) { return luaL_error(L, UTFCONV_ERROR_INVALID_CONVERSION ); }
     lua_pushstring(L, utf8_buffer);
     free(utf8_buffer);
   #else

--- a/src/main_com.c
+++ b/src/main_com.c
@@ -142,7 +142,7 @@ void executeCommand(const char *command, DWORD *exit_code) {
 
 int main(int argc, char *argv[]) {
     // Allocate initial memory for the command
-    size_t commandSize = 1024;
+    size_t commandSize = 3072;
     char *command = (char *)malloc(commandSize);
     if (command == NULL) {
         fprintf(stderr, "Memory allocation failed\n");


### PR DESCRIPTION
This change should also fix a possible buffer overflow on main_com.c

Fixes #216, thanks to AmerM137 for reporting the issue.