### PR TITLE
system: Add heap memory trimmer function

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1732,6 +1732,7 @@ function collectgarbage(opt, ...)
   else
     ret = collectgarbage_lua(opt, ...)
   end
+  system.mem_trim()
   return ret
 end
 

--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -391,4 +391,12 @@ function system.path_compare(path1, type1, path2, type2) end
 ---@return boolean ok True if call succeeded
 function system.setenv(key, val) end
 
+---
+---Trims unused heap memory back to the system.
+---On Linux (glibc) calls `malloc_trim(0)`.
+---On macOS calls `malloc_zone_pressure_relief(NULL, 0)`.
+---On Windows calls `HeapCompact()`.
+---No effect on platforms that do not support heap trimming.
+function system.mem_trim() end
+
 return system


### PR DESCRIPTION
Trim heap allocated memory on each collectgarbage call. This is specially useful on Linux where the allocated memory can sometimes takes a long time to be returned into the system resulting on high amounts of ram been reported on system monitor applications.