### PR TITLE
TreeView: round size.x on move_towards

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -310,6 +310,8 @@ function TreeView:update()
     self.init_size = false
   else
     self:move_towards(self.size, "x", dest, nil, "treeview")
+    -- round to allow constant positioning of slibing elements on resize
+    self.size.x = common.round(self.size.x)
   end
 
   if self.size.x == 0 or self.size.y == 0 or not self.visible then return end


### PR DESCRIPTION
This allows constant positioning of sibling elements on resize.

Before:

https://github.com/user-attachments/assets/a9f2461b-4bd8-41af-9cab-699b9c3a0118

After:

https://github.com/user-attachments/assets/9d7dc2cc-86a9-4dfb-92a8-8c1b5fc8da1a
