### PR TITLE
language_lua: add c syntax coloring to ffi.cdef

### DIFF
--- a/data/plugins/language_lua.lua
+++ b/data/plugins/language_lua.lua
@@ -306,6 +306,14 @@ syntax.add {
     { pattern = { "'", "'", '\\' },          type = "string" },
     { pattern = { "%[%[", "%]%]" },          type = "string" },
     { pattern = { "%[=", "=%]" },            type = "string" },
+    { pattern = { "ffi%.()cdef%s*()%[%[", "()()%]%]" },
+      type = { "normal", "function", "string" },
+      syntax = ".c"
+    },
+    { pattern = { "ffi%.()cdef%s*()%[%[", "()()%]%]" },
+      type = { "normal", "function", "string" },
+      syntax = ".c"
+    },
     { pattern = { "%-%-%[%[", "%]%]"},       type = "comment" },
     { pattern = "%-%-.-\n",                  type = "comment" },
     { pattern = "0x%x+%.%x*[pP][-+]?%d+",    type = "number" },


### PR DESCRIPTION
Supports the form ffi.cdef [[ code ]]

### Preview

![20250703-123411](https://github.com/user-attachments/assets/fa5a2c74-6499-4ac6-82f0-2bb133911b1c)
