### PR TITLE
meson: update freetype2 subproject to v2.14.1-1

### DIFF
--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,11 +1,10 @@
 [wrap-file]
-directory = freetype-2.13.3
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.13.3-1/freetype-2.13.3.tar.xz
-source_filename = freetype-2.13.3.tar.xz
-source_hash = 0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
-wrapdb_version = 2.13.3-1
+directory = freetype-2.14.1
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/freetype2_2.14.1-1/freetype-2.14.1.tar.xz
+source_filename = freetype-2.14.1.tar.xz
+source_hash = 32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc
+wrapdb_version = 2.14.1-1
 
 [provide]
-freetype2 = freetype_dep
-freetype = freetype_dep
+dependency_names = freetype2


### PR DESCRIPTION
Fixes unnecessary linking to libbz2