### PR TITLE
Fix inconsistency on toolbarview dest_size

### DIFF
--- a/data/core/common.lua
+++ b/data/core/common.lua
@@ -524,6 +524,41 @@ function common.bench(name, fn, ...)
   return res
 end
 
+
+---Print debugging information about the caller at a given stack level.
+---
+---This function retrieves and prints:
+---  * Source file of the call
+---  * Line number within that file
+---  * Name of the calling function (if available)
+---
+---Useful for tracing execution flow.
+---
+---Stack levels:
+---  1 = get_caller_info()
+---  2 = the function that called get_caller_info()
+---  3 = that function’s caller (default)
+---
+---@param stacklevel? integer The stack frame to inspect. Defaults to 3.
+function common.get_caller_info(stacklevel)
+  local lvl = stacklevel or 3
+  local info = debug.getinfo(lvl, "nSl")
+  if not info then
+    print(string.format("Caller info unavailable (stack level %d).", lvl))
+    return
+  end
+  -- Normalize the source: strip leading '@'
+  local source = info.source
+  if source:sub(1, 1) == "@" then
+    source = source:sub(2)
+  end
+  print("Caller info:")
+  print(string.format("  File    : %s", source))
+  print(string.format("  Line    : %d", info.currentline or -1))
+  print(string.format("  Function: %s", info.name or "(anonymous)"))
+end
+
+
 -- From gvx/Ser
 local oddvals = {[tostring(1/0)] = "1/0", [tostring(-1/0)] = "-1/0", [tostring(-(0/0))] = "-(0/0)", [tostring(0/0)] = "0/0"}
 

--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -71,7 +71,8 @@ function View:move_towards(t, k, dest, rate, name)
     return self:move_towards(self, t, k, dest, rate, name)
   end
   local val = t[k]
-  if tostring(val) == tostring(dest) then return end
+  -- we use epsilon comparison in case dest is inconsistent
+  if math.abs(dest - val) < 1e-8 then return end
   if
     not config.transitions
     or math.abs(val - dest) < 0.5

--- a/data/plugins/toolbarview.lua
+++ b/data/plugins/toolbarview.lua
@@ -29,7 +29,11 @@ end
 
 
 function ToolbarView:update()
-  local dest_size = self.visible and (self.toolbar_font:get_height() + style.padding.y * 2) or 0
+  -- round due to the inconsistency of operation on fractional scales
+  -- inconsistency traced with common.get_caller_info() from self:move_towards()
+  local dest_size = self.visible
+    and common.round(self.toolbar_font:get_height() + style.padding.y * 2)
+    or 0
   if self.init_size then
     self.size.y = dest_size
     self.init_size = nil


### PR DESCRIPTION
On fractional scales the calculation of dest_size can be inconsistent leading to undesired move_towards processing.

Also:

* Introduced common.get_caller_info(stacklevel) to help troubleshoot this kind of issues.
* Adapted move_towards to use an epsilon comparison (thanks to Mike Pall for suggestion and correction on wrong assumption from my part).