### PR TITLE
EmptyView: re-update childs on size/pos changes

### DIFF
--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -283,6 +283,8 @@ function EmptyView:update()
 
     self.prev_size.x = self.size.x
     self.prev_size.y = self.size.y
+
+    EmptyView.super.update(self)
   end
 end
 


### PR DESCRIPTION
This fixes an issue reported by Amer on Windows where the top and bottom widgets aren't visible if transitions are turned off until an input event is received (mouse, keyboard).