### PR TITLE
Disable a compatibility io overwrite on LuaJIT

### DIFF
--- a/data/compat/module.lua
+++ b/data/compat/module.lua
@@ -877,7 +877,10 @@ if lua_version < "5.3" then
          end
       end -- not luajit
 
-      if is_luajit then
+      -- NOTICE:
+      -- Disable this compatibility override because it overwrites the file
+      -- meta type from FILE* to userdata, and does not seems to be needed.
+      if false and is_luajit then
          local compat_file_meta = {}
          local compat_file_meta_loaded = 0
 


### PR DESCRIPTION
For some context:

We use https://github.com/lunarmodules/lua-compat-5.3 to add some of the newer Lua 5.3+ changes and recently we syncronized our copy with upstream on #224

The issue:

The compatibility code seems to have some workaround for the io module when patching LuaJIT that causes the file metatable type to be overwritten from `FILE*` to `userdata`, causing issues with native functions that expect a `FILE*`. On a quick inspection, this workaround does not seems to be required.

Fixes #228, thanks to AmerM137 for reporting the issue.