### PR TITLE
Allow spaces in plugins mod-version

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -658,7 +658,7 @@ end
 
 
 local mod_version_regex =
-  regex.compile([[--.*mod-version:(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:$|\s)]])
+  regex.compile([[--.*mod-version:\s*(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:$|\s)]])
 local function get_plugin_details(filename)
   local info = system.get_file_info(filename)
   if info ~= nil and info.type == "dir" then


### PR DESCRIPTION
Fixes plugin loading issue [evergreen-languages](https://github.com/Evergreen-lxl/evergreen-languages) plugins that have a mod-version header with a space in between.