### PR TITLE
DocView: keep IME area always updated

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -9,6 +9,9 @@ local View = require "core.view"
 
 local CACHE_LINE_LEN = 500
 
+local IME_VIEW = nil
+local IME_SELECTION = {line1 = 0, col1 = 0, line2 = 0, col2 = 0}
+
 ---@class core.docview.position
 ---@field line integer
 ---@field col integer
@@ -671,9 +674,25 @@ end
 ---Update IME composition window location.
 ---Sets the bounding box for the system IME composition window.
 function DocView:update_ime_location()
-  if not self.ime_status then return end
+  if core.active_view ~= self then return end
 
   local line1, col1, line2, col2 = self.doc:get_selection(true)
+  if
+    not self.ime_status and core.active_view == IME_VIEW
+    and
+    IME_SELECTION.line1 == line1 and IME_SELECTION.col1 == col1
+    and
+    IME_SELECTION.line2 == line2 and IME_SELECTION.col2 == col2
+  then
+    return
+  end
+
+  IME_VIEW = self
+  IME_SELECTION.line1 = line1
+  IME_SELECTION.col1 = col1
+  IME_SELECTION.line2 = line2
+  IME_SELECTION.col2 = col2
+
   local x, y = self:get_line_screen_position(line1)
   local h = self:get_line_height()
   local col = math.min(col1, col2)

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -10,7 +10,7 @@ local View = require "core.view"
 local CACHE_LINE_LEN = 500
 
 local IME_VIEW = nil
-local IME_SELECTION = {line1 = 0, col1 = 0, line2 = 0, col2 = 0}
+local IME_STATE = {line1 = 0, col1 = 0, line2 = 0, col2 = 0, w = 0, h = 0}
 
 ---@class core.docview.position
 ---@field line integer
@@ -680,18 +680,22 @@ function DocView:update_ime_location()
   if
     not self.ime_status and core.active_view == IME_VIEW
     and
-    IME_SELECTION.line1 == line1 and IME_SELECTION.col1 == col1
+    IME_STATE.line1 == line1 and IME_STATE.col1 == col1
     and
-    IME_SELECTION.line2 == line2 and IME_SELECTION.col2 == col2
+    IME_STATE.line2 == line2 and IME_STATE.col2 == col2
+    and
+    IME_STATE.w == self.size.x and IME_STATE.h == self.size.y
   then
     return
   end
 
   IME_VIEW = self
-  IME_SELECTION.line1 = line1
-  IME_SELECTION.col1 = col1
-  IME_SELECTION.line2 = line2
-  IME_SELECTION.col2 = col2
+  IME_STATE.line1 = line1
+  IME_STATE.col1 = col1
+  IME_STATE.line2 = line2
+  IME_STATE.col2 = col2
+  IME_STATE.w = self.size.x
+  IME_STATE.h = self.size.y
 
   local x, y = self:get_line_screen_position(line1)
   local h = self:get_line_height()

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1077,7 +1077,7 @@ int video_init(void) {
     SDL_EnableScreenSaver();
     SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
     SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
-    SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "1");
+    SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
     /* This hint tells SDL to respect borderless window as a normal window.
     ** For example, the window will sit right on top of the taskbar instead
     ** of obscuring it. */


### PR DESCRIPTION
* Update the IME input area everytime that the cursor changes.
* Properly set SDL_HINT_IME_IMPLEMENTED_UI to "composition" for SDL3.
* Also take into consideration the DocView dimensions on update_ime_location()

Related: #449