### PR TITLE
restore light lcd filter for slight hinting

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -171,7 +171,7 @@ static int font_set_render_options(RenFont* font) {
     unsigned char weights[] = { 0x10, 0x40, 0x70, 0x40, 0x10 } ;
     switch (font->hinting) {
       case FONT_HINTING_NONE: FT_Library_SetLcdFilter(library, FT_LCD_FILTER_NONE); break;
-      case FONT_HINTING_SLIGHT:
+      case FONT_HINTING_SLIGHT: FT_Library_SetLcdFilter(library, FT_LCD_FILTER_LIGHT); break;
       case FONT_HINTING_FULL: FT_Library_SetLcdFilterWeights(library, weights); break;
     }
     return FT_RENDER_MODE_LCD;


### PR DESCRIPTION
Pragtical equivilant of https://github.com/lite-xl/lite-xl/pull/2098

During the migration from libagg to freetype2 the original code was adapted poorly and slight hinting is given the full weights which, depending on the font, may result in more noticable color fringes. 

For the built-in fonts there is no difference