### PR TITLE
fix: remove constraint in image opening from treeview

### DIFF
--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -986,7 +986,7 @@ command.add(
     local item = treeitem()
     if item then
       local is_image, ext = ImageView.is_supported(item.abs_filename)
-      if is_image then
+      if is_image and (ext == "svg" or ext == "xpm") then
         return (core.active_view == view or menu.show_context_menu), item
       end
     end


### PR DESCRIPTION
Hello,

After closer inspection it seems that treeview is limiting the supported format of opening images to 'svg'. This seems an oversight given it was added in the PR that enables image support. I tested and it seems to work with several of the specified supported formats.

Not sure if this was intended but if it is was not then this should fix it. It might be the case that the condition is inverted and the purpose was to force opening svg as a text based file for editing. Either way let me know if the change makes sense.