### PR TITLE
Fix system.list_dir to work with /

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -667,6 +667,8 @@ static SDL_EnumerationResult list_dir_enumeration_callback(void *userdata, const
 
 static int f_list_dir(lua_State *L) {
   const char *path = luaL_checkstring(L, 1);
+  /* Seems that SDL internal path normalizations strip a single / */
+  path = strcmp(path, "/") == 0 ? "/." : path;
   lua_newtable(L);
   bool res = SDL_EnumerateDirectory(path, list_dir_enumeration_callback, L);
   if (!res) {


### PR DESCRIPTION
system.list_dir fails to return anything when '/' is given.

Not sure if this is a bug on SDL3 SDL_EnumerateDirectory function but it seems that the internal path normalization functionality strips a single '/' which is valid on posix OS like linux, mac, etc...

We replace '/' with '/.' to workaround the issue and get correct directory listing.