### PR TITLE
Add special highlight colors to search selections

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -246,6 +246,7 @@ local commands = {
       l1, c1 = dv.doc:get_selection_idx(1)
     end
     dv.doc:set_selection(l1, c1)
+    dv.doc:clear_search_selections()
   end,
 
   ["doc:cut"] = function()

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -43,6 +43,7 @@ end
 function Doc:reset()
   self.lines = { "\n" }
   self.selections = { 1, 1, 1, 1 }
+  self.search_selections = {}
   self.last_selection = 1
   self.undo_stack = { idx = 1 }
   self.redo_stack = { idx = 1 }
@@ -894,6 +895,24 @@ function Doc:get_non_word_chars(symbol)
   end
   return (current_syntax and current_syntax[non_word_chars])
     and current_syntax[non_word_chars] or config.non_word_chars
+end
+
+
+function Doc:add_search_selection(line1, col1, line2, col2)
+  line1, col1, line2, col2 = sort_positions(line1, col1, line2, col2)
+  local idx = string.format("%d:%d-%d:%d", line1, col1, line2, col2)
+  self.search_selections[idx] = true
+end
+
+function Doc:is_search_selection(line1, col1, line2, col2)
+  line1, col1, line2, col2 = sort_positions(line1, col1, line2, col2)
+  local idx = string.format("%d:%d-%d:%d", line1, col1, line2, col2)
+  if self.search_selections[idx] then return true end
+  return false
+end
+
+function Doc:clear_search_selections()
+  self.search_selections = {}
 end
 
 

--- a/data/core/doc/search.lua
+++ b/data/core/doc/search.lua
@@ -123,7 +123,9 @@ function search.find(doc, line, col, text, opt)
     until matches == true or not e or e < s or e >= line_len
     if s then
       if e >= s and (e ~= line_len or s ~= e) then
-        return line, s, line, e == line_len and e or e + 1
+        local col2 = e == line_len and e or e + 1
+        doc:add_search_selection(line, s, line, col2)
+        return line, s, line, col2
       end
     end
     col = opt.reverse and -1 or 1


### PR DESCRIPTION
As noted by Amer and me included, most color schemes provide a highlight selection color that is hard to spot when performing search operations or selections as in this command  `find-replace:select-add-all`.

For this reason this PR introduces the concept of a document search selections. These search selections will be colored different than a typical selection to make it more easy to identify. By default they will use as background color the style.caret and for the text the style.background. Two new style elements will be used if available:

* `style.search_selection` - background color of the selection
* `style.search_selection_text` - foreground (text) color of selection

When pressing the escape key (as with normal document selections) the search selections will be cleared out.

### Preview

https://github.com/user-attachments/assets/097a96b0-e80e-4664-ba17-09d1fe23d737
