### PR TITLE
Fix contextmenu triggered on window manager resize

### DIFF
--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -219,6 +219,12 @@ end
 function ContextMenu:on_mouse_pressed(button, px, py, clicks)
   local caught = false
 
+  -- Don't trigger context menu if modkey pressed
+  -- this prevents issues with global hotkeys like Alt+Right, etc...
+  for _, pressed in pairs(keymap.modkeys) do
+    if pressed then return caught end
+  end
+
   if self.show_context_menu then
     local selected
     if button == "left" then


### PR DESCRIPTION
Prevents the issue by ensuring that no mod keys are set when listening for the on_mouse_pressed right click.

Fixes #355, thanks to M4he for reporting!