### PR TITLE
Fix cpu usage due to treeview plugin move_towards

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -304,14 +304,15 @@ end
 
 function TreeView:update()
   -- update width
-  local dest = self.visible and self.target_size or 0
+  local dest = self.visible and common.round(self.target_size) or 0
   if self.init_size then
     self.size.x = dest
     self.init_size = false
-  else
+  elseif self.size.x ~= dest then
     self:move_towards(self.size, "x", dest, nil, "treeview")
     -- round to allow constant positioning of slibing elements on resize
     self.size.x = common.round(self.size.x)
+    if math.abs(dest - self.size.x) < 2 then self.size.x = dest end
   end
 
   if self.size.x == 0 or self.size.y == 0 or not self.visible then return end


### PR DESCRIPTION
Previously a fix was done on #384 to round the width of treeview but not rounding also the destination caused a constant move_towards which increased cpu usage.

Side Note: such a small change could affect so much the cpu usage :)