### PR TITLE
Only update active views and draw visible ones

### DIFF
--- a/data/core/nagview.lua
+++ b/data/core/nagview.lua
@@ -27,6 +27,7 @@ function NagView:new()
   self.target_height = 0
   self.on_mouse_pressed_root = nil
   self.dim_alpha = 0
+  self.visible = false
 end
 
 function NagView:get_title()
@@ -60,8 +61,6 @@ function NagView:get_scrollable_size()
   if self.visible and self:get_target_height() > h then
     self.size.y = h
     return self:get_target_height()
-  else
-    self.size.y = 0
   end
   return 0
 end
@@ -177,6 +176,7 @@ function NagView:update()
   NagView.super.update(self)
 
   if self.visible and core.active_view == self and self.title then
+    if self.size.y == 0 then self.size.y = 0.001 end
     local target_height = self:get_target_height()
     self:move_towards(self, "show_height", target_height, nil, "nagbar")
     self:move_towards(self, "underline_progress", 1, nil, "nagbar")
@@ -185,6 +185,7 @@ function NagView:update()
     self:move_towards(self, "show_height", 0, nil, "nagbar")
     self:move_towards(self, "dim_alpha", 0, nil, "nagbar")
     if self.show_height <= 0 then
+      self.size.y = 0
       self.title = nil
       self.message = nil
       self.options = nil

--- a/data/core/node.lua
+++ b/data/core/node.lua
@@ -510,9 +510,7 @@ end
 function Node:update()
   if self.type == "leaf" then
     self:scroll_tabs_to_visible()
-    for _, view in ipairs(self.views) do
-      view:update()
-    end
+    self.active_view:update()
     self:tab_hovered_update(core.root_view.mouse.x, core.root_view.mouse.y)
     local tab_width = self:target_tab_width()
     self:move_towards("tab_shift", tab_width * (self.tab_offset - 1), nil, "tabs")
@@ -622,9 +620,11 @@ function Node:draw()
       self:draw_tabs()
     end
     local pos, size = self.active_view.position, self.active_view.size
-    core.push_clip_rect(pos.x, pos.y, size.x, size.y)
-    self.active_view:draw()
-    core.pop_clip_rect()
+    if size.x > 0 and size.y > 0 then
+      core.push_clip_rect(pos.x, pos.y, size.x, size.y)
+      self.active_view:draw()
+      core.pop_clip_rect()
+    end
   else
     local x, y, w, h = self:get_divider_rect()
     renderer.draw_rect(x, y, w, h, style.divider)


### PR DESCRIPTION
When having a lot of documents or views open, with a lot of plugins installed that perform actions on each update() call, the editor starts to become slow.

This change should fix that by:

* Performing View:update() only on active views.
* Drawing only the views that are truly visible as in the width and height been more than zero.

This also adapts NagView to properly work with this change.