### PR TITLE
ImageView: reposition scrollbars when needed

### DIFF
--- a/data/core/imageview.lua
+++ b/data/core/imageview.lua
@@ -313,9 +313,14 @@ function ImageView:on_mouse_wheel(d)
   ox, oy = get_scaled_image_offset(self)
 
   -- Adjust scroll so cursor stays over same pixel
-  self.scroll.to.x = img_x * self.zoom_scale - mx + ox
-  self.scroll.to.y = img_y * self.zoom_scale - my + oy
-  self.scroll.x, self.scroll.y = self.scroll.to.x, self.scroll.to.y
+  if self.width > self.size.x then
+    self.scroll.to.x = img_x * self.zoom_scale - mx + ox
+    self.scroll.x = self.scroll.to.x
+  end
+  if self.height > self.size.y then
+    self.scroll.to.y = img_y * self.zoom_scale - my + oy
+    self.scroll.y = self.scroll.to.y
+  end
 
   return true
 end


### PR DESCRIPTION
The change on #420 introduced support to reposition the image when zoomed according to mouse pointer position. This change skips repositioning of scrollbars if the image width or height is smaller than the View.

**Before:**

https://github.com/user-attachments/assets/0eccd546-4a3b-440b-8e45-3d56a250826a


**After:**

https://github.com/user-attachments/assets/06597cf7-1b18-4c05-8b09-c658394a932e