### PR TITLE
Initial support for muon build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('pragtical',
-    ['c'],
+    ['c', 'cpp'],
     version : '3.7.1',
     license : 'MIT',
     meson_version : '>= 0.63',
@@ -232,7 +232,7 @@ if not get_option('source-only')
         meson.override_dependency('sdl3', sdl_dep)
     endif
 
-    sdl_image = dependency('SDL3_image', fallback: ['sdl3_image', 'sdl3_image_dep'],
+    sdl_image = dependency('SDL3_image', 'sdl3-image', fallback: ['sdl3_image', 'sdl3_image_dep'],
         default_options: default_fallback_options + ['default_library=static']
     )
 

--- a/scripts/run-local
+++ b/scripts/run-local
@@ -75,8 +75,13 @@ fi
 builddir="${pargs[0]}"
 
 build_pragtical () {
-  echo "running meson compile"
-  meson compile -C "$builddir"
+  if [ -e "$builddir/.muon" ]; then
+    echo "running muon samu"
+    muon samu -C "$builddir"
+  else
+    echo "running meson compile"
+    meson compile -C "$builddir"
+  fi
 }
 
 copy_pragtical_build () {

--- a/subprojects/packagefiles/plugins/meson.build
+++ b/subprojects/packagefiles/plugins/meson.build
@@ -1,4 +1,4 @@
-project('plugins', version: 'GIT', license: 'MIT')
+project('plugins', 'c', version: 'GIT', license: 'MIT')
 
 # Check for valid shell
 unix_shell = find_program('sh', required: false).found()


### PR DESCRIPTION
[muon](https://github.com/muon-build/muon) is a `C` implementation of meson that is magnitudes faster than the official python implementation.

These minimal changes allow compiling pragtical with muon from latest git https://github.com/muon-build/muon with shared libraries:

```sh
muon setup -Dppm=false -Duse_system_lua=true build

muon samu -C build
```

Also this changes adjust `./scripts/run-local` in order to detect if muon was used for setup and use it to build and then launch the editor:

```sh
./scripts/run-local -global build
```

As described on its repo it is missing some meson features but, since muon is really fast it is great for development purposes (as in been able to setup and compile your project a lot faster). Besides been faster than meson it does some things differently, for example:

1. a nice feature I found is it always copies your subproject meson.build packagefiles when building so when performing changes you don't need to worry about synchronizing
subprojects/packagefiles/sub/[meson-stuff] into subprojects/sub/[meson-stuff]

2. It is stricter than meson, like not allowing access to a compiler if it wasn't declared on the project.

3. Has built-in LSP (language server), while still buggy for auto-completion it provides nice diagnostics.

4. and a bunch of other things haven't discovered yet and mentioned on https://docs.muon.build/differences.html

It is so fast you can setup and build on a single command:

```sh
muon build -Dppm=false -Duse_system_lua=true build
```

Did I mention it is fast? :)