### PR TITLE
Round draw_text x and y coords

### DIFF
--- a/src/rencache.c
+++ b/src/rencache.c
@@ -195,6 +195,7 @@ void rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color
 
 double rencache_draw_text(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, double y, RenColor color, RenTab tab)
 {
+  x = SDL_round(x); y = SDL_round(y);
   int x_offset;
   double width = ren_font_group_get_width(fonts, text, len, tab, &x_offset);
   RenRect rect = { x + x_offset, y, (int)(width - x_offset), ren_font_group_get_height(fonts) };


### PR DESCRIPTION
This fixes jumpy text positioning caused by the extra decimal points.

Before:

https://github.com/user-attachments/assets/61f077ae-b7cd-4036-b8f1-e0eae803ae19

After:

https://github.com/user-attachments/assets/bed0d94f-fe6a-495a-8d01-c392f77407e5