### PR TITLE
rework dirmonitors to be able to support multiple backends

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -285,6 +285,12 @@ config.lower_input_latency = true
 ---@type boolean | { font: renderer.font, icon: string } | nil
 config.stonks = true
 
+---Specifies the dirmonitor backend to be used or nil
+---to use the first available one.
+---
+---Defaults to nil
+config.dirmonitor_backend = nil
+
 -- holds the plugins real config table
 local plugins_config = {}
 

--- a/data/core/dirwatch.lua
+++ b/data/core/dirwatch.lua
@@ -1,3 +1,4 @@
+local core = require "core"
 local common = require "core.common"
 local config = require "core.config"
 local Object = require "core.object"
@@ -26,7 +27,12 @@ function DirWatch:new()
   self.watched = {}
   self.reverse_watched = {}
   self.last_modified = {}
-  self.monitor = dirmonitor.new()
+  local ok, monitor = pcall(dirmonitor.new, config.dirmonitor_backend)
+  if not ok then
+    monitor = dirmonitor.new()
+    core.error("Couldn't initialize directory watch with %s backend", config.dirmonitor_backend)
+  end
+  self.monitor = monitor
   self.single_watch_top = nil
   self.single_watch_count = 0
 end

--- a/docs/api/dirmonitor.lua
+++ b/docs/api/dirmonitor.lua
@@ -12,8 +12,10 @@ dirmonitor = {}
 ---
 ---Creates a new dirmonitor object.
 ---
+---@param backend? string Name of the dirmonitor backend to be used
+---
 ---@return dirmonitor
-function dirmonitor.new() end
+function dirmonitor.new(backend) end
 
 ---
 ---Monitors a directory or file for changes.

--- a/docs/api/dirmonitor.lua
+++ b/docs/api/dirmonitor.lua
@@ -66,5 +66,11 @@ function dirmonitor:check(callback, error_callback) end
 ---@return "single" | "multiple"
 function dirmonitor:mode() end
 
