### PR TITLE
PPM subproject: download git submodules on demand

### DIFF
--- a/subprojects/packagefiles/ppm/meson.build
+++ b/subprojects/packagefiles/ppm/meson.build
@@ -101,6 +101,14 @@ else
     # Check dependencies
     bash_exe = find_program('bash')
     cmake_exe = find_program('cmake')
+    git_command = find_program('git')
+
+    # Fetch git submodules
+    message('Cloning git submodules...')
+    run_command(git_command,
+        'submodule', 'update', '--init', '--recursive', '--depth', '1',
+        check : false
+    )
 
     env = environment()
 

--- a/subprojects/ppm.wrap
+++ b/subprojects/ppm.wrap
@@ -3,4 +3,3 @@ url = https://github.com/pragtical/plugin-manager.git
 revision = head
 depth = 1
 patch_directory = ppm
-clone-recursive = true


### PR DESCRIPTION
This change removes the need of also cloning the plugin manager git submodules when linking against system libraries.