### PR TITLE
Handle incomplete token type

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -518,7 +518,7 @@ function DocView:draw_line_text(line, x, y)
   local _, indent_size = self.doc:get_indent_info()
   local start_tx = tx
   for tidx, type, text in self.doc.highlighter:each_token(line) do
-    local color = style.syntax[type]
+    local color = style.syntax[type] or style.syntax["normal"]
     local font = style.syntax_fonts[type] or default_font
     if font ~= default_font then font:set_tab_size(indent_size) end
     -- do not render newline, fixes issue #1164

--- a/data/core/jitsetup.lua
+++ b/data/core/jitsetup.lua
@@ -88,6 +88,11 @@ ffi.cdef [[
 
 renderer.draw_rect_lua = renderer.draw_rect
 function renderer.draw_rect(x, y, w, h, color, tab)
+  if not color then
+    local core = require "core"
+    core.error("renderer.draw_rect: color not provided")
+    color = {255, 255, 255, 255}
+  end
   ffi.C.rencache_draw_rect_ffi(
     ffi.C.ren_get_target_window_ffi(),
     x, y, w, h,
@@ -98,6 +103,11 @@ end
 renderer.draw_text_lua = renderer.draw_text
 local fonts_pointer_cache = setmetatable({}, { __mode = "k" })
 function renderer.draw_text(font, text, x, y, color, tab)
+  if not color then
+    local core = require "core"
+    core.error("renderer.draw_text: color not provided")
+    color = {255, 255, 255, 255}
+  end
   if not fonts_pointer_cache[font] then
     local fonts_list = font
     if type(font) ~= "table" then

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -480,7 +480,7 @@ function DocView:draw_line_text(line, x, y)
   local idx, _, count = get_line_idx_col_count(self, line)
   local total_offset = 1
   for _, type, text in self.doc.highlighter:each_token(line) do
-    local color = style.syntax[type]
+    local color = style.syntax[type] or style.syntax["normal"]
     local font = style.syntax_fonts[type] or default_font
     local token_offset = 1
     -- Split tokens if we're at the end of the document.


### PR DESCRIPTION
Fixes no valid color when the `incomplete` token type is returned by the tokeninzer.