### PR TITLE
Trim double quotes from path on core:open-file

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -75,6 +75,8 @@ local function open_file(use_dialog, label, selection_callback)
       )
     end,
     validate = function(text)
+      -- strip double quotes in case the user pasted the path
+      text = text:gsub("^\"*(.-)\"*$", "%1", 1)
       filename = root_dir == core.root_project().path and
         core.root_project():absolute_path(
           common.home_expand(text)


### PR DESCRIPTION
Allows opening a path like "/path/to/file" that may have been copied from a file explorer, etc...

Corrects one of the issues on #468