### PR TITLE
draw_stats: fix usage of wrong numbers

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -12,12 +12,13 @@ local config = {}
 ---@type number
 config.fps = 60
 
----Draw the current FPS, the rendering speed in FPS possible and the maximum
----time that a coroutine has to run without affecting the rendering
----process plus the total amount of running coroutines.
+---Draw the current FPS, the average frame time, and the maximum time that
+---coroutines have to run per frame without affecting the rendering process
+---plus the total amount of running coroutines. If set to 'uncapped' the system
+---will draw at the maximum speed per second for benchmarking purposes.
 ---
 ---Defaults to false.
----@type boolean
+---@type boolean | "uncapped"
 config.draw_stats = false
 
 ---Maximum number of log items that will be stored.

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -710,12 +710,19 @@ settings.add("Development",
     },
     {
       label = "Draw Stats",
-      description = "Draw the current FPS, the rendering speed in FPS possible "
-        .. "and the maximum time that a coroutine has to run without affecting "
-        .. "the rendering process plus the total amount of running coroutines.",
+      description = "Draw the current FPS, the average frame time, and the "
+        .. "maximum time that coroutines have to run per frame without "
+        .. "affecting the rendering process plus the total amount of running "
+        .. "coroutines. If set to 'uncapped' the system will draw at the "
+        .. "maximum speed per second for benchmarking purposes.",
       path = "draw_stats",
-      type = settings.type.TOGGLE,
-      default = false
+      type = settings.type.SELECTION,
+      default = false,
+      values = {
+        {"Off", false},
+        {"On", true},
+        {"Uncapped", "uncapped"}
+      }
     }
   }
 )
@@ -2024,6 +2031,12 @@ function Settings:update()
   if self.about:is_visible() then
     self.about:update_positions()
   end
+end
+
+---Hide the widget when the node is removed.
+function Settings:try_close(do_close)
+  self.super.try_close(self, do_close)
+  self:hide()
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION

![20250704-153500](https://github.com/user-attachments/assets/31c6803a-56df-4989-8a87-6f82d3dbf210)

New "uncapped" option to config.draw_stats to render at maximum speed.

![20250704-155143](https://github.com/user-attachments/assets/bba00d1f-a826-46b4-a705-0b5e51954663)

Also, added frame capping/skipping on core.step():

Skip drawing if there is time left before next frame, unless, an event is received, benchmarking or core.redraw was enabled from update call. Skipping helps keep FPS near to the value set on config.fps when core.redraw is set from a coroutine and not by user interaction. Otherwise, rendering is prioritized on user events and config.fps not obeyed.