+---
+---List all available dirmonitor backends
+---
+---@return table.
+function dirmonitor.backends() end
+
 
 return dirmonitor

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option('bundle', type : 'boolean', value : false, description: 'Build a macOS bu
 option('source-only', type : 'boolean', value : false, description: 'Configure source files only, doesn\'t checks for dependencies')
 option('portable', type : 'boolean', value : false, description: 'Portable install')
 option('renderer', type : 'boolean', value : false, description: 'Use SDL renderer')
-option('dirmonitor_backend', type : 'combo', value : '', choices : ['', 'inotify', 'fsevents', 'kqueue', 'win32', 'dummy'], description: 'define what dirmonitor backend to use')
+option('dirmonitor_backends', type : 'array', value : [], choices : ['inotify', 'fsevents', 'kqueue', 'inodewatcher', 'win32', 'dummy'], description: 'define what dirmonitor backend to use')
 option('arch_tuple', type : 'string', value : '', description: 'Specify a custom architecture tuple')
 option('use_system_lua', type : 'boolean', value : false, description: 'Prefer System Lua over the meson wrap')
 option('extra_colors', type : 'boolean', value : true, description: 'Include additional colors')

--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -192,7 +192,7 @@ static int f_dirmonitor_backends(lua_State* L) {
 
   lua_createtable(L, 0, s);
   for (size_t i = 0; i < s; ++i) {
-    lua_pushnumber(L, i);
+    lua_pushnumber(L, i+1);
     lua_pushstring(L, backends[i]->name);
     lua_settable(L, -3);
   }

--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -187,6 +187,18 @@ static int f_dirmonitor_mode(lua_State* L) {
   return 1;
 }
 
+static int f_dirmonitor_backends(lua_State* L) {
+  const size_t s = (sizeof(backends) / sizeof(backends[0])) - 1;
+
+  lua_createtable(L, 0, s);
+  for (size_t i = 0; i < s; ++i) {
+    lua_pushnumber(L, i);
+    lua_pushstring(L, backends[i]->name);
+    lua_settable(L, -3);
+  }
+
+  return 1;
+}
 
 static const luaL_Reg dirmonitor_lib[] = {
   { "new",      f_dirmonitor_new         },
@@ -195,6 +207,7 @@ static const luaL_Reg dirmonitor_lib[] = {
   { "unwatch",  f_dirmonitor_unwatch     },
   { "check",    f_dirmonitor_check       },
   { "mode",     f_dirmonitor_mode        },
+  { "backends", f_dirmonitor_backends    },
   {NULL, NULL}
 };
 

--- a/src/api/dirmonitor/dirmonitor.h
+++ b/src/api/dirmonitor/dirmonitor.h
@@ -1,0 +1,22 @@
+#ifndef DIRMONITOR_H
+#define DIRMONITOR_H
+
+struct dirmonitor_backend {
+  const char* name;
+  struct dirmonitor_internal* (*init)(void);
+  void (*deinit)(struct dirmonitor_internal*);
+  int (*get_changes)(struct dirmonitor_internal*, char*, int);
+  int (*translate_changes)(struct dirmonitor_internal*, char*, int, int (*)(int, const char*, void*), void*);
+  int (*add)(struct dirmonitor_internal*, const char*);
+  void (*remove)(struct dirmonitor_internal*, int);
+  int (*get_mode)();
+};
+
+extern struct dirmonitor_backend dirmonitor_dummy;
+extern struct dirmonitor_backend dirmonitor_fsevents;
+extern struct dirmonitor_backend dirmonitor_inodewatcher;
+extern struct dirmonitor_backend dirmonitor_inotify;
+extern struct dirmonitor_backend dirmonitor_kqueue;
+extern struct dirmonitor_backend dirmonitor_win32;
+
+#endif

--- a/src/api/dirmonitor/dummy.c
+++ b/src/api/dirmonitor/dummy.c
@@ -1,9 +1,22 @@
 #include <stdlib.h>
 
-struct dirmonitor_internal* init_dirmonitor() { return NULL; }
-void deinit_dirmonitor(struct dirmonitor_internal* monitor) { }
-int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int len) { return -1; }
-int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int size, int (*callback)(int, const char*, void*), void* data) { return -1; }
-int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) { return -1; }
-void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) { }
-int get_mode_dirmonitor() { return 1; }
+#include "dirmonitor.h"
+
+static struct dirmonitor_internal* init_dirmonitor() { return NULL; }
+static void deinit_dirmonitor(struct dirmonitor_internal* monitor) { }
+static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int len) { return -1; }
+static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int size, int (*callback)(int, const char*, void*), void* data) { return -1; }
+static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) { return -1; }
+static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) { }
+static int get_mode_dirmonitor() { return 1; }
+
+struct dirmonitor_backend dirmonitor_dummy = {
+  .name = "dummy",
+  .init = init_dirmonitor,
+  .deinit = deinit_dirmonitor,
+  .get_changes = get_changes_dirmonitor,
+  .translate_changes = translate_changes_dirmonitor,
+  .add = add_dirmonitor,
+  .remove = remove_dirmonitor,
+  .get_mode = get_mode_dirmonitor,
+};

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <poll.h>
 
+#include "dirmonitor.h"
 
 struct dirmonitor_internal {
   int fd;
@@ -12,7 +13,7 @@ struct dirmonitor_internal {
 };
 
 
-struct dirmonitor_internal* init_dirmonitor() {
+static struct dirmonitor_internal* init_dirmonitor() {
   struct dirmonitor_internal* monitor = calloc(1, sizeof(struct dirmonitor_internal));
   monitor->fd = inotify_init();
   pipe(monitor->sig);
@@ -22,35 +23,46 @@ struct dirmonitor_internal* init_dirmonitor() {
 }
 
 
-void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
+static void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
   close(monitor->fd);
   close(monitor->sig[0]);
   close(monitor->sig[1]);
 }
 
 
-int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length) {
+static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length) {
   struct pollfd fds[2] = { { .fd = monitor->fd, .events = POLLIN | POLLERR, .revents = 0 }, { .fd = monitor->sig[0], .events = POLLIN | POLLERR, .revents = 0 } };
   poll(fds, 2, -1);
   return read(monitor->fd, buffer, length);
 }
 
 
-int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length, int (*change_callback)(int, const char*, void*), void* data) {
+static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length, int (*change_callback)(int, const char*, void*), void* data) {
   for (struct inotify_event* info = (struct inotify_event*)buffer; (char*)info < buffer + length; info = (struct inotify_event*)((char*)info + sizeof(struct inotify_event)))
     change_callback(info->wd, NULL, data);
   return 0;
 }
 
 
