### PR TITLE
Generalize the rendering cache system

### DIFF
--- a/src/api/renderer.c
+++ b/src/api/renderer.c
@@ -1,13 +1,12 @@
 #include <math.h>
 #include <string.h>
 #include <assert.h>
+#include <lua.h>
+
 #include "api.h"
 #include "../renderer.h"
 #include "../rencache.h"
-#ifdef PRAGTICAL_USE_SDL_RENDERER
 #include "../renwindow.h"
-#endif
-#include "lua.h"
 
 // a reference index to a table that stores the fonts
 static int RENDERER_FONT_REF = LUA_NOREF;
@@ -246,7 +245,7 @@ static int f_font_set_size(lua_State *L) {
 #ifdef PRAGTICAL_USE_SDL_RENDERER
   RenWindow *window = ren_get_target_window();
   if (window != NULL) {
-    scale = renwin_get_surface(window).scale_x;
+    scale = rencache_get_surface(&window->cache).scale_x;
   }
 #endif
   ren_font_group_set_size(fonts, size, scale);
@@ -410,8 +409,9 @@ static int f_show_debug(lua_State *L) {
 static int f_get_size(lua_State *L) {
   int w = 0, h = 0;
   RenWindow *window = ren_get_target_window();
+  RenSurface rs = rencache_get_surface(&window->cache);
   if (window)
-    ren_get_size(window, &w, &h);
+    ren_get_size(&rs, &w, &h);
   lua_pushnumber(L, w);
   lua_pushnumber(L, h);
   return 2;
@@ -422,7 +422,7 @@ static int f_begin_frame(UNUSED lua_State *L) {
   assert(ren_get_target_window() == NULL);
   RenWindow *window = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
   ren_set_target_window(window);
-  rencache_begin_frame(window);
+  rencache_begin_frame(&window->cache);
   return 0;
 }
 
@@ -430,7 +430,7 @@ static int f_begin_frame(UNUSED lua_State *L) {
 static int f_end_frame(UNUSED lua_State *L) {
   RenWindow *window = ren_get_target_window();
   assert(window != NULL);
-  rencache_end_frame(window);
+  rencache_end_frame(&window->cache);
   ren_set_target_window(NULL);
   // clear the font reference table
   lua_newtable(L);
@@ -452,7 +452,7 @@ static int f_set_clip_rect(lua_State *L) {
   lua_Number w = luaL_checknumber(L, 3);
   lua_Number h = luaL_checknumber(L, 4);
   RenRect rect = rect_to_grid(x, y, w, h);
-  rencache_set_clip_rect(ren_get_target_window(), rect);
+  rencache_set_clip_rect(&ren_get_target_window()->cache, rect);
   return 0;
 }
 
@@ -464,7 +464,7 @@ static int f_draw_rect(lua_State *L) {
   lua_Number h = luaL_checknumber(L, 4);
   RenRect rect = rect_to_grid(x, y, w, h);
   RenColor color = checkcolor(L, 5, 255);
-  rencache_draw_rect(ren_get_target_window(), rect, color);
+  rencache_draw_rect(&ren_get_target_window()->cache, rect, color);
   return 0;
 }
 
@@ -490,7 +490,7 @@ static int f_draw_text(lua_State *L) {
   double y = luaL_checknumber(L, 4);
   RenColor color = checkcolor(L, 5, 255);
   RenTab tab = checktab(L, 6);
-  x = rencache_draw_text(ren_get_target_window(), fonts, text, len, x, y, color, tab);
+  x = rencache_draw_text(&ren_get_target_window()->cache, fonts, text, len, x, y, color, tab);
   lua_pushnumber(L, x);
   return 1;
 }

--- a/src/api/renwindow.c
+++ b/src/api/renwindow.c
@@ -1,8 +1,8 @@
+#include <lua.h>
+#include <SDL3/SDL.h>
 #include "api.h"
 #include "../renwindow.h"
-#include "lua.h"
-#include <SDL3/SDL.h>
-#include <stdlib.h>
+#include "../rencache.h"
 
 static RenWindow *persistant_window = NULL;
 
@@ -65,7 +65,8 @@ static int f_renwin_gc(lua_State *L) {
 static int f_renwin_get_size(lua_State *L) {
   RenWindow *window_renderer = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
   int w, h;
-  ren_get_size(window_renderer, &w, &h);
+  RenSurface rs = rencache_get_surface(&window_renderer->cache);
+  ren_get_size(&rs, &w, &h);
   lua_pushnumber(L, w);
   lua_pushnumber(L, h);
   return 2;
@@ -95,7 +96,7 @@ static int f_renwin_restore(lua_State *L) {
 static int f_get_refresh_rate(lua_State *L) {
   RenWindow *window_renderer = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
 
-  SDL_DisplayID display = SDL_GetDisplayForWindow(window_renderer->window);
+  SDL_DisplayID display = SDL_GetDisplayForWindow(window_renderer->cache.window);
   if (!display) return 0;
 
   const SDL_DisplayMode *mode;

--- a/src/ffiexports.c
+++ b/src/ffiexports.c
@@ -32,6 +32,7 @@
 
 #include "renderer.h"
 #include "rencache.h"
+#include "renwindow.h"
 
 #if defined(_WIN32)
   #define EXPORT __declspec(dllexport)
@@ -54,33 +55,33 @@ EXPORT RenWindow* ren_get_target_window_ffi(void)
 
 EXPORT void rencache_set_clip_rect_ffi(RenWindow *window_renderer, float x, float y, float w, float h) {
   RenRect rect = rect_to_grid(x, y, w, h);
-  rencache_set_clip_rect(window_renderer, rect);
+  rencache_set_clip_rect(&window_renderer->cache, rect);
 }
 
 EXPORT void rencache_draw_rect_ffi(RenWindow *window_renderer, float x, float y, float w, float h, unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {
   RenRect rect = rect_to_grid(x, y, w, h);
   RenColor color = {.r = r, .g = g, .b = b, .a = a};
-  rencache_draw_rect(window_renderer, rect, color);
+  rencache_draw_rect(&window_renderer->cache, rect, color);
 }
 
 EXPORT double rencache_draw_text_ffi(RenWindow *window_renderer, RenFont **fonts, const char *text, size_t len, double x, double y, unsigned char r, unsigned char g, unsigned char b, unsigned char a, double tab_offset)
 {
   RenColor color = {.r = r, .g = g, .b = b, .a = a};
   RenTab tab = {.offset = tab_offset};
-  return rencache_draw_text(window_renderer, fonts, text, len, x, y, color, tab);
+  return rencache_draw_text(&window_renderer->cache, fonts, text, len, x, y, color, tab);
 }
 
 EXPORT void rencache_begin_frame_ffi(RenWindow *window_renderer)
 {
   ren_set_target_window(window_renderer);
-  rencache_begin_frame(window_renderer);
+  rencache_begin_frame(&window_renderer->cache);
 }
 
 EXPORT void rencache_end_frame_ffi()
 {
   RenWindow *window = ren_get_target_window();
-  rencache_end_frame(window);
+  rencache_end_frame(&window->cache);
   ren_set_target_window(NULL);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,11 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <signal.h>
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
-#include "api/api.h"
-#include "rencache.h"
-#include "renderer.h"
 
-#include <signal.h>
+#include "api/api.h"
+#include "renderer.h"
 
 #ifdef _WIN32
   #include <windows.h>
@@ -251,7 +250,6 @@ init_lua:
   lua_pcall(L, 0, 1, 0);
   if (lua_toboolean(L, -1)) {
     lua_close(L);
-    rencache_invalidate();
     has_restarted = 1;
     goto init_lua;
   }

--- a/src/rencache.h
+++ b/src/rencache.h
@@ -5,12 +5,16 @@
 #include <lua.h>
 #include "renderer.h"
 
+void rencache_init(RenCache *rc);
+void rencache_uninit(RenCache *rc);
 void  rencache_show_debug(bool enable);
-void  rencache_set_clip_rect(RenWindow *window_renderer, RenRect rect);
-void  rencache_draw_rect(RenWindow *window_renderer, RenRect rect, RenColor color);
-double rencache_draw_text(RenWindow *window_renderer, RenFont **font, const char *text, size_t len, double x, double y, RenColor color, RenTab tab);
-void  rencache_invalidate(void);
-void  rencache_begin_frame(RenWindow *window_renderer);
-void  rencache_end_frame(RenWindow *window_renderer);
+void  rencache_set_clip_rect(RenCache *rc, RenRect rect);
+void  rencache_draw_rect(RenCache *rc, RenRect rect, RenColor color);
+double rencache_draw_text(RenCache *rc, RenFont **font, const char *text, size_t len, double x, double y, RenColor color, RenTab tab);
+void  rencache_invalidate(RenCache *rc);
+void  rencache_begin_frame(RenCache *rc);
+void  rencache_end_frame(RenCache *rc);
+RenSurface rencache_get_surface(RenCache *rc);
+void rencache_update_rects(RenCache *rc, RenRect *rects, int count);
 
 #endif

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -17,6 +17,10 @@
 #define RECT_TYPE int
 #endif
 
+#define RENCACHE_CELLS_X 80
+#define RENCACHE_CELLS_Y 50
+#define RENCACHE_CELL_SIZE 96
+
 #define FONT_FALLBACK_MAX 10
 typedef struct RenFont RenFont;
 typedef enum { FONT_HINTING_NONE, FONT_HINTING_SLIGHT, FONT_HINTING_FULL } ERenFontHinting;
@@ -28,6 +32,26 @@ typedef struct { RECT_TYPE x, y, width, height; } RenRect;
 typedef struct { double offset; } RenTab;
 typedef struct { SDL_Surface *surface; float scale_x, scale_y; } RenSurface;
 typedef struct { EFontMetaTag tag; char *value; size_t len; } FontMetaData;
+
+typedef struct {
+  uint8_t *command_buf;
+  size_t command_buf_idx;
+  size_t command_buf_size;
+  unsigned cells_buf1[RENCACHE_CELLS_X * RENCACHE_CELLS_Y];
+  unsigned cells_buf2[RENCACHE_CELLS_X * RENCACHE_CELLS_Y];
+  unsigned *cells_prev;
+  unsigned *cells;
+  RenRect rect_buf[RENCACHE_CELLS_X * RENCACHE_CELLS_Y / 2];
+  bool resize_issue;
+  RenRect screen_rect;
+  RenRect last_clip_rect;
+  SDL_Window *window;   /* The cache can be used for both a window or surface */
+  RenSurface rensurface;
+#ifdef PRAGTICAL_USE_SDL_RENDERER
+  SDL_Renderer *renderer;
+  SDL_Texture *texture;
+#endif
+} RenCache;
 
 struct RenWindow;
 typedef struct RenWindow RenWindow;
@@ -55,9 +79,8 @@ void ren_free(void);
 RenWindow* ren_create(SDL_Window *win);
 void ren_destroy(RenWindow* window_renderer);
 void ren_resize_window(RenWindow *window_renderer);
-void ren_update_rects(RenWindow *window_renderer, RenRect *rects, int count);
-void ren_set_clip_rect(RenWindow *window_renderer, RenRect rect);
-void ren_get_size(RenWindow *window_renderer, int *x, int *y); /* Reports the size in points. */
+void ren_set_clip_rect(RenSurface *rs, RenRect rect);
+void ren_get_size(RenSurface *rs, int *x, int *y); /* Reports the size in points. */
 size_t ren_get_window_list(RenWindow ***window_list_dest);
 RenWindow* ren_find_window(SDL_Window *window);
 RenWindow* ren_find_window_from_id(uint32_t id);

--- a/src/renwindow.h
+++ b/src/renwindow.h
@@ -1,5 +1,6 @@
 #include <SDL3/SDL.h>
 #include "renderer.h"
+#include "rencache.h"
 
 struct HitTestInfo {
   int title_height;
@@ -9,23 +10,14 @@ struct HitTestInfo {
 typedef struct HitTestInfo HitTestInfo;
 
 struct RenWindow {
-  SDL_Window *window;
-  uint8_t *command_buf;
-  size_t command_buf_idx;
-  size_t command_buf_size;
+  RenCache cache;
   float scale_x;
   float scale_y;
   HitTestInfo hit_test_info;
-#ifdef PRAGTICAL_USE_SDL_RENDERER
-  SDL_Renderer *renderer;
-  SDL_Texture *texture;
-  RenSurface rensurface;
-#endif
 };
 typedef struct RenWindow RenWindow;
 
-void renwin_init_surface(RenWindow *ren);
-void renwin_init_command_buf(RenWindow *ren);
+RenWindow* renwin_create(SDL_Window *win);
 void renwin_clip_to_surface(RenWindow *ren);
 void renwin_set_clip_rect(RenWindow *ren, RenRect rect);
 void renwin_resize_surface(RenWindow *ren);
@@ -33,4 +25,3 @@ void renwin_update_scale(RenWindow *ren);
 void renwin_show_window(RenWindow *ren);
 void renwin_update_rects(RenWindow *ren, RenRect *rects, int count);
 void renwin_free(RenWindow *ren);
-RenSurface renwin_get_surface(RenWindow *ren);


### PR DESCRIPTION
With this change the command buffer and cells grid are localized to a RenCache object to allow the usage of rencache in other components, for example a canvas.