### PR TITLE
Configurable amount of context lines visible on scroll

### DIFF
--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -164,6 +164,13 @@ config.highlight_current_line = "no_selection"
 ---@type number
 config.line_height = 1.2
 
+---Minimum number of lines to keep visible above and below the cursor
+---when scrolling the document.
+---
+---The default is 10
+---@type integer
+config.scroll_context_lines = 10
+
 ---The number of spaces each level of indentation represents.
 ---
 ---The default is 2.

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -369,8 +369,13 @@ function DocView:scroll_to_make_visible(line, col)
   local _, ly = self:get_line_screen_position(line, col)
   local lh = self:get_line_height()
   local _, _, _, scroll_h = self.h_scrollbar:get_track_rect()
-  local overscroll = math.min(lh * 2, self.size.y) -- always show the previous / next line when possible
-  self.scroll.to.y = common.clamp(self.scroll.to.y, ly - oy - self.size.y + scroll_h + overscroll, ly - oy - lh)
+
+  local pad = (config.scroll_context_lines or 1)
+  local above = ly - oy - lh * pad
+  local below = ly - oy - self.size.y + scroll_h + lh * pad
+
+  self.scroll.to.y = common.clamp(self.scroll.to.y, below, above)
+
   local gw = self:get_gutter_width()
   local xoffset = self:get_col_x_offset(line, col)
   local xmargin = 3 * self:get_font():get_width(' ')
@@ -378,6 +383,7 @@ function DocView:scroll_to_make_visible(line, col)
   local xinf = xoffset - xmargin
   local _, _, scroll_w = self.v_scrollbar:get_track_rect()
   local size_x = math.max(0, self.size.x - scroll_w)
+
   if xsup > self.scroll.x + size_x then
     self.scroll.to.x = xsup - size_x
   elseif xinf < self.scroll.x then

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -606,6 +606,15 @@ settings.add("Editor",
       step = 0.1
     },
     {
+      label = "Context Lines",
+      description = "Minimum number of lines to keep visible above and below the cursor when scrolling the document.",
+      path = "scroll_context_lines",
+      type = settings.type.NUMBER,
+      default = 10,
+      min = 0,
+      step = 1
+    },
+    {
       label = "Highlight Line",
       description = "Highlight the current line.",
       path = "highlight_current_line",


### PR DESCRIPTION
As suggested by Amer, this adds a new config option that controls how much lines to keep visible above and below the cursor when performing certain scrolling operations (mainly cursor movement).

### Preview

https://github.com/user-attachments/assets/1ae403a5-c260-49c8-9915-c846f546eb5d