### PR TITLE
doc:go-to-line: live syntax preview

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -576,6 +576,23 @@ local commands = {
           init_items()
           return common.fuzzy_match(items, text)
         end
+      end,
+      draw_text = function(item, font, color, x, y, w, h)
+        y = common.round(y + (h - font:get_height()) / 2)
+        local tx = x
+        local last_token = nil
+        local tokens = dv.doc.highlighter:get_line(item.line).tokens
+        local tokens_count = #tokens
+        if tokens_count > 0 and string.sub(tokens[tokens_count], -1) == "\n" then
+          last_token = tokens_count - 1
+        end
+        for tidx, type, text in dv.doc.highlighter:each_token(item.line) do
+          color = style.syntax[type] or style.syntax["normal"]
+          -- do not render newline, fixes issue #1164
+          if tidx == last_token then text = text:sub(1, -2) end
+          tx = renderer.draw_text(font, text, tx, y, color)
+          if tx > (x + w) - font:get_width(item.info) - style.padding.x * 2 then break end
+        end
       end
     })
   end,


### PR DESCRIPTION
As suggested by Amer, this PR implement live syntax preview when typing text on the doc:go-to-line command. This is done by introducing a `draw_text` flag to the CommandView that accepts a function to perform custom text drawing.

### Preview

https://github.com/user-attachments/assets/095801d2-3844-4f68-a882-fd3890558238