### PR TITLE
build: force libiconv on sdl3 cmake subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,9 +237,16 @@ if not get_option('source-only')
             'SDL_X11': sdl_x11, 'SDL_WAYLAND': sdl_wayland,
             'SDL_TESTS': 'OFF', 'SDL_X11_XTEST': 'OFF',
             'SDL_OPENGL': sdl_opengl, 'SDL_OPENGLES': sdl_opengles,
-            'SDL_DIRECTX': 'ON', 'SDL_EXAMPLES': 'OFF',
+            'SDL_DIRECTX': 'ON', 'SDL_EXAMPLES': 'OFF', 'SDL_LIBICONV': 'ON',
             'SDL_VENDOR_INFO': 'pragtical'
         })
+
+        if host_machine.system() == 'windows'
+            # Force LIBICONV because detection seems to fail on msys2
+            sdl_options.add_cmake_defines({
+                'HAVE_ICONV': '1', 'HAVE_LIBICONV': '1'
+            })
+        endif
 
         sdl = cmake.subproject('sdl3', options: sdl_options)
         sdl_dep = sdl.dependency('SDL3-static')

--- a/meson.build
+++ b/meson.build
@@ -243,9 +243,13 @@ if not get_option('source-only')
 
         if host_machine.system() == 'windows'
             # Force LIBICONV because detection seems to fail on msys2
-            sdl_options.add_cmake_defines({
-                'HAVE_ICONV': '1', 'HAVE_LIBICONV': '1'
-            })
+            if cc.find_library('iconv', required: false).found()
+                sdl_options.add_cmake_defines({
+                    'HAVE_ICONV': '1', 'HAVE_LIBICONV': '1'
+                })
+            else
+                warning('LIBICONV not found, various encoding conversions may fail')
+            endif
         endif
 
         sdl = cmake.subproject('sdl3', options: sdl_options)

--- a/src/meson.build
+++ b/src/meson.build
@@ -124,7 +124,7 @@ if host_machine.system() == 'windows'
         pragtical_deps += cc.find_library('imm32', required: true)
         pragtical_deps += cc.find_library('setupapi', required: true)
         pragtical_deps += cc.find_library('version', required: true)
-        pragtical_deps += cc.find_library('iconv', required: true)
+        pragtical_deps += cc.find_library('iconv', required: false)
     endif
 elif host_machine.system() == 'darwin'
     pragtical_sources += 'bundle_open.m'

--- a/src/meson.build
+++ b/src/meson.build
@@ -124,6 +124,7 @@ if host_machine.system() == 'windows'
         pragtical_deps += cc.find_library('imm32', required: true)
         pragtical_deps += cc.find_library('setupapi', required: true)
         pragtical_deps += cc.find_library('version', required: true)
+        pragtical_deps += cc.find_library('iconv', required: true)
     endif
 elif host_machine.system() == 'darwin'
     pragtical_sources += 'bundle_open.m'


### PR DESCRIPTION
Forces enablement of HAVE_ICONV and HAVE_LIBICONV on SDL3 cmake subproject since its detection is failing under msys2, which causes official windows binary builds to ship with a basic and lacking sdl_iconv implementation. (Maybe this should be reported to SDL3 project, not sure...)

Should fix the issue discussed on #455 