### PR TITLE
python: fix vars and params type hinting matching

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -142,7 +142,7 @@ local python_func = {
       type = "operator",
       syntax = python_type
     },
-    { pattern = { ":%s*", "%f[^%[%]%w_]" }, syntax = python_type },
+    { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, syntax = python_type },
 
   }, python_patterns),
 
@@ -212,11 +212,20 @@ syntax.add {
       type = { "keyword", "keyword2", "normal" }
     },
 
+    -- single quote forward type declarations eg: variable_name: 'type1 | type2'
     { pattern = { ":()%s*'", "()'" },
       type = { "normal", "string" },
       syntax = python_type
     },
-    { pattern = { ":%s*", "%f[^%[%]%w_]" }, syntax = python_type },
+
+    -- double quote forward type declarations eg: variable_name: "type1 | type2"
+    { pattern = { ':()%s*"', '()"' },
+      type = { "normal", "string" },
+      syntax = python_type
+    },
+
+    -- type declarations eg: variable_name: type1 | type2
+    { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, syntax = python_type },
 
   }, python_patterns),
 

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -142,6 +142,14 @@ local python_func = {
       type = "operator",
       syntax = python_type
     },
+    { pattern = { ":()%s*'", "()'" },
+      type = { "normal", "string" },
+      syntax = python_type
+    },
+    { pattern = { ':()%s*"', '()"' },
+      type = { "normal", "string" },
+      syntax = python_type
+    },
     { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, syntax = python_type },
 
   }, python_patterns),

--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -67,12 +67,12 @@ local python_fstring = {
 local python_patterns = {
   { pattern = "#.*", type = "comment" },
 
-  { pattern = '[uUrR]%f["]', type = "keyword" },
+  { pattern = '[uUrR]%f["\']', type = "keyword" },
 
-  { pattern = { '[ruU]?"""', '"""', '\\' }, type = "string" },
-  { pattern = { "[ruU]?'''", "'''", '\\' }, type = "string" },
-  { pattern = { '[ruU]?"', '"', '\\' }, type = "string" },
-  { pattern = { "[ruU]?'", "'", '\\' }, type = "string" },
+  { pattern = { '"""', '"""', '\\' }, type = "string" },
+  { pattern = { "'''", "'''", '\\' }, type = "string" },
+  { pattern = { '"', '"', '\\' }, type = "string" },
+  { pattern = { "'", "'", '\\' }, type = "string" },
 
   { pattern = { 'f"', '"', "\\" },
     type = "string", syntax = python_fstring


### PR DESCRIPTION
As reported by Amer the type declarations were incorrectly matching outside of the valid expression, this should fix:

```python
def somefunc(param1: int | None, param2: list[int], param3: tuple[int, string]):
    '''some function that does something'''
    var_name: 'int | string'
    var_name: "int | string"
    var_name: int | string
    with open('file', 'r') as file:
        # open file in read mode
        content = file.read()
```
### Other Changes

* Support forward declarations also on function params
* Match [rRuU] as function also on single quotes

Depends on #339