### PR TITLE
Reset previous project module settings on change

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -210,7 +210,12 @@ command.add(nil, {
         end
         if abs_path == core.root_project().path then return end
         core.confirm_close_docs(core.docs, function(dirpath)
+          local project_module_loaded = core.project_module_loaded
+          core.project_module_loaded = nil
           core.open_project(dirpath)
+          if project_module_loaded then
+            command.perform "core:restart"
+          end
         end, abs_path)
       end,
       suggest = suggest_directory

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -832,6 +832,7 @@ function core.load_project_module()
       local fn, err = loadfile(filename)
       if not fn then error("Error when loading project module:\n\t" .. err) end
       fn()
+      core.project_module_loaded = true
       core.log_quiet("Loaded project module")
     end)
   end


### PR DESCRIPTION
With this change a core:restart is performed when the main project is changed and the previous project had a custom project module loaded.

Fixes #328