### PR TITLE
Open images in viewer from open file operations

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -45,7 +45,7 @@ local function open_file(use_dialog, label, selection_callback)
       if status == "accept" then
       	for _, filename in ipairs(result --[[ @as string[] ]]) do
           if not selection_callback then
-            core.root_view:open_doc(core.open_doc(filename))
+            core.open_file(filename)
           else
             selection_callback(filename)
           end
@@ -64,7 +64,7 @@ local function open_file(use_dialog, label, selection_callback)
     text = default_text,
     submit = function(text)
       if not selection_callback then
-        core.root_view:open_doc(core.open_doc(filename))
+        core.open_file(filename)
       else
         selection_callback(filename)
       end

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1210,6 +1210,20 @@ function core.open_image(filename)
 end
 
 
+---Opens the given file path in the root view.
+---If the given file is a supported image, it will open it in the image viewer;
+---otherwise, it will open it as a normal text file.
+---@param filename string Path to the file to open
+---@return core.imageview|core.docview
+function core.open_file(filename)
+  local view = core.open_image(filename)
+  if not view then
+    return core.root_view:open_doc(core.open_doc(filename))
+  end
+  return view
+end
+
+
 function core.custom_log(level, show, backtrace, fmt, ...)
   local text = string.format(fmt, ...)
   if show then

--- a/data/plugins/findfile.lua
+++ b/data/plugins/findfile.lua
@@ -373,7 +373,7 @@ command.add(nil, {
           local filename = core.current_project():absolute_path(
             common.home_expand(text)
           )
-          core.root_view:open_doc(core.open_doc(filename))
+          core.open_file(filename)
           return
         end
         text = suggestion.text
@@ -386,9 +386,7 @@ command.add(nil, {
               if project_name == common.basename(project.path) then
                 local file = project.path .. PATHSEP .. file_path
                 if is_file(file) then
-                  core.root_view:open_doc(
-                    core.open_doc(project.path .. PATHSEP .. file_path)
-                  )
+                  core.open_file(project.path .. PATHSEP .. file_path)
                   return
                 end
               end
@@ -398,9 +396,7 @@ command.add(nil, {
         local file = core.projects[1]:absolute_path(
           common.home_expand(text)
         )
-        if is_file(file) then
-          core.root_view:open_doc(core.open_doc(file))
-        end
+        if is_file(file) then core.open_file(file) end
       end,
       suggest = function(text)
         local results = {}


### PR DESCRIPTION
* Introduces a convenient core.open_file(filename) that opens images in the viewer and files on a document viewer.
* Modifies the core:open-file to use core.open_file.
* Modifies findfile plugin to use core.open_file.