### PR TITLE
Change meson cross files to ini added zig conf

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -4,7 +4,7 @@ This folder contains resources that is used for building or packaging the projec
 
 ### Build
 
-- `cross/*.txt`: Meson [cross files][1] for cross-compiling pragtical on other platforms.
+- `cross/*.ini`: Meson [cross files][1] for cross-compiling pragtical on other platforms.
 
 ### Packaging
 

--- a/resources/cross/linux-aarch64.ini
+++ b/resources/cross/linux-aarch64.ini
@@ -1,5 +1,5 @@
 # cross file for Linux aarch64.
-# use this file by running meson setup --cross-file resources/cross/linux-aarch64.txt <builddir>
+# use this file by running meson setup --cross-file resources/cross/linux-aarch64.ini <builddir>
 
 [host_machine]
 system = 'linux'

--- a/resources/cross/linux-zig-x86_64.ini
+++ b/resources/cross/linux-zig-x86_64.ini
@@ -1,0 +1,18 @@
+# cross file for Linux x86_64 with Zig.
+# use this file by running meson setup --cross-file resources/cross/linux-zig-x86_64.ini <builddir>
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[binaries]
+c = ['zig', 'cc', '-target', 'x86_64-linux-gnu.2.17.0']
+cpp = ['zig', 'c++', '-target', 'x86_64-linux-gnu.2.17.0']
+ar = ['sh', '@GLOBAL_SOURCE_ROOT@/scripts/zig-ar.sh']
+ranlib = ['zig', 'ranlib']
+objcopy = ['zig', 'objcopy']
+strip = 'strip'
+cmake = 'cmake'
+pkg-config = 'pkg-config'

--- a/resources/cross/macos-arm64.ini
+++ b/resources/cross/macos-arm64.ini
@@ -1,5 +1,5 @@
 # cross file for compiling on MacOS ARM (Apple Sillicon).
-# use this file by running meson setup --cross-file resources/cross/macos_arm64.txt <builddir>
+# use this file by running meson setup --cross-file resources/cross/macos_arm64.ini <builddir>
 
 [host_machine]
 system = 'darwin'

--- a/resources/cross/unknown-wasm32.ini
+++ b/resources/cross/unknown-wasm32.ini
@@ -1,5 +1,5 @@
 # Cross file for WASM.
-# Use this file by running meson setup --cross-file resources/cross/wasm.txt <builddir>
+# Use this file by running meson setup --cross-file resources/cross/wasm.ini <builddir>
 # You can import other cross files after this one to override the options.
 
 [constants]

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -163,7 +163,7 @@ main() {
   cross="${cross:-$CROSS_ARCH}"
   if [[ -n "$cross" ]]; then
     arch="${cross_arch}"
-    cross_file=("--cross-file" "resources/cross/linux-${arch}.txt")
+    cross_file=("--cross-file" "resources/cross/linux-${arch}.ini")
     # check if required cross-compile tools installed
     if ! which "$arch-linux-gnu-gcc" > /dev/null; then
       echo "Cross-compiler for '$arch' not found, please install '$arch-linux-gnu-gcc'"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -155,7 +155,7 @@ main() {
     fi
     platform="${cross_platform:-$platform}"
     arch="${cross_arch:-$arch}"
-    cross_file=("--cross-file" "${cross_file:-resources/cross/$platform-$arch.txt}")
+    cross_file=("--cross-file" "${cross_file:-resources/cross/$platform-$arch.ini}")
     # reload build_dir because platform and arch might change
     build_dir="$(get_default_build_dir "$platform" "$arch")"
   fi

--- a/scripts/zig-ar.sh
+++ b/scripts/zig-ar.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+# Meson passes "T" to ar when creating thin archives.
+# A normal archive stores the object file contents inside the .a file, while
+# a thin archive only stores references to the original .o files.
+# Zig's linker later rejects those thin archives in this build, so strip the
+# thin-archive flag here and let zig ar produce a regular archive instead.
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    *T*)
+      first_arg=$(printf '%s' "$1" | tr -d 'T')
+      shift
+      set -- "$first_arg" "$@"
+      ;;
+  esac
+fi
+
+exec zig ar "$@"


### PR DESCRIPTION
Changes the cross file extensions to .ini to allow for syntax highlighting and added a new zig cross file that allows targeting an older glib version that allows targetting older Linux distros.