### PR TITLE
Reduce rencache cell size for better dirty detect

### DIFF
--- a/src/rencache.h
+++ b/src/rencache.h
@@ -4,9 +4,13 @@
 #include <stdbool.h>
 #include "renderer.h"
 
-#define RENCACHE_CELLS_X 80
-#define RENCACHE_CELLS_Y 50
-#define RENCACHE_CELL_SIZE 96
+/* These values represent the maximum size that can be tracked by rencache
+   7680x4320 = 8k resolution, we use a common divisor for the size of regions
+   that will be dirty checked.
+*/
+#define RENCACHE_CELL_SIZE 60 /* common divisor of width and height */
+#define RENCACHE_CELLS_X (7680 / RENCACHE_CELL_SIZE) /* 128 cells */
+#define RENCACHE_CELLS_Y (4320 / RENCACHE_CELL_SIZE) /* 72 cells */
 
 typedef struct {
   uint8_t *command_buf;


### PR DESCRIPTION
This change reduces the RENCACHE_CELL_SIZE from 96 to 60 to allow better tracking of dirty regions.

Before:

<img width="794" height="597" alt="20251230-155622" src="https://github.com/user-attachments/assets/7e2ce9c5-ede8-41ea-a487-42b829831483" />

After:

<img width="746" height="521" alt="20251230-155655" src="https://github.com/user-attachments/assets/7fb0fad1-1c03-46f9-882e-b2eac0be47f1" />