-int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
+static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
   return inotify_add_watch(monitor->fd, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MODIFY | IN_MOVED_TO);
 }
 
 
-void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
+static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
   inotify_rm_watch(monitor->fd, fd);
 }
 
 
-int get_mode_dirmonitor() { return 2; }
+static int get_mode_dirmonitor() { return 2; }
+
+struct dirmonitor_backend dirmonitor_inotify = {
+  .name = "inotify",
+  .init = init_dirmonitor,
+  .deinit = deinit_dirmonitor,
+  .get_changes = get_changes_dirmonitor,
+  .translate_changes = translate_changes_dirmonitor,
+  .add = add_dirmonitor,
+  .remove = remove_dirmonitor,
+  .get_mode = get_mode_dirmonitor,
+};

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -1,12 +1,13 @@
 #include <windows.h>
 
+#include "dirmonitor.h"
 
 struct dirmonitor_internal {
   HANDLE handle;
 };
 
 
-int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
+static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
   HANDLE handle = monitor->handle;
   if (handle && handle != INVALID_HANDLE_VALUE) {
     DWORD bytes_transferred;
@@ -18,7 +19,7 @@ int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, in
 }
 
 
-struct dirmonitor* init_dirmonitor() {
+static struct dirmonitor* init_dirmonitor() {
   return calloc(1, sizeof(struct dirmonitor_internal));
 }
 
@@ -33,12 +34,12 @@ static void close_monitor_handle(struct dirmonitor_internal* monitor) {
 }
 
 
-void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
+static void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
   close_monitor_handle(monitor);
 }
 
 
-int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size, int (*change_callback)(int, const char*, void*), void* data) {
+static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size, int (*change_callback)(int, const char*, void*), void* data) {
   for (FILE_NOTIFY_INFORMATION* info = (FILE_NOTIFY_INFORMATION*)buffer; (char*)info < buffer + buffer_size; info = (FILE_NOTIFY_INFORMATION*)(((char*)info) + info->NextEntryOffset)) {
     char transform_buffer[MAX_PATH*4];
     int count = WideCharToMultiByte(CP_UTF8, 0, (WCHAR*)info->FileName, info->FileNameLength / 2, transform_buffer, MAX_PATH*4 - 1, NULL, NULL);
@@ -50,16 +51,27 @@ int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buff
 }
 
 
-int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
+static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
   close_monitor_handle(monitor);
   monitor->handle = CreateFileA(path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
   return !monitor->handle || monitor->handle == INVALID_HANDLE_VALUE ? -1 : 1;
 }
 
 
-void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
+static  void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
   close_monitor_handle(monitor);
 }
 
 
