### PR TITLE
Fix the statusview tooltips jumpy text

### DIFF
--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -722,8 +722,9 @@ function StatusView:draw_item_tooltip(item)
     renderer.draw_text(
       style.font,
       text,
-      x + (style.padding.x * 2),
-      self.position.y - h - style.padding.y,
+      -- we round the coords to prevent jumpy text on fractional scales
+      common.round(x + (style.padding.x * 2)),
+      common.round(self.position.y - h - style.padding.y),
       style.text
     )
   end)


### PR DESCRIPTION
Fixes the issue described on #359 by performing the rounding of the coords given to renderer.draw_text from Lua side.