### PR TITLE
Limit FPS to match config.fps even during frequent events 

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -286,8 +286,8 @@ config.log_slow_threads = false
 ---less for system events when events are received. Disable this option to
 ---reduce CPU usage.
 ---
----Defaults to true.
-config.lower_input_latency = true
+---Defaults to false.
+config.lower_input_latency = false
 
 ---Increases the performance of the editor and its user.
 ---Do not change this unless you know what you are doing.

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -671,7 +671,7 @@ settings.add("Editor",
       description = "Reduce input latency by processing background tasks more aggressively, may use more CPU.",
       path = "lower_input_latency",
       type = settings.type.TOGGLE,
-      default = true
+      default = false
     }
   }
 )


### PR DESCRIPTION
Previously, a frame was drawn for every received event, causing the actual frame rate to exceed the configured cap (config.fps), especially under high event frequency.

Now, core.step() enforces the configured FPS limit more strictly, preventing unnecessary redraws and reducing CPU usage. This also improves the timing between frames, avoiding redundant draws when a frame was
just rendered.

Additionally, RootView:update was being triggered on every event, leading to excessive update calculations. Updates are now tied more closely to the frame rate rather than raw event frequency.

Finally, input latency should be reduced now by default without the previous cpu impact.

Expected result: reduced CPU usage and more consistent frame timing.