### PR TITLE
Add the option to change background mode of images

### DIFF
--- a/data/core/commands/image.lua
+++ b/data/core/commands/image.lua
@@ -1,3 +1,4 @@
+local config = require "core.config"
 local command = require "core.command"
 local ImageView = require "core.imageview"
 
@@ -13,5 +14,18 @@ command.add(ImageView, {
   ["image-view:zoom-in"] = function(av)
     ---@cast av core.imageview
     av:zoom_in()
+  end,
+  ["image-view:zoom-reset"] = function(av)
+    ---@cast av core.imageview
+    av:zoom_reset()
+  end,
+  ["image-view:background-mode-solid"] = function()
+    config.images_background_mode = "solid"
+  end,
+  ["image-view:background-mode-grid"] = function()
+    config.images_background_mode = "grid"
+  end,
+  ["image-view:background-mode-none"] = function()
+    config.images_background_mode = "none"
   end,
 })

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -27,6 +27,19 @@ config.fps = 60
 ---@type boolean | "uncapped"
 config.draw_stats = false
 
+---The type of background drawn behind the images.
+---
+---Defaults to "grid".
+---@type "grid" | "solid" | "none"
+config.images_background_mode = "grid"
+
+---The color used for the background of transparent images when the
+---background mode is set to solid.
+---
+---Defaults to "#ffffff".
+---@type renderer.color
+config.images_background_color = { common.color "#ffffff" }
+
 ---Maximum number of log items that will be stored.
 ---When the number of log items exceed this value, old items will be discarded.
 ---

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -721,6 +721,30 @@ settings.add("Editor",
   }
 )
 
+settings.add("Image Viewer",
+  {
+    {
+      label = "Background Mode",
+      description = "The type of background to draw behind transparent images.",
+      path = "images_background_mode",
+      type = settings.type.SELECTION,
+      default = "grid",
+      values = {
+        {"Grid", "grid"},
+        {"Solid", "solid"},
+        {"None", "none"}
+      }
+    },
+    {
+      label = "Background Color",
+      description = "The color used when background mode is set to solid.",
+      path = "images_background_color",
+      type = settings.type.COLOR,
+      default = table.pack(table.unpack(config.images_background_color))
+    }
+  }
+)
+
 settings.add("Development",
   {
     {


### PR DESCRIPTION
The options are:

* "grid" - displays gray squares
* "solid" - displays a configurable color
* "none" - no background is displayed

New config flags:

```lua
---The type of background drawn behind the images.
---
---Defaults to "grid".
---@type "grid" | "solid" | "none"
config.images_background_mode = "grid"

---The color used for the background of transparent images when the
---background mode is set to solid.
---
---Defaults to "#ffffff".
---@type renderer.color
config.images_background_color = { common.color "#ffffff" }
```

### Video Preview

https://github.com/user-attachments/assets/efefbd0e-bc37-4d5b-b847-ba442ddc0480
