### PR TITLE
CI: disable polyfill_glibc - issues with linenoise

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -77,6 +77,10 @@ get_default_build_dir() {
 }
 
 polyfill_glibc() {
+  if [[ true ]]; then # Disable polyfill for now since giving issues with linenoise
+    return
+  fi
+
   local platform
   platform=$(get_platform_name)
 


### PR DESCRIPTION
This should fix CI builds where a crash is happening on older GLIBC version (like the one shipped with ubuntu 22.04) also since the linenoise addition (for REPL) it seems we can no longer target older glibc versions by just patching with polyfill_glibc, so until more testing or a proper fix, this change disables polyfill_glibc to get the binary working again on Ubuntu 22.04