### PR TITLE
DiffView: always account for gaps on scrolling

### DIFF
--- a/data/plugins/diffview.lua
+++ b/data/plugins/diffview.lua
@@ -544,7 +544,10 @@ function DiffView:on_touch_moved(...)
 end
 
 function DiffView:get_scrollable_size()
-  local lc = math.max(#self.doc_view_a.doc.lines, #self.doc_view_b.doc.lines)
+  local a_lines, b_lines = #self.doc_view_a.doc.lines, #self.doc_view_b.doc.lines
+  local a_gaps = (self.a_gaps[a_lines] and self.a_gaps[a_lines][2] or 0)
+  local b_gaps = (self.b_gaps[b_lines] and self.b_gaps[b_lines][2] or 0)
+  local lc = math.max(a_lines + a_gaps, b_lines + b_gaps)
   if not config.scroll_past_end then
     local _, _, _, h_scroll = self.h_scrollbar:get_track_rect()
     return self.doc_view_a:get_line_height() * (lc) + style.padding.y * 2 + h_scroll
@@ -761,11 +764,12 @@ function DiffView:patch_views()
     doc_view.get_scrollable_size = function(self)
       local gaps = is_a and parent.a_gaps or parent.b_gaps
       local lc = #self.doc.lines
+      lc = lc + (gaps[lc] and gaps[lc][2] or 0)
       if not config.scroll_past_end then
         local _, _, _, h_scroll = self.h_scrollbar:get_track_rect()
         return self:get_line_height() * (lc) + style.padding.y * 2 + h_scroll
       end
-      return self:get_line_height() * ((lc + (gaps[lc] and gaps[lc][2] or 0)) - 1) + self.size.y
+      return self:get_line_height() * (lc - 1) + self.size.y
     end
   end
 


### PR DESCRIPTION
As reported by @bananakid https://github.com/pragtical/pragtical/pull/306#issuecomment-3253552218 scrolling wasn't working correctly. This was caused because in some cases we were not properly accounting for side a and b gaps. This PR fixes the issue by:

* Always adding the amount of gaps when scrolling one of the sides even if config.scroll_past_end is off.
* Properly calculate the longest side by taking into consideration the gaps when scrolling the parent DiffView.