-int get_mode_dirmonitor() { return 1; }
+static int get_mode_dirmonitor() { return 1; }
+
+struct dirmonitor_backend dirmonitor_win32 = {
+  .name = "win32",
+  .init = init_dirmonitor,
+  .deinit = deinit_dirmonitor,
+  .get_changes = get_changes_dirmonitor,
+  .translate_changes = translate_changes_dirmonitor,
+  .add = add_dirmonitor,
+  .remove = remove_dirmonitor,
+  .get_mode = get_mode_dirmonitor,
+};

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 pragtical_sources = [
     'api/api.c',
+    'api/dirmonitor.c',
     'api/renderer.c',
     'api/renwindow.c',
     'api/regex.c',
@@ -17,49 +18,66 @@ pragtical_sources = [
     'main.c',
 ]
 
-pragtical_sources += 'api/dirmonitor.c'
-# dirmonitor backend
-if get_option('dirmonitor_backend') == ''
+dirmonitor_backends = get_option('dirmonitor_backends')
+
+if dirmonitor_backends.length() == 0
     if cc.has_function('inotify_init', prefix : '#include<sys/inotify.h>')
-        dirmonitor_backend = 'inotify'
-    elif host_machine.system() == 'darwin' and cc.check_header('CoreServices/CoreServices.h')
-        dirmonitor_backend = 'fsevents'
-    elif cc.has_function('kqueue', prefix : '#include<sys/event.h>')
+        dirmonitor_backends += 'inotify'
+    endif
+
+    if host_machine.system() == 'darwin' and cc.check_header('CoreServices/CoreServices.h')
+        dirmonitor_backends += 'fsevents'
+    endif
+
+    if cc.has_function('kqueue', prefix : '#include<sys/event.h>')
         dirmonitor_backend = 'kqueue'
-    elif cc.has_function('create_inode_watcher', prefix : '#include<fcntl.h>')
+    endif
+
+    if cc.has_function('create_inode_watcher', prefix : '#include<fcntl.h>')
         dirmonitor_backend = 'inodewatcher'
-    elif dependency('libkqueue', required : false).found()
+    endif
+
+    if dependency('libkqueue', required : false).found()
         dirmonitor_backend = 'kqueue'
-    elif host_machine.system() == 'windows'
+    endif
+
+    if host_machine.system() == 'windows'
         dirmonitor_backend = 'win32'
+    endif
+
+    dirmonitor_backends += 'dummy'
+endif
+
+foreach backend : dirmonitor_backends
+    if backend == 'inotify'
+        pragtical_sources += 'api' / 'dirmonitor' / 'inotify.c'
+        pragtical_cargs += '-DDIRMONITOR_INOTIFY'
+    elif backend == 'fsevents'
+        pragtical_sources += 'api' / 'dirmonitor' / 'fsevents.c'
+        pragtical_cargs += '-DDIRMONITOR_FSEVENTS'
+    elif backend == 'kqueue'
+        pragtical_sources += 'api' / 'dirmonitor' / 'kqueue.c'
+        libkqueue_dep = dependency('libkqueue', required : false)
+        if libkqueue_dep.found()
+            pragtical_deps += libkqueue_dep
+        endif
+        pragtical_cargs += '-DDIRMONITOR_KQUEUE'
+    elif backend == 'inodewatcher'
+        add_languages('cpp')
+        pragtical_sources += 'api' / 'dirmonitor' / 'inodewatcher.cpp'
+        pragtical_cargs += '-DDIRMONITOR_INODEWATCHER'
+    elif backend == 'win32'
+        pragtical_sources += 'api' / 'dirmonitor' / 'win32.c'
+        pragtical_cargs += '-DDIRMONITOR_WIN32'
+    elif backend == 'dummy'
+        pragtical_sources += 'api' / 'dirmonitor' / 'dummy.c'
+        pragtical_cargs += '-DDIRMONITOR_DUMMY'
     else
-        dirmonitor_backend = 'dummy'
-        warning('no suitable backend found, defaulting to dummy backend')
+        error('Unknown dirmonitor backend @0@'.format(backend))
     endif
-else
-    dirmonitor_backend = get_option('dirmonitor_backend')
-endif
+endforeach
 
-if dirmonitor_backend == 'inotify'
-    pragtical_sources += 'api/dirmonitor/inotify.c'
-elif dirmonitor_backend == 'fsevents'
-    pragtical_sources += 'api/dirmonitor/fsevents.c'
-elif dirmonitor_backend == 'kqueue'
-    pragtical_sources += 'api/dirmonitor/kqueue.c'
-    libkqueue_dep = dependency('libkqueue', required : false)
-    if libkqueue_dep.found()
-        pragtical_deps += libkqueue_dep
-    endif
-elif dirmonitor_backend == 'inodewatcher'
-    add_languages('cpp')
-    pragtical_sources += 'api/dirmonitor/inodewatcher.cpp'
-elif dirmonitor_backend == 'win32'
-    pragtical_sources += 'api/dirmonitor/win32.c'
-else
-    pragtical_sources += 'api/dirmonitor/dummy.c'
-endif
-
-message('dirmonitor_backend: @0@'.format(dirmonitor_backend))
+summary('dirmonitor backends', dirmonitor_backends)
 
 # luajit compatibility files
 if lua_compat_needed


### PR DESCRIPTION
Pragtical version of https://github.com/lite-xl/lite-xl/pull/1949

also adds a config value to select the dirmonitor backend and graceful dirwatch error handling incase the user set a bad value.