### PR TITLE
Include 'user' directory on portable installs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -240,10 +240,15 @@ if get_option('portable') or host_machine.system() == 'windows'
     pragtical_bindir = '/'
     pragtical_docdir = '/doc'
     pragtical_datadir = '/data'
-    configure_file(
-        input: 'resources/windows/pragtical.exe.manifest.in',
-        output: 'pragtical.exe.manifest',
-        configuration: conf_data
+    if host_machine.system() == 'windows'
+        configure_file(
+            input: 'resources/windows/pragtical.exe.manifest.in',
+            output: 'pragtical.exe.manifest',
+            configuration: conf_data
+        )
+    endif
+    install_data('resources/portable/README.md',
+        install_dir : pragtical_bindir / 'user'
     )
 elif get_option('bundle') and host_machine.system() == 'darwin'
     pragtical_cargs += '-DMACOS_USE_BUNDLE'

--- a/resources/README.md
+++ b/resources/README.md
@@ -14,6 +14,7 @@ This folder contains resources that is used for building or packaging the projec
 - `macos/appdmg.png`: Background image for packaging MacOS DMGs.
 - `macos/Info.plist.in`: Template for generating `info.plist` on MacOS. See `macos/macos-retina-display.md` for details.
 - `windows/001-lua-unicode.diff`: Patch for allowing Lua to load files with UTF-8 filenames on Windows.
+- `portable/README.md`: Copied to the `user` directory of portable builds.
 
 ### Development
 

--- a/resources/portable/README.md
+++ b/resources/portable/README.md
@@ -1,0 +1,10 @@
+# Portable User Directory
+
+This directory holds all your user settings. Since the directory is alongside
+the editor's executable, it allows the installation to be truly portable. If
+this isn't required or desired you can remove or move this directory to the
+global config path of your operating system. The global config directory can be:
+
+* `$XDG_CONFIG_HOME/pragtical` - Linux or any OS that follows the XDG specification
+* `$HOME/.config/pragtical` - Any Unix based system (macOS, FreeBSD, etc...)
+* `$USERPROFILE/.config/pragtical` - Windows

--- a/scripts/innosetup/innosetup.sh
+++ b/scripts/innosetup/innosetup.sh
@@ -80,10 +80,16 @@ main() {
     exit 1
   fi
 
-  output="Pragtical${version}-${arch_file}-setup"
+  # remove portable user settings directory since this is a fixed install
+  mv "pragtical/user" .
 
+  # generate setup
+  output="Pragtical${version}-${arch_file}-setup"
   "/c/Program Files (x86)/Inno Setup 6/ISCC.exe" -dARCH=$arch //F"${output}" "${build_dir}/scripts/innosetup.iss"
   pushd "${build_dir}/scripts"; mv Pragtical*.exe "./../../"; popd
+
+  # recreate user settings directory after generating setup
+  mv user "pragtical/"
 }
 
 main "$@"


### PR DESCRIPTION
This makes portable builds truly portable since user settings will be stored on current pragtical location.