### PR TITLE
Scale initialization fixes

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1,6 +1,6 @@
 require "core.strict"
 local common = require "core.common"
-local config = require "core.config"
+local config
 local style
 local cli
 local scale
@@ -374,9 +374,6 @@ end
 
 
 function core.init()
-  core.log_items = {}
-  core.log_quiet("Pragtical version %s - mod-version %s", VERSION, MOD_VERSION_STRING)
-
   core.window = renwindow._restore()
   if core.window == nil then
     core.window = renwindow.create("")
@@ -385,6 +382,13 @@ function core.init()
   DEFAULT_FPS = core.window:get_refresh_rate() or DEFAULT_FPS
   DEFAULT_SCALE = system.get_scale(core.window)
   SCALE = tonumber(os.getenv("PRAGTICAL_SCALE")) or DEFAULT_SCALE
+
+  -- load config after scale detection for flags that depend on it
+  config = require "core.config"
+
+  -- log functions depend on config so initialize after loading config
+  core.log_items = {}
+  core.log_quiet("Pragtical version %s - mod-version %s", VERSION, MOD_VERSION_STRING)
 
   style = require "colors.default"
   cli = require "core.cli"

--- a/data/core/process.lua
+++ b/data/core/process.lua
@@ -1,4 +1,4 @@
-local config = require "core.config"
+local config
 
 
 ---An abstraction over the standard input and outputs of a process
@@ -161,6 +161,8 @@ end
 
 local old_start = process.start
 function process.start(command, options)
+  -- delay config load since some values depend on system scale
+  if not config then config = require "core.config" end
   assert(type(command) == "table" or type(command) == "string", "invalid argument #1 to process.start(), expected string or table, got "..type(command))
   assert(type(options) == "table" or type(options) == "nil", "invalid argument #2 to process.start(), expected table or nil, got "..type(options))
   if PLATFORM == "Windows" then

--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -55,14 +55,18 @@ function scale.set(scale)
 
   SCALE = scale
 
-  style.padding.x               = style.padding.x               * s
-  style.padding.y               = style.padding.y               * s
-  style.divider_size            = style.divider_size            * s
-  style.scrollbar_size          = style.scrollbar_size          * s
-  style.expanded_scrollbar_size = style.expanded_scrollbar_size * s
-  style.caret_width             = style.caret_width             * s
-  style.tab_width               = style.tab_width               * s
-  config.mouse_wheel_scroll     = config.mouse_wheel_scroll     * s
+  style.divider_size                = style.divider_size                * s
+  style.scrollbar_size              = style.scrollbar_size              * s
+  style.expanded_scrollbar_size     = style.expanded_scrollbar_size     * s
+  style.minimum_thumb_size          = style.minimum_thumb_size          * s
+  style.contracted_scrollbar_margin = style.contracted_scrollbar_margin * s
+  style.expanded_scrollbar_margin   = style.expanded_scrollbar_margin   * s
+  style.caret_width                 = style.caret_width                 * s
+  style.tab_width                   = style.tab_width                   * s
+  style.padding.x                   = style.padding.x                   * s
+  style.padding.y                   = style.padding.y                   * s
+  style.margin.tab.top              = style.margin.tab.top              * s
+  config.mouse_wheel_scroll         = config.mouse_wheel_scroll         * s
 
   for _, name in ipairs {"font", "big_font", "icon_font", "icon_big_font"} do
     style[name]:set_size(s * style[name]:get_size())

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -443,9 +443,9 @@ settings.add("User Interface",
       description = "The amount of margin to apply on the top of tabs.",
       path = "tabs_top_margin",
       type = settings.type.NUMBER,
-      default = -style.divider_size * SCALE,
+      default = -style.divider_size,
       on_apply = function(value)
-        style.margin.tab.top = tonumber(value)
+        style.margin.tab.top = (tonumber(value) or -1) * SCALE
       end
     },
     {


### PR DESCRIPTION
Fixes config.mouse_wheel_scroll not properly scaling at startup by loading the config after the SCALE has been properly detected.

Also adds some missing style flags to the rescale logic of the scale plugin and adjusts the settings ui plugin to display non scaled defaults of mouse_wheel_scroll and top tabs margin configs.