### PR TITLE
Fix PPM not packaging into generated DMG's for mac

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -70,14 +70,28 @@ package_plugin_manager() {
   local file="ppm.${arch}-${platform}"
   if [[ $platform == "windows" ]]; then
     file="$file.exe"
+  elif [[ $platform == "macos" ]]; then
+    if [[ $arch == "arm64" ]]; then
+      arch="aarch64"
+    fi
+    file="ppm.${arch}-darwin"
   fi
   if [ ! -e "$file" ]; then
-    if ! wget -O "$file" "https://github.com/pragtical/plugin-manager/releases/download/continuous/${file}" ; then
-      echo "Could not download PPM for the arch '${arch}'."
-      return
+    if which wget ; then
+      if ! wget -O "$file" "https://github.com/pragtical/plugin-manager/releases/download/continuous/${file}" ; then
+        echo "Could not download PPM for the arch '${arch}'."
+        return
+      fi
+    elif which curl ; then
+      if ! curl -L -o "$file" "https://github.com/pragtical/plugin-manager/releases/download/continuous/${file}" ; then
+        echo "Could not download PPM for the arch '${arch}'."
+        return
+      fi
     else
-      chmod 0755 "$file"
+      echo "Could not download PPM: 'wget' or 'curl' not found."
+      return
     fi
+    chmod 0755 "$file"
   fi
   cp -av "subprojects/ppm/libraries" "${data_dir}/"
   cp -av "subprojects/ppm/plugins/plugin_manager" "${data_dir}/plugins/"


### PR DESCRIPTION
We use wget to download pre-built ppm binaries from the plugin-manager repository but on macOS wget is not available by default so we fallback into curl. Also, the platform needs to be overwritten to darwin and the arm64 arch to aarch64.