### PR TITLE
CI: Polyfill GLIBC for backward compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,11 @@ jobs:
     strategy:
       matrix:
         config:
-          - compiler: default
-            arch: x86_64
-          - compiler: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-            arch: aarch64
-    runs-on: ubuntu-22.04
+          - arch: x86_64
+            distro: ubuntu-22.04
+          - arch: aarch64
+            distro: ubuntu-22.04-arm
+    runs-on: ${{ matrix.config.distro }}
     env:
       CC: gcc
       CXX: g++
@@ -81,50 +81,22 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "/usr/lib/ccache" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-          if [[ $(uname -m) != ${{ matrix.config.arch }} ]]; then
-            echo "ARCH=--cross-arch ${{ matrix.config.arch }}" >> "$GITHUB_ENV"
-          fi
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Update Packages
-        run: |
-          if [[ $(uname -m) = ${{ matrix.config.arch }} ]]; then
-            sudo apt-get update
-          else
-            url="http://ports.ubuntu.com/ubuntu-ports"
-            repos="main restricted universe multiverse"
-            echo "deb [arch=arm64] $url jammy $repos" > arm64.list
-            echo "deb [arch=arm64] $url jammy-updates $repos" >> arm64.list
-            echo "deb [arch=arm64] $url jammy-security $repos" >> arm64.list
-            echo "deb [arch=arm64] $url jammy-backports $repos" >> arm64.list
-            sudo mv arm64.list /etc/apt/sources.list.d/
-            sudo apt-get update
-            sudo dpkg --add-architecture arm64
-          fi
+        run: sudo apt-get update
       - name: Install Dependencies
         run: |
           sudo apt-get install -y ccache
-          if [[ $(uname -m) = ${{ matrix.config.arch }} ]]; then
-            bash scripts/install-dependencies.sh --debug
-          else
-            pip3 install meson
-            sudo apt-get install -y libfuse2 ninja-build
-            sudo apt-get install -y wayland-protocols:arm64 libsdl2-dev:arm64 libfreetype6:arm64
-          fi
-      - name: Install Cross Compiler
-        if: ${{ matrix.config.compiler != 'default' }}
-        run: sudo apt-get install -y ${{ matrix.config.compiler }}
+          bash scripts/install-dependencies.sh --debug
       - name: Build Portable
-        run: |
-          bash scripts/build.sh --debug --forcefallback --portable --release $ARCH
+        run: bash scripts/build.sh --debug --forcefallback --portable --release
       - name: Package Portables
-        run: |
-          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release $ARCH
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
       - name: Build AppImages
-        run: |
-          bash scripts/appimage.sh --debug --static --addons --version ${INSTALL_REF} --release $ARCH
+        run: bash scripts/appimage.sh --debug --static --addons --version ${INSTALL_REF} --release
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -62,11 +62,11 @@ jobs:
     strategy:
       matrix:
         config:
-          - compiler: default
-            arch: x86_64
-          - compiler: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-            arch: aarch64
-    runs-on: ubuntu-22.04
+          - arch: x86_64
+            distro: ubuntu-22.04
+          - arch: aarch64
+            distro: ubuntu-22.04-arm
+    runs-on: ${{ matrix.config.distro }}
     env:
       CC: gcc
       CXX: g++
@@ -79,50 +79,22 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "/usr/lib/ccache" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${{ needs.release.outputs.version }}" >> "$GITHUB_ENV"
-          if [[ $(uname -m) != ${{ matrix.config.arch }} ]]; then
-            echo "ARCH=--cross-arch ${{ matrix.config.arch }}" >> "$GITHUB_ENV"
-          fi
       - name: Python Setup
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Update Packages
-        run: |
-          if [[ $(uname -m) = ${{ matrix.config.arch }} ]]; then
-            sudo apt-get update
-          else
-            url="http://ports.ubuntu.com/ubuntu-ports"
-            repos="main restricted universe multiverse"
-            echo "deb [arch=arm64] $url jammy $repos" > arm64.list
-            echo "deb [arch=arm64] $url jammy-updates $repos" >> arm64.list
-            echo "deb [arch=arm64] $url jammy-security $repos" >> arm64.list
-            echo "deb [arch=arm64] $url jammy-backports $repos" >> arm64.list
-            sudo mv arm64.list /etc/apt/sources.list.d/
-            sudo apt-get update
-            sudo dpkg --add-architecture arm64
-          fi
+        run: sudo apt-get update
       - name: Install Dependencies
         run: |
           sudo apt-get install -y ccache
