### PR TITLE
don't fuzzy items without a needle

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -252,6 +252,9 @@ local function compare_score(a, b)
 end
 
 local function fuzzy_match_items(items, needle, files)
+  if needle == "" then
+    return items
+  end
   local res = {}
   needle = (PLATFORM == "Windows" and files) and needle:gsub('/', PATHSEP) or needle
   for _, item in ipairs(items) do


### PR DESCRIPTION
if the needle is empty then there is nothing we have to match for
and by not reordering the items according to a fuzzy search we retain the benefits of 268bdec5128095c4c3a11b603bb17b05f5c8aca9 and the file list will have items ordered according to the folder structure.

Before:
![image](https://github.com/user-attachments/assets/648fd5b6-e59b-45ad-b67d-8f9bdd01b0aa)


After:
![image](https://github.com/user-attachments/assets/ec4176ba-7e06-4603-8a96-f5dcc5c6982e)
