### PR TITLE
Add option to show repainted areas

### DIFF
--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -747,6 +747,18 @@ settings.add("Development",
         {"On", true},
         {"Uncapped", "uncapped"}
       }
+    },
+    {
+      label = "Draw Repainted Areas",
+      description = "Toggles drawing debugging rectangles on the currently "
+        .. "rendered sections of the window to help troubleshoot the "
+        .. "renderer.",
+      path = "draw_repaint",
+      type = settings.type.TOGGLE,
+      default = false,
+      on_apply = function(value)
+        renderer.show_debug(value)
+      end
     }
   }
 )


### PR DESCRIPTION
This PR adds a development settings gui flag to allow toggling the drawing of debugging rectangles with `renderer.show_debug(enable)`

<img width="978" height="80" alt="20251123-212121" src="https://github.com/user-attachments/assets/a06df9d5-51a2-4057-83e0-7228b23bd3c1" />
