### PR TITLE
Add config option for insensitive next word selection

### DIFF
--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -170,7 +170,10 @@ local function select_add_next(all)
     end
     local text = doc():get_text(l1, c1, l2, c2)
     repeat
-      l1, c1, l2, c2 = search.find(doc(), l2, c2, text, { wrap = true })
+      l1, c1, l2, c2 = search.find(
+        doc(), l2, c2, text,
+        { wrap = true, no_case = config.select_add_next_no_case }
+      )
       if l1 == il1 and c1 == ic1 then break end
       if l2 and not is_in_any_selection(l2, c2) then
         doc():add_selection(l2, c2, l1, c1)

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -158,6 +158,12 @@ config.always_show_tabs = true
 ---@type config.highlightlinetype
 config.highlight_current_line = "no_selection"
 
+---Perform case insensitive next word selection.
+---
+---The default is false.
+---@type boolean
+config.select_add_next_no_case = false
+
 ---The spacing between each line of text.
 ---
 ---The default is 120% of the height of the text (1.2).

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -638,6 +638,13 @@ settings.add("Editor",
       end
     },
     {
+      label = "Case Insensitive Word Selection",
+      description = "Perform case insensitive next word selection.",
+      path = "select_add_next_no_case",
+      type = settings.type.TOGGLE,
+      default = false
+    },
+    {
       label = "Maximum Undo History",
       description = "The amount of undo elements to keep.",
       path = "max_undos",


### PR DESCRIPTION
As requested by Amer, this PR adds the ability to perform case insensitive next word selection on some find/replace commands.

New config flag:

```lua
---Perform case insensitive next word selection.
---
---The default is false.
---@type boolean
config.select_add_next_no_case = false
```

Applicable commands:

* find-replace:select-add-next
* find-replace:select-add-all

### Preview

https://github.com/user-attachments/assets/12870d5c-105a-4e82-a3c1-6937a3b0fd8a
