### PR TITLE
Fix non-scrollable skipping affecting statusview

### DIFF
--- a/data/core/view.lua
+++ b/data/core/view.lua
@@ -488,7 +488,13 @@ function View:update()
     self:on_scale_change(SCALE, self.current_scale)
     self.current_scale = SCALE
   end
-  if not self.scrollable then return end
+  if
+    not self.scrollable
+    and self.scroll.x == self.scroll.to.x
+    and self.scroll.y == self.scroll.to.y
+  then
+    return
+  end
   self:clamp_scroll_position()
   if self.scroll.x ~= self.scroll.to.x then
     self:move_towards(self.scroll, "x", self.scroll.to.x, 0.2, "scroll")


### PR DESCRIPTION
Previously we added a change to prevent unnecessary scroll movement on a View update but didn't noticed this affected the status view show message method functionality. This change should take into account such scenario where a view is marked as non scrollable but still hacks around the scroll mechanism...