### PR TITLE
Fix luajit crosscompilation for muon

### DIFF
--- a/subprojects/packagefiles/luajit/meson.build
+++ b/subprojects/packagefiles/luajit/meson.build
@@ -10,6 +10,7 @@ project('luajit',
 )
 
 cc = meson.get_compiler('c')
+cc_native = meson.get_compiler('c', native : true)
 
 system = host_machine.system()
 
@@ -17,6 +18,11 @@ if system == 'linux' or system == 'darwin' or system == 'windows'
     system_deps = [
         cc.find_library('dl', required: false),
         cc.find_library('m', required: false)
+    ]
+
+    system_deps_native = [
+        cc_native.find_library('dl', required: false),
+        cc_native.find_library('m', required: false)
     ]
 
     # get architecture id for the host machine so it can be set when compiling buildvm natively

--- a/subprojects/packagefiles/luajit/src/host/meson.build
+++ b/subprojects/packagefiles/luajit/src/host/meson.build
@@ -57,6 +57,6 @@ buildvm_arch = custom_target('buildvm_arch.h',
                              output: 'buildvm_arch.h')
 
 buildvm = executable('buildvm', buildvm_src, buildvm_arch, luajit_h,
-                     dependencies: system_deps,
+                     dependencies: system_deps_native,
                      include_directories: src_inc,
                      native: true)

--- a/subprojects/packagefiles/luajit/src/meson.build
+++ b/subprojects/packagefiles/luajit/src/meson.build
@@ -77,7 +77,7 @@ ljcore_src = files(
 src_inc = include_directories('.')
 
 minilua = executable('minilua', 'host/minilua.c',
-                     dependencies: system_deps,
+                     dependencies: system_deps_native,
                      native: true)
 
 relver = vcs_tag(command: ['git', 'show', '-s', '--format=%ct'],


### PR DESCRIPTION
As explained here: https://docs.muon.build/differences.html#native-true

muon properly errors out when trying to link a build machine target using a host machine dependencies, this PR properly uses the build machine compiler to get system dependencies, instead of using the host machine dependencies.