### PR TITLE
Add built-in config to toggle line numbers

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -43,6 +43,10 @@ command.add(nil, {
     config.hide_tabs = not config.hide_tabs
   end,
 
+  ["core:toggle-line-numbers"] = function()
+    config.show_line_numbers = not config.show_line_numbers
+  end,
+
   ["core:toggle-fullscreen"] = function()
     local current_mode = system.get_window_mode(core.window)
     local fullscreen = current_mode == "fullscreen"

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -171,6 +171,12 @@ config.line_height = 1.2
 ---@type integer
 config.scroll_context_lines = 10
 
+---Show or hide the line numbers.
+---
+---The default is true
+---@type boolean
+config.show_line_numbers = true
+
 ---The number of spaces each level of indentation represents.
 ---
 ---The default is 2.

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -145,7 +145,10 @@ end
 
 function DocView:get_gutter_width()
   local padding = style.padding.x * 2
-  return self:get_font():get_width(#self.doc.lines) + padding, padding
+  if config.show_line_numbers then
+    return self:get_font():get_width(#self.doc.lines) + padding, padding
+  end
+  return style.padding.x, padding
 end
 
 
@@ -698,16 +701,18 @@ end
 
 
 function DocView:draw_line_gutter(line, x, y, width)
-  local color = style.line_number
-  for _, line1, _, line2 in self.doc:get_selections(true) do
-    if line >= line1 and line <= line2 then
-      color = style.line_number2
-      break
-    end
-  end
-  x = x + style.padding.x
   local lh = self:get_line_height()
-  common.draw_text(self:get_font(), color, line, "right", x, y, width, lh)
+  if config.show_line_numbers then
+    local color = style.line_number
+    for _, line1, _, line2 in self.doc:get_selections(true) do
+      if line >= line1 and line <= line2 then
+        color = style.line_number2
+        break
+      end
+    end
+    x = x + style.padding.x
+    common.draw_text(self:get_font(), color, line, "right", x, y, width, lh)
+  end
   return lh
 end
 

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -615,6 +615,13 @@ settings.add("Editor",
       step = 1
     },
     {
+      label = "Show Line Numbers",
+      description = "Show or hide a document line numbers.",
+      path = "show_line_numbers",
+      type = settings.type.TOGGLE,
+      default = true,
+    },
+    {
       label = "Highlight Line",
       description = "Highlight the current line.",
       path = "highlight_current_line",


### PR DESCRIPTION
Also adds a matching `core:toggle-line-numbers` command, and a graphical toggle on the settings interface,