### PR TITLE
Add common.open_in_system(resource) function

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -869,4 +869,69 @@ function common.rm(path, recursively)
 end
 
 
+---Open the given resource using the system launcher.
+---The resource can be an url, file or directory in most cases...
+---@param resource string
+---@return boolean success
+function common.open_in_system(resource)
+  -- Detect platforms
+  local function detect_platform()
+    if PLATFORM:lower():find("unknown", 1, true) then
+      -- AmigaOS: ENV: is a system assign
+      local f = io.open("ENV:", "r")
+      if f then f:close() return "amiga" end
+      -- Try uname
+      local uname = process.start({"uname", "-s"})
+      if uname then
+        uname:wait(1000)
+        return uname:read_stdout(128):lower()
+      end
+      return "unknown"
+    end
+    return PLATFORM:lower()
+  end
+
+  local function is_url(str)
+    return str:match("^[a-z]+://")
+  end
+
+  local launcher
+  local platform = detect_platform()
+
+  if platform:find("windows", 1, true) then
+    launcher = 'start ""'
+  elseif
+    platform:find("mac", 1, true)
+    or platform:find("haiku", 1, true)
+    or platform:find("serenity", 1, true)
+  then
+    launcher = "open"
+  elseif
+    platform:find("amiga", 1, true)
+    or platform:find("morph", 1, true)
+    or platform:find("aros", 1, true)
+  then
+    if is_url(resource) then
+      launcher = "OpenURL"
+    else
+      local rtype = system.get_file_info(resource)
+      if rtype and rtype.type == "file" then
+        launcher = "Multiview"
+      else
+        launcher = "WBRun"
+      end
+    end
+  else
+    launcher = "xdg-open"
+  end
+
+  if launcher then
+    system.exec(string.format('%s %q', launcher, resource))
+    return true
+  end
+
+  return false
+end
+
+
 return common

--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -49,21 +49,6 @@ local buttons = {
   }
 }
 
----Opens web link using the current operating system launcher if possible.
----TODO: We should provide a core function for doing this which command is configurable
----@param link string
-local function open_link(link)
-  local launcher_command
-  if PLATFORM == "Windows" then
-    launcher_command = "start"
-  elseif PLATFORM == "Mac OS X" then
-    launcher_command = "open"
-  else
-    launcher_command = "xdg-open"
-  end
-  system.exec(launcher_command .. " " .. link)
-end
-
 ---Constructor
 function EmptyView:new()
   EmptyView.super.new(self, nil, false)
@@ -110,14 +95,14 @@ function EmptyView:new()
   self.website:set_icon("G")
   self.website:set_tooltip("Visit the editor website")
   self.website.on_click = function(_, pressed)
-    open_link("https://pragtical.dev")
+    common.open_in_system("https://pragtical.dev")
   end
 
   self.docs = Button(self.center_container, "Documentation")
   self.docs:set_icon("?")
   self.docs:set_tooltip("Visit the editor documentation")
   self.docs.on_click = function(_, pressed)
-    open_link("https://pragtical.dev/docs/intro")
+    common.open_in_system("https://pragtical.dev/docs/intro")
   end
 
   self.first_draw = true

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -1911,23 +1911,11 @@ function Settings:setup_about()
     true
   )
 
-  local function open_link(link)
-    local platform_filelauncher
-    if PLATFORM == "Windows" then
-      platform_filelauncher = "start"
-    elseif PLATFORM == "Mac OS X" then
-      platform_filelauncher = "open"
-    else
-      platform_filelauncher = "xdg-open"
-    end
-    system.exec(platform_filelauncher .. " " .. link)
-  end
-
   ---@type widget.button
   local button = Button(self.about, "Visit Website")
   button:set_icon("G")
   button:set_tooltip("Open https://pragtical.dev/")
-  function button:on_click() open_link("https://pragtical.dev/") end
+  function button:on_click() common.open_in_system("https://pragtical.dev/") end
 
   ---@type widget.listbox
   local contributors = ListBox(self.about)
@@ -1935,7 +1923,7 @@ function Settings:setup_about()
   contributors:add_column("Contributors")
   contributors:add_column("")
   contributors:add_column("Website")
-  function contributors:on_row_click(_, data) open_link(data) end
+  function contributors:on_row_click(_, data) common.open_in_system(data) end
 
 local contributors_list = {
   { "Rxi", "Lite Founder", "https://github.com/rxi" },

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -965,13 +965,7 @@ command.add(
   end,
 
   ["treeview:open-in-system"] = function(item)
-    if PLATFORM == "Windows" then
-      system.exec(string.format("start \"\" %q", item.abs_filename))
-    elseif string.find(PLATFORM, "Mac") then
-      system.exec(string.format("open %q", item.abs_filename))
-    elseif PLATFORM == "Linux" or string.find(PLATFORM, "BSD") then
-      system.exec(string.format("xdg-open %q", item.abs_filename))
-    end
+    common.open_in_system(item.abs_filename)
   end
 })
 


### PR DESCRIPTION
This functionality was fragmented thru the source code as in EmptyView, Settings and TreeView providing their own code to open links, files and directories using the system launcher.

Also various plugins on the plugins repo provide their own way. With this PR they can be adapted to use this function instead of duplicating the functionality.

Besides providing a built-in mechanism of opening resources with the operating system launcher, it also adds supports for other operating systems:

* Amiga
* Haiku
* SerenityOS

Also the function should provide a central location for supporting other systems if the need arises.