### PR TITLE
Update SDL2 to latest fixes from master

### DIFF
--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,13 +1,11 @@
 [wrap-file]
-directory = SDL2-2.30.6
-source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-2.30.6.tar.gz
-source_filename = SDL2-2.30.6.tar.gz
-source_hash = c6ef64ca18a19d13df6eb22df9aff19fb0db65610a74cc81dae33a82235cacd4
-patch_filename = sdl2_2.30.6-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.30.6-2/get_patch
-patch_hash = aa9f6a4947b07510c2ea84fb457e965bebe5a5deeb9f5059fbcf10dfe6b76d1f
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.30.6-2/SDL2-2.30.6.tar.gz
-wrapdb_version = 2.30.6-2
+directory = SDL2-2.32.8
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.32.8/SDL2-2.32.8.tar.gz
+source_filename = SDL2-2.32.8.tar.gz
+source_hash = 0ca83e9c9b31e18288c7ec811108e58bac1f1bb5ec6577ad386830eac51c787e
+patch_filename = sdl2_2.32.8-1_patch.zip
+patch_url = https://github.com/pragtical/meson-wraps/releases/download/sdl2-v2.38.8/sdl2_2.32.8-1_patch.zip
+patch_hash = f09f4e4540ec2afc04fbee93ea773e3e333409403ead31ffc080cfff67cedeb6
 
 [provide]
 sdl2 = sdl2_dep


### PR DESCRIPTION
For this we ship our own patched copy of the wrapdb meson files with fixes for wayland and whatever else we catch on CI,