### PR TITLE
Update sdl to v3.2.28

### DIFF
--- a/subprojects/packagefiles/sdl3/meson.build
+++ b/subprojects/packagefiles/sdl3/meson.build
@@ -1,1 +1,1 @@
-project('sdl3', version : '3.2.20', license : 'zlib')
+project('sdl3', version : '3.2.28', license : 'zlib')

--- a/subprojects/sdl3.wrap
+++ b/subprojects/sdl3.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/libsdl-org/SDL.git
-revision = release-3.2.26
+revision = release-3.2.28
 depth = 1
 patch_directory = sdl3
 


### PR DESCRIPTION
Relevant changes:

* Fixed a divide by zero with a zero sized blit in some cases
* Fixed blitting bitmaps with a non-zero x offset
* Fixed the initial X11 window position in some environments