### PR TITLE
Do not sort fuzzy results on empty needle

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -251,16 +251,27 @@ local function compare_score(a, b)
   return a.score > b.score
 end
 
+local function compare_text(a, b)
+  return a.text < b.text
+end
+
 local function fuzzy_match_items(items, needle, files)
   local res = {}
   needle = (PLATFORM == "Windows" and files) and needle:gsub('/', PATHSEP) or needle
   for _, item in ipairs(items) do
-    local score = system.fuzzy_match(tostring(item), needle, files)
+    local score = 0
+    if needle ~= "" then
+      score = system.fuzzy_match(tostring(item), needle, files)
+    end
     if score then
       table.insert(res, { text = item, score = score })
     end
   end
-  table.sort(res, compare_score)
+  if needle ~= "" then
+    table.sort(res, compare_score)
+  elseif not files then
+    table.sort(res, compare_text)
+  end
   for i, item in ipairs(res) do
     res[i] = item.text
   end


### PR DESCRIPTION
This is a continuation of #269 that returns the results on the expected table format while skipping sorting for files and sorting by names on non-files (which gives us a sorted commands palette).