-          if [[ $(uname -m) = ${{ matrix.config.arch }} ]]; then
-            bash scripts/install-dependencies.sh --debug
-          else
-            pip3 install meson
-            sudo apt-get install -y libfuse2 ninja-build
-            sudo apt-get install -y wayland-protocols:arm64 libsdl2-dev:arm64 libfreetype6:arm64
-          fi
-      - name: Install Cross Compiler
-        if: ${{ matrix.config.compiler != 'default' }}
-        run: sudo apt-get install -y ${{ matrix.config.compiler }}
+          bash scripts/install-dependencies.sh --debug
       - name: Build Portable
-        run: |
-          bash scripts/build.sh --debug --forcefallback --portable $ARCH
+        run: bash scripts/build.sh --debug --forcefallback --portable
       - name: Package Portables
-        run: |
-          bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary $ARCH
+        run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
       - name: Build AppImages
-        run: |
-          bash scripts/appimage.sh --debug --static --addons --version ${INSTALL_REF} $ARCH
+        run: bash scripts/appimage.sh --debug --static --addons --version ${INSTALL_REF}
       - name: Upload Files
         uses: softprops/action-gh-release@v2
         with:

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -30,7 +30,7 @@ show_help(){
 setup_appimagetool() {
   local arch=$1
   if [ ! -e "appimagetool.$arch" ]; then
-    if ! wget -O "appimagetool.$arch" "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${arch}.AppImage" ; then
+    if ! wget -O "appimagetool.$arch" "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${arch}.AppImage" ; then
       echo "Could not download the appimagetool for the arch '${arch}'."
       exit 1
     else
@@ -55,7 +55,7 @@ download_appimage_runtime() {
   local arch=$1
   local file="runtime-${arch}"
   if [ ! -e "$file" ]; then
-    if ! wget -O "$file" "https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-${arch}" ; then
+    if ! wget -O "$file" "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-${arch}" ; then
       echo "Could not download AppImage Runtime for the arch '${arch}'."
       exit 1
     else
@@ -222,6 +222,10 @@ main() {
 
   DESTDIR="$(realpath Pragtical.AppDir)" meson install $strip_flag \
     --skip-subprojects="freetype2,pcre2" -C "${build_dir}"
+
+  if [[ -z "$cross" ]]; then
+    polyfill_glibc Pragtical.AppDir/usr/bin/pragtical
+  fi
 
   cp "AppRun.$arch" Pragtical.AppDir/AppRun
   cp -av "subprojects/ppm/libraries" Pragtical.AppDir/usr/share/pragtical/

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -76,6 +76,43 @@ get_default_build_dir() {
   echo "build-$platform-$arch"
 }
 
+polyfill_glibc() {
+  local platform
+  platform=$(get_platform_name)
+
+  if [[ "$platform" != "linux" ]]; then
+    return 0
+  fi
+
+  local arch
+  arch=$(get_platform_arch)
+
+  if [ ! -e "polyfill-glibc" ]; then
+    if ! wget -O "polyfill-glibc" "https://github.com/pragtical/polyfill-glibc/releases/download/binaries/polyfill-glibc.${arch}" ; then
+      echo "Could not download polyfill-glibc for the arch '${arch}'."
+      exit 1
+    else
+      chmod 0755 "polyfill-glibc"
+    fi
+  fi
+
+  local rename_symbols=""
+  if [[ "$arch" == "aarch64" ]]; then
+    local symbols="aarch_symbols_rename.txt"
+    echo "__isoc23_strtol@GLIBC_2.38 strtol" > $symbols
+    echo "__isoc23_strtoll@GLIBC_2.38 strtoll" >> $symbols
+    echo "__isoc23_strtoul@GLIBC_2.38 strtoul" >> $symbols
+    echo "__isoc23_strtoull@GLIBC_2.38 strtoull" >> $symbols
+    rename_symbols="--rename-dynamic-symbols=${symbols}"
+  fi
+
+  local binary_path="$1"
+  echo "======================================================================="
+  echo "Polyfill GLIBC on: ${binary_path}"
+  echo "======================================================================="
+  ./polyfill-glibc --target-glibc=2.17 $rename_symbols "$binary_path"
+}
+
 if [[ $(get_platform_name) == "UNSUPPORTED-OS" ]]; then
   echo "Error: unknown OS type: \"$OSTYPE\""
   exit 1

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -280,6 +280,10 @@ main() {
     exe_file="$(pwd)/${dest_dir}/$prefix/bin/pragtical"
   fi
 
+  if [[ -z "$cross" ]]; then
+    polyfill_glibc "${exe_file}"
+  fi
+
   mkdir -p "${data_dir}"
 
   if [[ $addons == true ]]; then


### PR DESCRIPTION
We now use https://github.com/corsix/polyfill-glibc in order to patch the pragtical binary to be backward compatible with older glibc versions.

Other Changes:

* Updated to latest AppImage runtime with static libfuse.
* Switched to new ubuntu aarch64 runners.