### PR TITLE
Add search highlight styles to pre-packaged themes

### DIFF
--- a/data/colors/default.lua
+++ b/data/colors/default.lua
@@ -5,7 +5,7 @@ style.background = { common.color "#2c2c2c" }  -- Docview
 style.background2 = { common.color "#222222" } -- Treeview
 style.background3 = { common.color "#222222" } -- Command view
 style.text = { common.color "#C0BFBC" }
-style.caret = { common.color "#3771c8" }
+style.caret = { common.color "#87aade" }
 style.accent = { common.color "#FCFCFC" }
 -- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
 -- search result, hotkeys for context menu and command view
@@ -27,6 +27,9 @@ style.good = { common.color "#47D35C" }
 style.warn = { common.color "#FAA82F" }
 style.error = { common.color "#c7162b" }
 style.modified = { common.color "#19B6EE" }
+
+style.search_selection = { common.color "#6a5acd" }
+style.search_selection_text = { common.color "#ffffff" }
 
 style.syntax["normal"] = { common.color "#C0BFBC" }
 style.syntax["symbol"] = { common.color "#B0AFAC" }

--- a/data/colors/fall.lua
+++ b/data/colors/fall.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#383637" }
 style.scrollbar = { common.color "#454344" }
 style.scrollbar2 = { common.color "#524F50" }
 
+style.search_selection = { common.color "#827d80" }
+style.search_selection_text = { common.color "#ffffff" }
+
 style.syntax["normal"] = { common.color "#efdab9" }
 style.syntax["symbol"] = { common.color "#efdab9" }
 style.syntax["comment"] = { common.color "#615d5f" }

--- a/data/colors/lite.lua
+++ b/data/colors/lite.lua
@@ -28,6 +28,9 @@ style.warn = { common.color "#FFA94D" }
 style.error = { common.color "#FF3333" }
 style.modified = { common.color "#1c7c9c" }
 
+style.search_selection = { common.color "#6a5acd" }
+style.search_selection_text = { common.color "#ffffff" }
+
 style.syntax["normal"] = { common.color "#e1e1e6" }
 style.syntax["symbol"] = { common.color "#e1e1e6" }
 style.syntax["comment"] = { common.color "#676b6f" }

--- a/data/colors/summer.lua
+++ b/data/colors/summer.lua
@@ -16,6 +16,9 @@ style.line_highlight = { common.color "#f2f2f2" }
 style.scrollbar = { common.color "#e0e0e0" }
 style.scrollbar2 = { common.color "#c0c0c0" }
 
+style.search_selection = { common.color "#f0bb28" }
+style.search_selection_text = { common.color "#333333" }
+
 style.syntax["normal"] = { common.color "#181818" }
 style.syntax["symbol"] = { common.color "#181818" }
 style.syntax["comment"] = { common.color "#22a21f" }

--- a/data/colors/textadept.lua
+++ b/data/colors/textadept.lua
@@ -25,6 +25,10 @@ style.scrollbar2          =     { common.color(b60) }
 style.nagbar              =     { common.color(red) }
 style.nagbar_text         =     { common.color(b00) }
 style.nagbar_dim          =     { common.color(b05) }
+
+style.search_selection = { common.color "#e6b800" }
+style.search_selection_text = { common.color "#4d3d00" }
+
 --------------------------=--------------------------
 style.syntax              =                        {}
 style.syntax['normal']    =     { common.color(b80) }


### PR DESCRIPTION
This updates the pre-packaged color themes with the new `style.search_selection` and `style.search_selection_text` parameters.

@jgmdev feel free to modify my color selections. Also, I made the caret a little more visible in the `default` theme.