### PR TITLE
Search UI: also scroll horizontally

### DIFF
--- a/data/plugins/search_ui.lua
+++ b/data/plugins/search_ui.lua
@@ -408,7 +408,7 @@ local function find(reverse, not_scroll, unselect_first, no_wrap)
         doc:set_selection(line1, col1, line2, col2)
       end
       if not not_scroll then
-        doc_view:scroll_to_line(line1, true)
+        doc_view:scroll_to_make_visible(line1, col1)
       end
       Results:find(text, doc)
     end


### PR DESCRIPTION
When going to a search result the document scrolled to make the matching line visible but not to make the column visible.

This should fix that.