### PR TITLE
fix: context menu not properly sized 

### DIFF
--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -72,7 +72,6 @@ local function update_items_size(items, update_binding)
     local lw, lh = get_item_size(item)
     width = math.max(width, lw)
     height = height + lh
-    core.log("%s %d %d", item, width, height)
   end
   width = width + style.padding.x * 2
   items.width, items.height = width, height


### PR DESCRIPTION
Due to how some predicates conditionally show/hide elements the width is more often than not wrongly calculated. 

Not totally impressed with the solutions as there are multiple places where this is called and i'm quite not sure why the proper values are not correctly sized. I suspect it has something to do with the order in which draw calls are done (where supposedly the width should get updated and with the file list of items).

This small fix does seem to do it. But if anyone has better ideia or insight let me know.

Before:
<img width="159" height="217" alt="image" src="https://github.com/user-attachments/assets/837cf738-d4c6-46ef-9a41-29f202118276" />
<img width="196" height="129" alt="image" src="https://github.com/user-attachments/assets/976b876d-e750-4ce1-a5a1-abb5ad2b0d9a" />

<img width="171" height="168" alt="image" src="https://github.com/user-attachments/assets/cf85f0e2-e0df-4dfa-b899-4e09ca00055a" />


After:
<img width="194" height="217" alt="image" src="https://github.com/user-attachments/assets/3f556e16-7224-4671-ad10-99b0037af0be" />
<img width="197" height="127" alt="image" src="https://github.com/user-attachments/assets/cd1979c2-d6dd-4c2d-a147-9cb6ec29fddf" />
<img width="189" height="167" alt="image" src="https://github.com/user-attachments/assets/21e08cc6-5eb6-4c7d-a589-854c72693ae8" />


