### PR TITLE
Fix equal float comparison returning false

### DIFF
--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -71,7 +71,7 @@ function View:move_towards(t, k, dest, rate, name)
     return self:move_towards(self, t, k, dest, rate, name)
   end
   local val = t[k]
-  if val == dest then return end
+  if tostring(val) == tostring(dest) then return end
   if
     not config.transitions
     or math.abs(val - dest) < 0.5


### PR DESCRIPTION
Discovered a possible LuaJIT bug which returns false when comparing two equal float numbers, which returns true when converting both numbers to a string and comparing them... Basically:

```lua
if num1 ~= num2 and tostring(num1) == tostring(num2) then 
  print(string.format("%f %f", num1, num2)) 
end
```

This issue caused move_towards latest changes to always force a redraw impacting rendering performance.