### PR TITLE
Improve contrast for default themes

### DIFF
--- a/data/colors/fall.lua
+++ b/data/colors/fall.lua
@@ -10,13 +10,13 @@ style.accent = { common.color "#ffd152" }
 style.dim = { common.color "#615d5f" }
 style.divider = { common.color "#242223" }
 style.selection = { common.color "#454244" }
-style.line_number = { common.color "#454244" }
-style.line_number2 = { common.color "#615d5f" }
+style.line_number = { common.color "#575356" }
+style.line_number2 = { common.color "#857F81" }
 style.line_highlight = { common.color "#383637" }
 style.scrollbar = { common.color "#454344" }
 style.scrollbar2 = { common.color "#524F50" }
 
-style.search_selection = { common.color "#827d80" }
+style.search_selection = { common.color "#6a5acd" }
 style.search_selection_text = { common.color "#ffffff" }
 
 style.syntax["normal"] = { common.color "#efdab9" }

--- a/data/colors/lite.lua
+++ b/data/colors/lite.lua
@@ -4,12 +4,12 @@ local common = require "core.common"
 style.background = { common.color "#2e2e32" }  -- Docview
 style.background2 = { common.color "#252529" } -- Treeview
 style.background3 = { common.color "#252529" } -- Command view
-style.text = { common.color "#97979c" }
+style.text = { common.color "#ADADB3" }
 style.caret = { common.color "#93DDFA" }
 style.accent = { common.color "#e1e1e6" }
 -- style.dim - text color for nonactive tabs, tabs divider, prefix in log and
 -- search result, hotkeys for context menu and command view
-style.dim = { common.color "#525257" }
+style.dim = { common.color "#636369" }
 style.divider = { common.color "#202024" } -- Line between nodes
 style.selection = { common.color "#48484f" }
 style.line_number = { common.color "#525259" }

--- a/data/colors/summer.lua
+++ b/data/colors/summer.lua
@@ -3,7 +3,7 @@ local common = require "core.common"
 
 style.background = { common.color "#fbfbfb" }
 style.background2 = { common.color "#f2f2f2" }
-style.background3 = { common.color "#f2f2f2" }
+style.background3 = { common.color "#F5F5F5" }
 style.text = { common.color "#404040" }
 style.caret = { common.color "#fc1785" }
 style.accent = { common.color "#fc1785" }
@@ -12,12 +12,12 @@ style.divider = { common.color "#e8e8e8" }
 style.selection = { common.color "#b7dce8" }
 style.line_number = { common.color "#d0d0d0" }
 style.line_number2 = { common.color "#808080" }
-style.line_highlight = { common.color "#f2f2f2" }
+style.line_highlight = { common.color "#EAEAEA" }
 style.scrollbar = { common.color "#e0e0e0" }
 style.scrollbar2 = { common.color "#c0c0c0" }
 
-style.search_selection = { common.color "#f0bb28" }
-style.search_selection_text = { common.color "#333333" }
+style.search_selection = { common.color "#3B6DD9" }
+style.search_selection_text = { common.color "#ffffff" }
 
 style.syntax["normal"] = { common.color "#181818" }
 style.syntax["symbol"] = { common.color "#181818" }

--- a/data/colors/textadept.lua
+++ b/data/colors/textadept.lua
@@ -1,8 +1,8 @@
 local b05 = 'rgba(0,0,0,0.5)'   local red = '#994D4D'
 local b80 = '#333333'       local orange  = '#B3661A'
-local b60 = '#808080'       local green   = '#52994D'
+local b60 = '#525252'       local green   = '#52994D'
 local b40 = '#ADADAD'       local teal    = '#4D9999'
-local b20 = '#CECECE'       local blue    = '#1A66B3'
+local b20 = '#EDEDED'       local blue    = '#1A66B3'
 local b00 = '#E6E6E6'       local magenta = '#994D99'
 --------------------------=--------------------------
 local style               =     require  'core.style'
@@ -11,11 +11,11 @@ local common              =     require 'core.common'
 style.line_highlight      =     { common.color(b20) }
 style.background          =     { common.color(b00) }
 style.background2         =     { common.color(b20) }
-style.background3         =     { common.color(b20) }
-style.text                =     { common.color(b60) }
+style.background3         =     { common.color(b00) }
+style.text                =     { common.color(b80) }
 style.caret               =     { common.color(b80) }
 style.accent              =     { common.color(b80) }
-style.dim                 =     { common.color(b60) }
+style.dim                 =     { common.color(b40) }
 style.divider             =     { common.color(b40) }
 style.selection           =     { common.color(b40) }
 style.line_number         =     { common.color(b60) }
@@ -26,8 +26,8 @@ style.nagbar              =     { common.color(red) }
 style.nagbar_text         =     { common.color(b00) }
 style.nagbar_dim          =     { common.color(b05) }
 
-style.search_selection = { common.color "#e6b800" }
-style.search_selection_text = { common.color "#4d3d00" }
+style.search_selection = { common.color "#6a5acd" }
+style.search_selection_text = { common.color "#ffffff" }
 
 --------------------------=--------------------------
 style.syntax              =                        {}


### PR DESCRIPTION
Some improvements for the default themes for consistency with https://github.com/pragtical/colors/pull/5.

More consistent `search_selection` and `search_selection_text` colors + a few changes for better contrast.