### PR TITLE
settings ui: allow lowering line height to 0.8

### DIFF
--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -600,7 +600,7 @@ settings.add("Editor",
       path = "line_height",
       type = settings.type.NUMBER,
       default = 1.2,
-      min = 1.0,
+      min = 0.8,
       max = 3.0,
       step = 0.1
     },


### PR DESCRIPTION
Going below 0.8 doesn't seems to be of any gain, you can always overwrite the permitted value by selecting the whole value and manually entering your desired one.

Should fix #298