### PR TITLE
LuaJIT subproject: install additional lua modules

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,23 @@ if host_machine.system() == 'windows'
 endif
 
 #===============================================================================
+# Configure output directories
+#===============================================================================
+if get_option('portable') or host_machine.system() == 'windows'
+    pragtical_bindir = '/'
+    pragtical_docdir = '/doc'
+    pragtical_datadir = '/data'
+elif get_option('bundle') and host_machine.system() == 'darwin'
+    pragtical_bindir = 'Contents/MacOS'
+    pragtical_docdir = 'Contents/Resources'
+    pragtical_datadir = 'Contents/Resources'
+else
+    pragtical_bindir = 'bin'
+    pragtical_docdir = 'share/doc/pragtical'
+    pragtical_datadir = 'share/pragtical'
+endif
+
+#===============================================================================
 # System dependency settings
 #===============================================================================
 use_system_lua = get_option('use_system_lua')
@@ -37,7 +54,7 @@ if get_option('jit')
     if not use_system_lua
         luajit_dep = subproject(
             'luajit',
-            default_options: ['default_library=static']
+            default_options: ['default_library=static', 'data_dir='+pragtical_datadir]
         ).get_variable('luajit_dep')
     else
         luajit_dep = dependency('luajit', required : false,
@@ -252,9 +269,6 @@ endif
 # Install Configuration
 #===============================================================================
 if get_option('portable') or host_machine.system() == 'windows'
-    pragtical_bindir = '/'
-    pragtical_docdir = '/doc'
-    pragtical_datadir = '/data'
     if host_machine.system() == 'windows'
         configure_file(
             input: 'resources/windows/pragtical.exe.manifest.in',
@@ -267,9 +281,6 @@ if get_option('portable') or host_machine.system() == 'windows'
     )
 elif get_option('bundle') and host_machine.system() == 'darwin'
     pragtical_cargs += '-DMACOS_USE_BUNDLE'
-    pragtical_bindir = 'Contents/MacOS'
-    pragtical_docdir = 'Contents/Resources'
-    pragtical_datadir = 'Contents/Resources'
     conf_data.set(
         'CURRENT_YEAR',
         run_command('date', '+%Y', capture: true).stdout().strip()
@@ -283,9 +294,6 @@ elif get_option('bundle') and host_machine.system() == 'darwin'
         install_dir : 'Contents'
     )
 else
-    pragtical_bindir = 'bin'
-    pragtical_docdir = 'share/doc/pragtical'
-    pragtical_datadir = 'share/pragtical'
     if host_machine.system() == 'linux'
         install_data('resources/icons/logo.svg',
             install_dir : 'share/icons/hicolor/scalable/apps',

--- a/subprojects/packagefiles/luajit/meson_options.txt
+++ b/subprojects/packagefiles/luajit/meson_options.txt
@@ -4,3 +4,10 @@ option(
     value: true,
     description: 'Perform amalgamated build of LuaJIT.',
 )
+
+option(
+  'data_dir',
+  type : 'string',
+  value : '/',
+  description: 'Data directory for installation of LuaJIT lua modules.'
+)

--- a/subprojects/packagefiles/luajit/src/meson.build
+++ b/subprojects/packagefiles/luajit/src/meson.build
@@ -110,6 +110,11 @@ foreach h: hdrgen
                                 output: 'lj_@0@.h'.format(h))
 endforeach
 
+custom_target('vmdef',
+              command: [buildvm, '-m', 'vmdef', '-o', '@OUTPUT@', ljlib_src],
+              output: 'vmdef.lua', build_by_default: true, install: true,
+              install_dir: join_paths(get_option('data_dir'), 'jit'))
+
 genheaders += custom_target('folddef',
                             command: [buildvm, '-m', 'folddef', '-o', '@OUTPUT@', files('lj_opt_fold.c')],
                             output: 'lj_folddef.h')
@@ -125,3 +130,10 @@ else
     luajit_lib = static_library('luajit', ljlib_src, ljcore_src, genheaders, ljvm,
                                 dependencies: system_deps)
 endif
+
+install_subdir(
+    'jit',
+    strip_directory: true,
+    install_dir: join_paths(get_option('data_dir'), 'jit'),
+    exclude_files: ['.gitignore']
+)


### PR DESCRIPTION
* Add generation of jit/vmdef.lua
* Allows access to jit.dump to easily log jit traces eg: require("jit.dump").on("ms", "logfile.txt")
* Allows access to high level LuaJIT profiler jit.p, etc...