### PR TITLE
treeview: fix a scale re-trigger issue

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -1051,10 +1051,12 @@ config.plugins.treeview.config_spec = {
     description = "Default treeview width.",
     path = "size",
     type = "number",
-    default = toolbar_view and math.ceil(toolbar_view:get_min_width() / SCALE)
-      or 200 * SCALE,
-    min = toolbar_view and toolbar_view:get_min_width() / SCALE
-      or 200 * SCALE,
+    default = toolbar_view
+      and math.ceil(toolbar_view:get_min_width() / SCALE)
+      or 200,
+    min = toolbar_view
+      and math.ceil(toolbar_view:get_min_width() / SCALE)
+      or 200,
     get_value = function(value)
       return value / SCALE
     end,
@@ -1062,6 +1064,8 @@ config.plugins.treeview.config_spec = {
       return value * SCALE
     end,
     on_apply = function(value)
+      -- prevent on_scale_change if applied on non default scale
+      if view.current_scale ~= SCALE then view.current_scale = SCALE end
       view:set_target_size("x", math.max(
         value, toolbar_view and toolbar_view:get_min_width() or 200 * SCALE
       ))


### PR DESCRIPTION
Previously, the on_scale_change event was introduced to properly scale the treeview on dynamic scale changes, but the size config on_apply was applying the user defined value already scaled which was causing on_scale_change to enlarge the treeview even more.

This PR fixes that behaviour and always uses unscaled size on the default and minimum values of the settings config.