### PR TITLE
borderless: scale window hit test info

### DIFF
--- a/src/renwindow.h
+++ b/src/renwindow.h
@@ -1,6 +1,13 @@
 #include <SDL.h>
 #include "renderer.h"
 
+struct HitTestInfo {
+  int title_height;
+  int controls_width;
+  int resize_border;
+};
+typedef struct HitTestInfo HitTestInfo;
+
 struct RenWindow {
   SDL_Window *window;
   uint8_t *command_buf;
@@ -8,6 +15,7 @@ struct RenWindow {
   size_t command_buf_size;
   float scale_x;
   float scale_y;
+  HitTestInfo hit_test_info;
 #ifdef PRAGTICAL_USE_SDL_RENDERER
   SDL_Renderer *renderer;
   SDL_Texture *texture;


### PR DESCRIPTION
Since the hit test callback returns the mouse pointer in points we need to scale the given hit test information to prevent going beyond the correct boundaries.

Should fix #173