### PR TITLE
Add REPL and run commands to the CLI

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -520,6 +520,29 @@ function core.init()
   -- Parse commandline arguments
   cli.parse(ARGS)
 
+  -- Update the files to open
+  if cli.last_command ~= "default" then
+    files = {}
+    system.chdir(core.init_working_dir)
+    for _, argument in ipairs(cli.unhandled_arguments) do
+      local arg_filename = strip_trailing_slash(argument)
+      local info = system.get_file_info(arg_filename) or {}
+      if info.type ~= "dir" then
+        local filename = common.normalize_path(arg_filename)
+        local abs_filename = system.absolute_path(filename or "")
+        local file_abs
+        if filename == abs_filename then
+          file_abs = abs_filename
+        else
+          file_abs = system.absolute_path(".") .. PATHSEP .. filename
+        end
+        if file_abs then
+          table.insert(files, file_abs)
+        end
+      end
+    end
+  end
+
   -- Maximizing the window makes it lose the hidden attribute on Windows
   -- so we delay this to keep window hidden until args parsed. Also, on
   -- Wayland we have issues applying the mode before showing the window

--- a/data/plugins/ipc.lua
+++ b/data/plugins/ipc.lua
@@ -5,6 +5,7 @@
 -- @license MIT
 --
 local core = require "core"
+local cli = require "core.cli"
 local config = require "core.config"
 local common = require "core.common"
 local command = require "core.command"
@@ -871,12 +872,16 @@ system.get_time = function()
     system.get_time = system_get_time
 
     local primary_instance = ipc:get_primary_instance()
-    if primary_instance and ARGS[2] then
+    if
+      primary_instance
+      and
+      cli.last_command == "default" and cli.unhandled_arguments[1]
+    then
       local open_directory = false
-      for i=2, #ARGS do
+      for i=1, #cli.unhandled_arguments do
         -- chdir to initial working directory to properly resolve absolute path
         system.chdir(core.init_working_dir)
-        local path = system.absolute_path(ARGS[i])
+        local path = system.absolute_path(cli.unhandled_arguments[i])
 
         if path then
           local path_info = system.get_file_info(path)
@@ -889,7 +894,7 @@ system.get_time = function()
               elseif config.plugins.ipc.dirs_instance == "change" then
                 ipc:call_async(primary_instance, "core.change_directory", nil, path)
               else
-                if #ARGS > 2 then
+                if #cli.unhandled_arguments > 1 then
                   system.exec(string.format("%q %q", EXEFILE, path))
                 else
                   open_directory = true


### PR DESCRIPTION
* New basic `repl` command useful to interactively execute Lua code with access to the Pragtical API. Supports single and multiple line expressions and includes some useful (maybe) built-in commands.
* New `run` command that allows executing Lua files or Lua code strings with access to the Pragtical API.
* Flags and commands list help output is now padded and wrapped.
* The current terminal columns width is detected for padding and wrapping.
* Now only treat as files the cli unhandled arguments.
* Support fetching value of single char flags when no spaces, eg: -Fvalue
* Support for insensitive true or false on boolean flags.
* Added new `edit` command to explicitly open a new editor instance by skipping the IPC system.
* Flags type and default value is now shown on help output.

### Preview

https://github.com/user-attachments/assets/085d16c3-8286-482e-8fbf-faa5716fbec2