### PR TITLE
highlight_current_line "no_selection" now default

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -145,9 +145,9 @@ config.always_show_tabs = true
 
 ---Highlights the current line.
 ---
----The default is true.
+---The default is "no_selection".
 ---@type config.highlightlinetype
-config.highlight_current_line = true
+config.highlight_current_line = "no_selection"
 
 ---The spacing between each line of text.
 ---

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -609,7 +609,7 @@ settings.add("Editor",
       description = "Highlight the current line.",
       path = "highlight_current_line",
       type = settings.type.SELECTION,
-      default = true,
+      default = "no_selection",
       values = {
         {"Yes", true},
         {"No", false},


### PR DESCRIPTION
Changed the default value of config.highlight_current_line to "no_selection" which is a more sensible value for color schemes that may provide the same color for selections and highlighted lines.

Change inspired from #273