### PR TITLE
Add MarkdownView preview support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ See the [licenses] directory for details on licenses used by the required depend
 [Get Plugins]:        https://github.com/pragtical/plugins
 [Get Color Themes]:   https://github.com/pragtical/colors
 [plugins repository]: https://github.com/pragtical/plugins
-[changelog]:          https://github.com/pragtical/pragtical/blob/master/changelog.md
+[changelog]:          changelog.md
 [LICENSE]:            LICENSE
 [licenses]:           licenses/licenses.md

--- a/data/core/command.lua
+++ b/data/core/command.lua
@@ -178,7 +178,7 @@ end
 function command.add_defaults()
   local reg = {
     "core", "root", "command", "doc", "findreplace",
-    "files", "dialog", "log", "statusbar", "image"
+    "files", "dialog", "log", "statusbar", "image", "markdown"
   }
   for _, name in ipairs(reg) do
     require("core.commands." .. name)

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -4,12 +4,21 @@ local common = require "core.common"
 local command = require "core.command"
 local config = require "core.config"
 local keymap = require "core.keymap"
+local DocView = require "core.docview"
+local MarkdownView = require "core.markdownview"
 local LogView = require "core.logview"
 
 
 local previous_win_mode = "normal"
 local previous_win_pos = core.window_size
 local restore_title_view = false
+
+local markdown_preview_split_directions = {
+  bottom = "down",
+  top = "up",
+  left = "left",
+  right = "right"
+}
 
 local function suggest_directory(text)
   text = common.home_expand(text)
@@ -357,4 +366,45 @@ command.add(nil, {
   ["core:view-website"] = function()
     common.open_in_system("https://pragtical.dev")
   end,
+})
+
+command.add(function()
+  if not core.active_view:extends(DocView) then
+    return false
+  end
+  local dv = core.active_view
+  return MarkdownView.is_supported(dv.doc.filename or ""), dv
+end, {
+  ["core:preview-markdown"] = function(dv)
+    local doc = dv.doc
+
+    for _, view in ipairs(core.root_view.root_node:get_children()) do
+      if view:extends(MarkdownView) and view.doc == doc then
+        local node = core.root_view.root_node:get_node_for_view(view)
+        if node then
+          node:set_active_view(view)
+        end
+        return
+      end
+    end
+
+    local node = core.root_view.root_node:get_node_for_view(dv)
+      or core.root_view:get_active_node_default()
+    local view = MarkdownView({
+      doc = doc,
+      path = doc.abs_filename,
+      title = doc:get_name()
+    })
+    local mode = config.markdown_preview_mode
+    local split_direction = markdown_preview_split_directions[mode]
+    if mode == "newtab" then
+      node:add_view(view)
+    else
+      (split_direction and node or core.root_view:get_active_node_default()):split(
+        split_direction or "right",
+        view
+      )
+    end
+    core.root_view.root_node:update_layout()
+  end
 })

--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -2,23 +2,13 @@ local core = require "core"
 local config = require "core.config"
 local common = require "core.common"
 local command = require "core.command"
-local config = require "core.config"
 local keymap = require "core.keymap"
-local DocView = require "core.docview"
-local MarkdownView = require "core.markdownview"
 local LogView = require "core.logview"
 
 
 local previous_win_mode = "normal"
 local previous_win_pos = core.window_size
 local restore_title_view = false
-
-local markdown_preview_split_directions = {
-  bottom = "down",
-  top = "up",
-  left = "left",
-  right = "right"
-}
 
 local function suggest_directory(text)
   text = common.home_expand(text)
@@ -366,45 +356,4 @@ command.add(nil, {
   ["core:view-website"] = function()
     common.open_in_system("https://pragtical.dev")
   end,
-})
-
-command.add(function()
-  if not core.active_view:extends(DocView) then
-    return false
-  end
-  local dv = core.active_view
-  return MarkdownView.is_supported(dv.doc.filename or ""), dv
-end, {
-  ["core:preview-markdown"] = function(dv)
-    local doc = dv.doc
-
-    for _, view in ipairs(core.root_view.root_node:get_children()) do
-      if view:extends(MarkdownView) and view.doc == doc then
-        local node = core.root_view.root_node:get_node_for_view(view)
-        if node then
-          node:set_active_view(view)
-        end
-        return
-      end
-    end
-
-    local node = core.root_view.root_node:get_node_for_view(dv)
-      or core.root_view:get_active_node_default()
-    local view = MarkdownView({
-      doc = doc,
-      path = doc.abs_filename,
-      title = doc:get_name()
-    })
-    local mode = config.markdown_preview_mode
-    local split_direction = markdown_preview_split_directions[mode]
-    if mode == "newtab" then
-      node:add_view(view)
-    else
-      (split_direction and node or core.root_view:get_active_node_default()):split(
-        split_direction or "right",
-        view
-      )
-    end
-    core.root_view.root_node:update_layout()
-  end
 })

--- a/data/core/commands/markdown.lua
+++ b/data/core/commands/markdown.lua
@@ -1,0 +1,132 @@
+local core = require "core"
+local command = require "core.command"
+local config = require "core.config"
+local DocView = require "core.docview"
+local MarkdownView = require "core.markdownview"
+
+local markdown_preview_split_directions = {
+  bottom = "down",
+  top = "up",
+  left = "left",
+  right = "right"
+}
+
+local markdown_raw_split_directions = {
+  bottom = "up",
+  top = "down",
+  left = "right",
+  right = "left"
+}
+
+local function get_doc_preview(dv)
+  local doc = dv.doc
+  for _, view in ipairs(core.root_view.root_node:get_children()) do
+    if view:extends(MarkdownView) and view.linked_doc == doc then
+      return view
+    end
+  end
+end
+
+local function get_raw_doc_view(path)
+  for _, view in ipairs(core.root_view.root_node:get_children()) do
+    if view:extends(DocView) and view.doc and view.doc.abs_filename == path then
+      return view
+    end
+  end
+end
+
+local function bind_preview_to_raw_view(mv, raw_view)
+  if not (raw_view and raw_view:extends(DocView)) then
+    return
+  end
+  mv.linked_doc = raw_view.doc
+  mv.path = raw_view.doc.abs_filename
+  mv.title = raw_view.doc:get_name()
+  mv:refresh_from_doc()
+end
+
+local function open_raw_doc_view(path, mv)
+  local doc = core.open_doc(path)
+  local node = core.root_view.root_node:get_node_for_view(mv)
+    or core.root_view:get_active_node_default()
+  if config.markdown_preview_mode == "newtab" then
+    for _, view in ipairs(node.views) do
+      if view:extends(DocView) and view.doc == doc then
+        node:set_active_view(view)
+        return view
+      end
+    end
+    local view = DocView(doc)
+    node:add_view(view)
+    core.root_view.root_node:update_layout()
+    view:scroll_to_line(view.doc:get_selection(), true, true)
+    return view
+  end
+
+  local view = DocView(doc)
+  local split_direction = markdown_raw_split_directions[config.markdown_preview_mode] or "left"
+  node:split(split_direction, view)
+  core.root_view.root_node:update_layout()
+  view:scroll_to_line(view.doc:get_selection(), true, true)
+  return view
+end
+
+command.add(function()
+  if not core.active_view:extends(DocView) then
+    return false
+  end
+  local dv = core.active_view
+  return MarkdownView.is_supported(dv.doc.filename or ""), dv
+end, {
+  ["markdown-view:preview"] = function(dv)
+    local view = get_doc_preview(dv)
+    if view then
+      local node = core.root_view.root_node:get_node_for_view(view)
+      if node then
+        node:set_active_view(view)
+      end
+      return
+    end
+
+    local node = core.root_view.root_node:get_node_for_view(dv)
+      or core.root_view:get_active_node_default()
+    view = MarkdownView({
+      linked_doc = dv.doc,
+      path = dv.doc.abs_filename,
+      title = dv.doc:get_name()
+    })
+    local mode = config.markdown_preview_mode
+    local split_direction = markdown_preview_split_directions[mode]
+    if mode == "newtab" then
+      node:add_view(view)
+    else
+      (split_direction and node or core.root_view:get_active_node_default()):split(
+        split_direction or "right",
+        view
+      )
+    end
+    core.root_view.root_node:update_layout()
+  end
+})
+
+command.add(function()
+  if not core.active_view:extends(MarkdownView) then
+    return false
+  end
+  local mv = core.active_view
+  local path = mv.path
+  return type(path) == "string" and path ~= "" and MarkdownView.is_supported(path), mv
+end, {
+  ["markdown-view:view-raw"] = function(mv)
+    local raw_view = get_raw_doc_view(mv.path)
+    if raw_view then
+      local node = core.root_view.root_node:get_node_for_view(raw_view)
+      if node then
+        node:set_active_view(raw_view)
+      end
+    else
+      raw_view = open_raw_doc_view(mv.path, mv)
+    end
+    bind_preview_to_raw_view(mv, raw_view)
+  end
+})

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -40,7 +40,7 @@ config.images_background_mode = "grid"
 ---| "top"
 ---| "left"
 
----How markdown previews opened by `core:preview-markdown` should be placed
+---How markdown previews opened by `markdown-view:preview` should be placed
 ---relative to the current document.
 ---
 ---Defaults to "right".

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -33,6 +33,20 @@ config.draw_stats = false
 ---@type "grid" | "solid" | "none"
 config.images_background_mode = "grid"
 
+---@alias config.markdownpreviewmode
+---| "right"
+---| "newtab"
+---| "bottom"
+---| "top"
+---| "left"
+
+---How markdown previews opened by `core:preview-markdown` should be placed
+---relative to the current document.
+---
+---Defaults to "right".
+---@type config.markdownpreviewmode
+config.markdown_preview_mode = "right"
+
 ---The color used for the background of transparent images when the
 ---background mode is set to solid.
 ---

--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -15,6 +15,7 @@ local CommandView
 local NagView
 local DocView
 local ImageView
+local MarkdownView
 local Doc
 local Project
 
@@ -359,6 +360,7 @@ function core.init()
   Project = require "core.project"
   DocView = require "core.docview"
   ImageView = require "core.imageview"
+  MarkdownView = require "core.markdownview"
   Doc = require "core.doc"
 
   -- apply to default color scheme
@@ -1223,6 +1225,33 @@ function core.open_image(filename)
         view.errmsg and " Error: " .. view.errmsg or ""
       )
     end
+  end
+end
+
+
+---@param filename string
+---@return core.markdownview? markdown_view
+function core.open_markdown(filename)
+  ---@cast MarkdownView core.markdownview
+  if MarkdownView.is_supported(filename) then
+    local file = io.open(filename)
+    if not file then
+      return false
+    end
+    file:close()
+
+    local node = core.root_view:get_active_node_default()
+    for i, view in ipairs(node.views) do
+      if view.path == filename then
+        node:set_active_view(node.views[i])
+        return view
+      end
+    end
+
+    local view = MarkdownView(filename)
+    node:add_view(view)
+    core.root_view.root_node:update_layout()
+    return view
   end
 end
 

--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -6,7 +6,7 @@ local function keymap_macos(keymap)
     ["cmd+,"] = "core:open-user-module",
     ["cmd+shift+c"] = "core:change-project-folder",
     ["cmd+shift+o"] = "core:open-project-folder",
-    ["cmd+option+m"] = "core:preview-markdown",
+    ["cmd+option+m"] = "markdown-view:preview",
     ["cmd+option+r"] = "core:restart",
     ["cmd+ctrl+return"] = "core:toggle-fullscreen",
 

--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -6,6 +6,7 @@ local function keymap_macos(keymap)
     ["cmd+,"] = "core:open-user-module",
     ["cmd+shift+c"] = "core:change-project-folder",
     ["cmd+shift+o"] = "core:open-project-folder",
+    ["cmd+option+m"] = "core:preview-markdown",
     ["cmd+option+r"] = "core:restart",
     ["cmd+ctrl+return"] = "core:toggle-fullscreen",
 

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -296,7 +296,7 @@ keymap.add_direct {
   ["ctrl+,"] = "core:open-user-module",
   ["ctrl+shift+c"] = "core:change-project-folder",
   ["ctrl+shift+o"] = "core:open-project-folder",
-  ["ctrl+alt+m"] = "core:preview-markdown",
+  ["ctrl+alt+m"] = "markdown-view:preview",
   ["ctrl+alt+r"] = "core:restart",
   ["alt+return"] = "core:toggle-fullscreen",
   ["f11"] = "core:toggle-fullscreen",

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -296,6 +296,7 @@ keymap.add_direct {
   ["ctrl+,"] = "core:open-user-module",
   ["ctrl+shift+c"] = "core:change-project-folder",
   ["ctrl+shift+o"] = "core:open-project-folder",
+  ["ctrl+alt+m"] = "core:preview-markdown",
   ["ctrl+alt+r"] = "core:restart",
   ["alt+return"] = "core:toggle-fullscreen",
   ["f11"] = "core:toggle-fullscreen",

--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -1,0 +1,3268 @@
+local core = require "core"
+local common = require "core.common"
+local config = require "core.config"
+local ImageView = require "core.imageview"
+local style = require "core.style"
+local syntax = require "core.syntax"
+local tokenizer = require "core.tokenizer"
+local View = require "core.view"
+local http
+
+local INLINE_CODE_PADDING_X = common.round(4 * SCALE)
+local INLINE_CODE_PADDING_Y = common.round(1 * SCALE)
+local BLOCK_PADDING_X = style.padding.x
+local BLOCK_PADDING_Y = style.padding.y
+local LIST_INDENT = common.round(18 * SCALE)
+local QUOTE_BAR_WIDTH = math.max(style.divider_size * 2, common.round(4 * SCALE))
+local QUOTE_GAP = style.padding.x
+local RULE_HEIGHT = math.max(style.divider_size, 1)
+local RULE_GAP = common.round(10 * SCALE)
+local BLOCK_SPACING = style.padding.y
+local PARAGRAPH_SPACING = BLOCK_SPACING * 2
+local CHECKBOX_SIZE_RATIO = 0.75
+local IMAGE_ROW_PADDING_Y = style.padding.y
+local IMAGE_CACHE_DIR = USERDIR .. PATHSEP .. "cache"
+local TABLE_BORDER = math.max(style.divider_size, 1)
+local TABLE_CELL_PADDING_X = style.padding.x
+local TABLE_CELL_PADDING_Y = math.max(common.round(style.padding.y / 2), 1)
+local CODE_FENCE_ALIASES = {
+  bash = "sh",
+  caddyfile = "caddyfile",
+  c = "c",
+  ["c#"] = "cs",
+  cc = "cpp",
+  cmake = "cmake",
+  cpp = "cpp",
+  ["c++"] = "cpp",
+  cxx = "cpp",
+  css = "css",
+  d = "d",
+  dart = "dart",
+  go = "go",
+  glsl = "glsl",
+  h = "cpp",
+  hpp = "cpp",
+  html = "html",
+  ini = "ini",
+  java = "java",
+  javascript = "js",
+  js = "js",
+  json = "json",
+  julia = "jl",
+  liquid = "liquid",
+  lua = "lua",
+  markdown = "md",
+  md = "md",
+  mjs = "js",
+  moon = "moon",
+  nim = "nim",
+  nix = "nix",
+  perl = "pl",
+  php = "php",
+  py = "py",
+  python = "py",
+  rescript = "res",
+  ruby = "rb",
+  rust = "rs",
+  sh = "sh",
+  toml = "toml",
+  typescript = "ts",
+  v = "v",
+  xml = "xml",
+  yaml = "yaml"
+}
+local CODE_FENCE_SYNTAX_CACHE = {}
+local parse_inline
+local parse_inline_lines
+local extract_single_image
+
+local function make_style_color(key, fallback)
+  return {
+    __markdown_style_color = true,
+    kind = "style",
+    key = key,
+    fallback = fallback
+  }
+end
+
+local function make_syntax_color(key, fallback)
+  return {
+    __markdown_style_color = true,
+    kind = "syntax",
+    key = key,
+    fallback = fallback
+  }
+end
+
+local COLOR_TEXT = make_style_color("text")
+local COLOR_ACCENT = make_style_color("accent", COLOR_TEXT)
+local COLOR_DIM = make_style_color("dim", COLOR_TEXT)
+local COLOR_BACKGROUND = make_style_color("background")
+local COLOR_BACKGROUND2 = make_style_color("background2", COLOR_BACKGROUND)
+local COLOR_DIVIDER = make_style_color("divider")
+local COLOR_LINK = make_syntax_color("function", COLOR_ACCENT)
+
+local function resolve_color(color)
+  if not color or not color.__markdown_style_color then
+    return color
+  end
+
+  local resolved
+  if color.kind == "style" then
+    resolved = style[color.key]
+  else
+    resolved = style.syntax and style.syntax[color.key]
+  end
+
+  if resolved then
+    return resolved
+  end
+
+  return resolve_color(color.fallback)
+end
+
+---@class core.markdownview.state
+---@field path string
+---@field scroll { x:number, y:number }
+
+---@class core.markdownview.source
+---@field doc core.doc?
+---@field path string?
+---@field text string?
+---@field title string?
+---@field name string?
+
+---@class core.markdownview : core.view
+---@overload fun(source?: string|table, title?: string):core.markdownview
+---@field super core.view
+---@field doc core.doc?
+---@field image_cache table<string,table>
+---@field path string?
+---@field title string?
+---@field text string
+---@field blocks table[]
+---@field references table<string,string>
+---@field footnotes table
+---@field layout table?
+---@field font_cache table?
+---@field last_doc_change_id integer?
+---@field hovered_link_url string?
+local MarkdownView = View:extend()
+
+function MarkdownView:__tostring() return "MarkdownView" end
+
+MarkdownView.resolve_color = resolve_color
+
+MarkdownView.context = "session"
+
+local function trim(text)
+  return (text:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function ltrim(text)
+  return (text:gsub("^%s+", ""))
+end
+
+local function rtrim(text)
+  return (text:gsub("%s+$", ""))
+end
+
+local function split_lines(text)
+  local lines = {}
+  text = (text or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
+  for line in (text .. "\n"):gmatch("(.-)\n") do
+    table.insert(lines, line)
+  end
+  if #lines == 0 then
+    lines[1] = ""
+  end
+  return lines
+end
+
+local function is_blank(line)
+  return line:match("^%s*$") ~= nil
+end
+
+local function is_rule(line)
+  local compact = line:gsub("%s+", "")
+  local char = compact:sub(1, 1)
+  if #compact < 3 or not (char == "-" or char == "*" or char == "_") then
+    return false
+  end
+  for i = 2, #compact do
+    if compact:sub(i, i) ~= char then
+      return false
+    end
+  end
+  return true
+end
+
+local function get_heading(line)
+  local marks, text = line:match("^%s*(#+)%s+(.-)%s*$")
+  if marks and #marks <= 6 then
+    return #marks, trim(text)
+  end
+end
+
+local function get_setext_heading_level(line)
+  local compact = trim(line):gsub("%s+", "")
+  local char = compact:sub(1, 1)
+  if #compact < 3 or not (char == "=" or char == "-") then
+    return nil
+  end
+  for i = 2, #compact do
+    if compact:sub(i, i) ~= char then
+      return nil
+    end
+  end
+  return char == "=" and 1 or 2
+end
+
+local function get_fence(line)
+  local marks, info = line:match("^%s*([`~][`~][`~]+)%s*(.-)%s*$")
+  if marks then
+    return marks:sub(1, 1), #marks, trim(info)
+  end
+end
+
+local function get_indentation_width(line)
+  local indent = line:match("^(%s*)") or ""
+  local width = 0
+  for i = 1, #indent do
+    local char = indent:sub(i, i)
+    if char == "\t" then
+      width = width + config.indent_size
+    else
+      width = width + 1
+    end
+  end
+  return width
+end
+
+local function get_visual_width(text)
+  local width = 0
+  for i = 1, #text do
+    local char = text:sub(i, i)
+    if char == "\t" then
+      width = width + (config.indent_size - (width % config.indent_size))
+    else
+      width = width + 1
+    end
+  end
+  return width
+end
+
+local function strip_indentation(line, width)
+  local i = 1
+  local consumed = 0
+  while i <= #line and consumed < width do
+    local char = line:sub(i, i)
+    if char == " " then
+      consumed = consumed + 1
+      i = i + 1
+    elseif char == "\t" then
+      local tab_width = config.indent_size - (consumed % config.indent_size)
+      if consumed + tab_width > width then
+        break
+      end
+      consumed = consumed + tab_width
+      i = i + 1
+    else
+      break
+    end
+  end
+  return line:sub(i)
+end
+
+local function strip_blockquote_prefix(line)
+  local stripped = line:gsub("^%s*>%s?", "", 1)
+  return stripped == line and nil or stripped
+end
+
+local function is_indented_code_line(line)
+  return not is_blank(line) and get_indentation_width(line) >= 4
+end
+
+local function get_definition_item(line)
+  local prefix, text = line:match("^(%s*:%s+)(.-)%s*$")
+  if prefix and text ~= "" then
+    return trim(text), get_indentation_width(prefix)
+  end
+end
+
+local function get_footnote_definition(line)
+  local prefix, id, text = line:match("^(%s*%[%^([^%]]+)%]:%s+)(.-)%s*$")
+  if prefix then
+    return trim(id), text, get_indentation_width(prefix)
+  end
+end
+
+local function get_list_item(line)
+  local indent = get_indentation_width(line)
+  local prefix, checked, text = line:match("^(%s*[-+*]%s+)%[([ xX])%]%s+(.-)%s*$")
+  if prefix and text then
+    return {
+      type = "unordered_list",
+      text = trim(text),
+      checked = checked ~= " ",
+      raw_indent = indent,
+      content_indent = get_visual_width(prefix .. "[ ] ")
+    }
+  end
+
+  prefix, text = line:match("^(%s*[-+*]%s+)(.-)%s*$")
+  if prefix and text then
+    return {
+      type = "unordered_list",
+      text = trim(text),
+      raw_indent = indent,
+      content_indent = get_visual_width(prefix)
+    }
+  end
+
+  prefix, text = line:match("^(%s*%d+[.)]%s+)(.-)%s*$")
+  local index = line:match("^%s*(%d+)[.)]%s+")
+  if prefix and text and index then
+    return {
+      type = "ordered_list",
+      index = tonumber(index),
+      text = trim(text),
+      raw_indent = indent,
+      content_indent = get_visual_width(prefix)
+    }
+  end
+end
+
+local function get_unordered_item(line)
+  local item = get_list_item(line)
+  if item and item.type == "unordered_list" then
+    return item.text, item.checked, item.raw_indent
+  end
+end
+
+local function get_ordered_item(line)
+  local item = get_list_item(line)
+  if item and item.type == "ordered_list" then
+    return item.index, item.text, item.raw_indent
+  end
+end
+
+local function is_blockquote(line)
+  return line:match("^%s*>") ~= nil
+end
+
+local function is_html_comment_start(line)
+  return trim(line):match("^<!%-%-") ~= nil
+end
+
+local function is_html_comment_end(line)
+  return line:find("-->", 1, true) ~= nil
+end
+
+local function is_block_start(line)
+  return get_fence(line)
+    or get_heading(line)
+    or is_rule(line)
+    or get_list_item(line)
+    or is_blockquote(line)
+    or get_definition_item(line)
+    or get_footnote_definition(line)
+    or is_html_comment_start(line)
+end
+
+local function append_wrapped_line(target, text)
+  if text ~= "" then
+    target[#target + 1] = trim(text)
+  end
+end
+
+local function normalize_link_label(label)
+  return trim(label or ""):lower():gsub("%s+", " ")
+end
+
+local function normalize_link_url(url)
+  url = trim(url or "")
+  return url:match("^<(.+)>$") or url
+end
+
+local function find_matching(text, start_index, open_char, close_char)
+  local depth = 0
+  local i = start_index
+  while i <= #text do
+    local char = text:sub(i, i)
+    if char == "\\" and i < #text then
+      i = i + 2
+    else
+      if char == open_char then
+        depth = depth + 1
+      elseif char == close_char then
+        depth = depth - 1
+        if depth == 0 then
+          return i
+        end
+      end
+      i = i + 1
+    end
+  end
+end
+
+local function skip_spaces(text, index)
+  while index <= #text and text:sub(index, index):match("%s") do
+    index = index + 1
+  end
+  return index
+end
+
+local function parse_quoted_title(text, index)
+  local opener = text:sub(index, index)
+  local closer = opener == "(" and ")" or opener
+  if opener == "" or (opener ~= '"' and opener ~= "'" and opener ~= "(") then
+    return nil
+  end
+
+  local i = index + 1
+  local start = i
+  while i <= #text do
+    local char = text:sub(i, i)
+    if char == "\\" and i < #text then
+      i = i + 2
+    elseif char == closer then
+      return text:sub(start, i - 1), i + 1
+    else
+      i = i + 1
+    end
+  end
+end
+
+local function parse_link_destination(text, index)
+  index = skip_spaces(text, index)
+  if index > #text then
+    return nil
+  end
+
+  if text:sub(index, index) == "<" then
+    local close = text:find(">", index + 1, true)
+    if not close then
+      return nil
+    end
+    return normalize_link_url(text:sub(index + 1, close - 1)), close + 1
+  end
+
+  local start = index
+  local depth = 0
+  while index <= #text do
+    local char = text:sub(index, index)
+    if char == "\\" and index < #text then
+      index = index + 2
+    elseif char == "(" then
+      depth = depth + 1
+      index = index + 1
+    elseif char == ")" then
+      if depth == 0 then
+        break
+      end
+      depth = depth - 1
+      index = index + 1
+    elseif char:match("%s") and depth == 0 then
+      break
+    else
+      index = index + 1
+    end
+  end
+
+  if index == start then
+    return nil
+  end
+
+  return normalize_link_url(text:sub(start, index - 1)), index
+end
+
+local function parse_parenthesized_target(text, open_index)
+  local url, index = parse_link_destination(text, open_index + 1)
+  if not url then
+    return nil
+  end
+
+  index = skip_spaces(text, index)
+  local title
+  if index <= #text then
+    local char = text:sub(index, index)
+    if char == '"' or char == "'" or char == "(" then
+      title, index = parse_quoted_title(text, index)
+      if not title then
+        return nil
+      end
+      index = skip_spaces(text, index)
+    end
+  end
+
+  if text:sub(index, index) ~= ")" then
+    return nil
+  end
+
+  return url, title, index
+end
+
+local function parse_reference_target(text)
+  local url, index = parse_link_destination(text, 1)
+  if not url then
+    return nil
+  end
+
+  index = skip_spaces(text, index)
+  local title
+  if index <= #text then
+    title, index = parse_quoted_title(text, index)
+    if not title then
+      return nil
+    end
+    index = skip_spaces(text, index)
+  end
+
+  if index <= #text then
+    return nil
+  end
+  return url, title
+end
+
+local function parse_image_reference(text, references)
+  if text:sub(1, 2) ~= "![" then
+    return nil
+  end
+
+  local close = find_matching(text, 2, "[", "]")
+  if not close then
+    return nil
+  end
+
+  local alt = text:sub(3, close - 1)
+  local next_char = text:sub(close + 1, close + 1)
+  if next_char == "(" then
+    local parsed_url, _, finish = parse_parenthesized_target(text, close + 1)
+    if parsed_url and finish == #text then
+      return alt, parsed_url
+    end
+  elseif next_char == "[" then
+    local ref_close = find_matching(text, close + 1, "[", "]")
+    if ref_close == #text then
+      local ref = text:sub(close + 2, ref_close - 1)
+      local url = references[normalize_link_label(ref ~= "" and ref or alt)]
+      if url then
+        return alt, url
+      end
+    end
+  elseif close == #text then
+    local url = references[normalize_link_label(alt)]
+    if url then
+      return alt, url
+    end
+  end
+end
+
+local function parse_link_reference(text, references)
+  if text:sub(1, 1) ~= "[" then
+    return nil
+  end
+
+  local close = find_matching(text, 1, "[", "]")
+  if not close then
+    return nil
+  end
+
+  local label = text:sub(2, close - 1)
+  local next_char = text:sub(close + 1, close + 1)
+  if next_char == "(" then
+    local url, _, finish = parse_parenthesized_target(text, close + 1)
+    if url and finish == #text then
+      return label, url
+    end
+  elseif next_char == "[" then
+    local ref_close = find_matching(text, close + 1, "[", "]")
+    if ref_close == #text then
+      local ref = text:sub(close + 2, ref_close - 1)
+      local url = references[normalize_link_label(ref ~= "" and ref or label)]
+      if url then
+        return label, url
+      end
+    end
+  elseif close == #text then
+    local url = references[normalize_link_label(label)]
+    if url then
+      return label, url
+    end
+  end
+end
+
+local function parse_linked_image_reference(text, references)
+  local inner, link_url = parse_link_reference(text, references)
+  if not inner or not link_url then
+    return
+  end
+
+  local alt, image_url = parse_image_reference(inner, references)
+  if alt and image_url then
+    return alt, image_url, link_url
+  end
+end
+
+local function parse_image_row(lines, references)
+  if #lines <= 1 then
+    return nil
+  end
+
+  local images = {}
+  for _, line in ipairs(lines) do
+    local alt, url, link_url = parse_linked_image_reference(line, references)
+    if url then
+      images[#images + 1] = {
+        alt = alt,
+        url = url,
+        link_url = link_url,
+        alignment = "left"
+      }
+    else
+      alt, url = parse_image_reference(line, references)
+      if not url then
+        return nil
+      end
+      images[#images + 1] = {
+        alt = alt,
+        url = url,
+        alignment = "left"
+      }
+    end
+  end
+
+  return images
+end
+
+local function split_table_row(line)
+  if not line or not line:find("|", 1, true) then
+    return nil
+  end
+
+  local text = trim(line)
+  if text == "" then
+    return nil
+  end
+
+  if text:sub(1, 1) == "|" then
+    text = text:sub(2)
+  end
+  if text:sub(-1) == "|" then
+    text = text:sub(1, -2)
+  end
+
+  local cells = {}
+  local current = {}
+  local i = 1
+  while i <= #text do
+    local char = text:sub(i, i)
+    if char == "\\" and text:sub(i + 1, i + 1) == "|" then
+      current[#current + 1] = "|"
+      i = i + 2
+    elseif char == "|" then
+      cells[#cells + 1] = trim(table.concat(current))
+      current = {}
+      i = i + 1
+    else
+      current[#current + 1] = char
+      i = i + 1
+    end
+  end
+
+  cells[#cells + 1] = trim(table.concat(current))
+  if #cells < 2 then
+    return nil
+  end
+  return cells
+end
+
+local function parse_table_alignments(line, columns)
+  local cells = split_table_row(line)
+  if not cells or #cells ~= columns then
+    return nil
+  end
+
+  local alignments = {}
+  for i, cell in ipairs(cells) do
+    local compact = trim(cell):gsub("%s+", "")
+    if not compact:match("^:?-+:?$") then
+      return nil
+    end
+    if compact:sub(1, 1) == ":" and compact:sub(-1) == ":" then
+      alignments[i] = "center"
+    elseif compact:sub(-1) == ":" then
+      alignments[i] = "right"
+    else
+      alignments[i] = "left"
+    end
+  end
+
+  return alignments
+end
+
+local function parse_table_block(lines, index)
+  local headers = split_table_row(lines[index])
+  if not headers then
+    return nil
+  end
+
+  local alignments = parse_table_alignments(lines[index + 1], #headers)
+  if not alignments then
+    return nil
+  end
+
+  local rows = {}
+  local i = index + 2
+  while i <= #lines do
+    if is_blank(lines[i]) then
+      break
+    end
+    local cells = split_table_row(lines[i])
+    if not cells or #cells ~= #headers then
+      break
+    end
+    rows[#rows + 1] = cells
+    i = i + 1
+  end
+
+  return {
+    type = "table",
+    headers = headers,
+    alignments = alignments,
+    rows = rows
+  }, i
+end
+
+local function parse_cell_content(text, references, footnotes)
+  local segments = parse_inline_lines({ text }, references, footnotes)
+  local image = extract_single_image(segments)
+  if image then
+    return {
+      type = "image",
+      text = text,
+      alt = image.alt,
+      url = image.url,
+      link_url = image.link_url
+    }
+  end
+
+  return {
+    type = "text",
+    text = text,
+    segments = segments
+  }
+end
+
+local function normalize_list_nesting(items)
+  local stack = {}
+
+  for _, item in ipairs(items) do
+    local indent = item.raw_indent or 0
+    while #stack > 0 and indent < stack[#stack] do
+      table.remove(stack)
+    end
+    if #stack == 0 or indent > stack[#stack] then
+      stack[#stack + 1] = indent
+    end
+    item.nesting = #stack - 1
+  end
+end
+
+local function hash_text(text)
+  local hash = 2166136261
+  for i = 1, #text do
+    hash = (hash * 16777619 + text:byte(i)) % 4294967296
+  end
+  return string.format("%08x", hash)
+end
+
+local function get_image_cache_path(url)
+  local normalized = url:match("^[^?#]+") or url
+  local ext = normalized:match("%.([%w]+)$")
+  if ext then
+    ext = ext:lower()
+  else
+    ext = "img"
+  end
+  return IMAGE_CACHE_DIR .. PATHSEP .. "markdown-image-" .. hash_text(url) .. "." .. ext
+end
+
+local function get_reference_definition(line)
+  local label, target = line:match("^%s*%[([^%]]+)%]:%s*(.-)%s*$")
+  if label and target then
+    local url = parse_reference_target(target)
+    if url then
+      return normalize_link_label(label), url
+    end
+  end
+end
+
+local function normalize_syntax_name(name)
+  return name:lower():gsub("[%W_]+", "")
+end
+
+local function get_code_fence_language(info)
+  local language = trim(info or ""):match("^[^%s]+")
+  if not language or language == "" then
+    return nil
+  end
+  language = language:lower()
+    :gsub("^language%-", "")
+    :gsub("^lang%-", "")
+  return CODE_FENCE_ALIASES[language] or language
+end
+
+local function resolve_code_fence_syntax(info)
+  local language = get_code_fence_language(info)
+  if not language then
+    return syntax.plain_text_syntax
+  end
+
+  local cached = CODE_FENCE_SYNTAX_CACHE[language]
+  if cached then
+    return cached
+  end
+
+  local resolved = syntax.get("codeblock." .. language)
+  if resolved == syntax.plain_text_syntax then
+    local normalized = normalize_syntax_name(language)
+    for _, item in ipairs(syntax.items) do
+      if normalize_syntax_name(item.name or "") == normalized then
+        resolved = item
+        break
+      end
+    end
+  end
+
+  CODE_FENCE_SYNTAX_CACHE[language] = resolved
+  return resolved
+end
+
+local function find_next_inline_marker(text, start_index)
+  for i = start_index, #text do
+    local char = text:sub(i, i)
+    if char == "\0" or char == "\\" or char == "!" or char == "*" or char == "_" or char == "~" or char == "`" or char == "[" or char == "<" then
+      return i
+    end
+  end
+end
+
+local function find_next_plain_url(text, start_index)
+  local http_start = text:find("http://", start_index, true)
+  local https_start = text:find("https://", start_index, true)
+  if http_start and https_start then
+    return math.min(http_start, https_start)
+  end
+  return http_start or https_start
+end
+
+local function trim_plain_url(url)
+  while url:match("[.,!?:;]$") do
+    url = url:sub(1, -2)
+  end
+  return url
+end
+
+local function style_kind(opts)
+  if opts.bold and opts.italic then
+    return "bold_italic"
+  elseif opts.bold then
+    return "bold"
+  elseif opts.italic then
+    return "italic"
+  end
+  return "text"
+end
+
+local function is_word_char(char)
+  return char ~= "" and char:match("[%w]") ~= nil
+end
+
+local function is_intraword_underscore(text, index)
+  if text:sub(index, index) ~= "_" then
+    return false
+  end
+  return is_word_char(text:sub(index - 1, index - 1))
+    and is_word_char(text:sub(index + 1, index + 1))
+end
+
+local function copy_style(opts, updates)
+  local res = {
+    bold = opts.bold,
+    italic = opts.italic,
+    strikethrough = opts.strikethrough
+  }
+  if updates then
+    for k, v in pairs(updates) do
+      res[k] = v
+    end
+  end
+  return res
+end
+
+local function append_segments(segments, incoming)
+  for _, segment in ipairs(incoming) do
+    local last = segments[#segments]
+    if last
+      and not last.image_url
+      and not segment.image_url
+      and last.kind ~= "linebreak"
+      and segment.kind ~= "linebreak"
+      and last.kind == segment.kind
+      and last.url == segment.url
+      and last.strikethrough == segment.strikethrough
+    then
+      last.text = last.text .. segment.text
+    else
+      segments[#segments + 1] = segment
+    end
+  end
+end
+
+local function register_footnote_reference(footnotes, id)
+  if not (footnotes and footnotes.definitions[id]) then
+    return nil
+  end
+  if not footnotes.numbers[id] then
+    footnotes.order[#footnotes.order + 1] = id
+    footnotes.numbers[id] = #footnotes.order
+  end
+  return footnotes.numbers[id]
+end
+
+parse_inline = function(text, references, opts, footnotes)
+  local segments = {}
+  opts = opts or {}
+
+  local function push_segment(kind, value, url, extra)
+    if value == "" and kind ~= "linebreak" and not (extra and extra.image_url) then
+      return
+    end
+    local segment = {
+      kind = kind,
+      text = value,
+      url = url,
+      strikethrough = opts.strikethrough
+    }
+    if extra then
+      for k, v in pairs(extra) do
+        segment[k] = v
+      end
+    end
+    append_segments(segments, { segment })
+  end
+
+  local i = 1
+  while i <= #text do
+    local triple = text:sub(i, i + 2)
+    local double = text:sub(i, i + 1)
+    local char = text:sub(i, i)
+
+    if char == "\0" then
+      push_segment("linebreak", "")
+      i = i + 1
+    elseif char == "\\" then
+      if i < #text then
+        push_segment(style_kind(opts), text:sub(i + 1, i + 1))
+        i = i + 2
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif double == "~~" then
+      local j = text:find("~~", i + 2, true)
+      if j and j > i + 2 then
+        append_segments(
+          segments,
+          parse_inline(
+            text:sub(i + 2, j - 1),
+            references,
+            copy_style(opts, { strikethrough = true }),
+            footnotes
+          )
+        )
+        i = j + 2
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif char == "!" and text:sub(i + 1, i + 1) == "[" then
+      local close = find_matching(text, i + 1, "[", "]")
+      if close then
+        local alt = text:sub(i + 2, close - 1)
+        local next_char = text:sub(close + 1, close + 1)
+        local url
+        local title
+        local finish
+        if next_char == "(" then
+          url, title, finish = parse_parenthesized_target(text, close + 1)
+        elseif next_char == "[" then
+          local ref_close = find_matching(text, close + 1, "[", "]")
+          if ref_close then
+            local ref = text:sub(close + 2, ref_close - 1)
+            url = references[normalize_link_label(ref ~= "" and ref or alt)]
+            finish = ref_close
+          end
+        else
+          url = references[normalize_link_label(alt)]
+          finish = close
+        end
+        if url and finish then
+          push_segment("image", alt, nil, {
+            alt = alt,
+            image_url = url
+          })
+          i = finish + 1
+        else
+          push_segment(style_kind(opts), char)
+          i = i + 1
+        end
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif char == "!" then
+      push_segment(style_kind(opts), char)
+      i = i + 1
+    elseif is_intraword_underscore(text, i) then
+      push_segment(style_kind(opts), char)
+      i = i + 1
+    elseif char == "~" then
+      push_segment(style_kind(opts), char)
+      i = i + 1
+    elseif triple == "***" or triple == "___" then
+      local j = text:find(triple, i + 3, true)
+      if j and j > i + 3 then
+        append_segments(
+          segments,
+          parse_inline(
+            text:sub(i + 3, j - 1),
+            references,
+            copy_style(opts, { bold = true, italic = true }),
+            footnotes
+          )
+        )
+        i = j + 3
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif double == "**" or double == "__" then
+      local j = text:find(double, i + 2, true)
+      if j and j > i + 2 then
+        append_segments(
+          segments,
+          parse_inline(
+            text:sub(i + 2, j - 1),
+            references,
+            copy_style(opts, { bold = true }),
+            footnotes
+          )
+        )
+        i = j + 2
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif char == "*" or char == "_" then
+      local j = text:find(char, i + 1, true)
+      if j and j > i + 1 then
+        append_segments(
+          segments,
+          parse_inline(
+            text:sub(i + 1, j - 1),
+            references,
+            copy_style(opts, { italic = true }),
+            footnotes
+          )
+        )
+        i = j + 1
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif char == "`" then
+      local tick_count = 1
+      while text:sub(i + tick_count, i + tick_count) == "`" do
+        tick_count = tick_count + 1
+      end
+      local fence = string.rep("`", tick_count)
+      local j = text:find(fence, i + tick_count, true)
+      if j and j > i + tick_count - 1 then
+        local code = text:sub(i + tick_count, j - 1)
+        if code:match("^ .- $") and code:match("%S") then
+          code = code:sub(2, -2)
+        end
+        push_segment("code", code)
+        i = j + tick_count
+      else
+        push_segment("text", char)
+        i = i + 1
+      end
+    elseif char == "[" then
+      local close = find_matching(text, i, "[", "]")
+      local label = close and text:sub(i + 1, close - 1)
+      if close and text:sub(close + 1, close + 1) == "(" then
+        local url, title, finish = parse_parenthesized_target(text, close + 1)
+        if finish then
+          local label_segments = parse_inline(label, references, opts, footnotes)
+          for _, segment in ipairs(label_segments) do
+            segment.url = url
+          end
+          append_segments(segments, label_segments)
+          i = finish + 1
+        else
+          push_segment(style_kind(opts), char)
+          i = i + 1
+        end
+      elseif close and text:sub(close + 1, close + 1) == "[" then
+        local finish = find_matching(text, close + 1, "[", "]")
+        if finish then
+          local ref = text:sub(close + 2, finish - 1)
+          local url = references[normalize_link_label(ref ~= "" and ref or label)]
+          if url then
+            local label_segments = parse_inline(label, references, opts, footnotes)
+            for _, segment in ipairs(label_segments) do
+              segment.url = url
+            end
+            append_segments(segments, label_segments)
+            i = finish + 1
+          else
+            push_segment(style_kind(opts), char)
+            i = i + 1
+          end
+        else
+          push_segment(style_kind(opts), char)
+          i = i + 1
+        end
+      elseif close then
+        if label:sub(1, 1) == "^" then
+          local footnote_id = trim(label:sub(2))
+          local number = register_footnote_reference(footnotes, footnote_id)
+          if number then
+            push_segment(style_kind(opts), string.format("[%d]", number), "#footnote-" .. footnote_id, {
+              footnote_id = footnote_id,
+              footnote_number = number
+            })
+          else
+            push_segment(style_kind(opts), char)
+          end
+          i = close + 1
+        else
+          local url = references[normalize_link_label(label)]
+          if url then
+            local label_segments = parse_inline(label, references, opts, footnotes)
+            for _, segment in ipairs(label_segments) do
+              segment.url = url
+            end
+            append_segments(segments, label_segments)
+            i = close + 1
+          else
+            push_segment(style_kind(opts), char)
+            i = i + 1
+          end
+        end
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif char == "<" then
+      local close = text:find(">", i + 1, true)
+      if close then
+        local resource = text:sub(i + 1, close - 1)
+        local url = resource:match("^https?://%S+$")
+        if not url and resource:match("^[^%s@]+@[^%s@]+%.[^%s@]+$") then
+          url = "mailto:" .. resource
+        end
+        if url then
+          push_segment(style_kind(opts), resource, url)
+          i = close + 1
+        else
+          push_segment(style_kind(opts), char)
+          i = i + 1
+        end
+      else
+        push_segment(style_kind(opts), char)
+        i = i + 1
+      end
+    elseif text:sub(i):match("^https?://%S+") then
+      local url = trim_plain_url(text:sub(i):match("^(https?://%S+)"))
+      push_segment(style_kind(opts), url, url)
+      i = i + #url
+    else
+      local marker_index = find_next_inline_marker(text, i)
+      local url_index = find_next_plain_url(text, i)
+      local j
+      if marker_index and url_index then
+        j = math.min(marker_index, url_index)
+      else
+        j = marker_index or url_index
+      end
+
+      if j then
+        push_segment(style_kind(opts), text:sub(i, j - 1))
+        i = j
+      else
+        push_segment(style_kind(opts), text:sub(i))
+        break
+      end
+    end
+  end
+
+  return segments
+end
+
+parse_inline_lines = function(lines, references, footnotes, opts)
+  local combined = {}
+  for i, line in ipairs(lines) do
+    local text = ltrim(line)
+    local hard_break = false
+    if i < #lines and text:sub(-1) == "\\" then
+      hard_break = true
+      text = text:sub(1, -2)
+    elseif i < #lines and text:match("  +$") then
+      hard_break = true
+      text = rtrim(text)
+    end
+
+    combined[#combined + 1] = text
+    if i < #lines then
+      if hard_break then
+        combined[#combined + 1] = "\0"
+      else
+        combined[#combined + 1] = "\n"
+      end
+    end
+  end
+  return parse_inline(table.concat(combined), references, opts, footnotes)
+end
+
+local function get_first_text(blocks)
+  for _, block in ipairs(blocks or {}) do
+    if block.text and block.text ~= "" then
+      return block.text
+    elseif block.type == "quote" then
+      local nested = get_first_text(block.blocks)
+      if nested then
+        return nested
+      end
+    end
+  end
+end
+
+extract_single_image = function(segments)
+  if #segments == 1 and segments[1].kind == "image" then
+    return {
+      alt = segments[1].alt,
+      url = segments[1].image_url,
+      link_url = segments[1].url
+    }
+  end
+end
+
+local function parse_blocks_from_lines(lines, state)
+  local blocks = {}
+  local i = 1
+
+  local function parse_nested_lines(nested_lines)
+    if #nested_lines == 0 then
+      return {}
+    end
+    return parse_blocks_from_lines(nested_lines, state)
+  end
+
+  while i <= #lines do
+    local line = lines[i]
+
+    if is_blank(line) then
+      i = i + 1
+      goto continue
+    end
+
+    if is_html_comment_start(line) then
+      while i <= #lines do
+        if is_html_comment_end(lines[i]) then
+          i = i + 1
+          break
+        end
+        i = i + 1
+      end
+      goto continue
+    end
+
+    local footnote_id, footnote_text, footnote_indent = get_footnote_definition(line)
+    if footnote_id then
+      local definition_lines = { footnote_text }
+      local blank_pending = false
+      i = i + 1
+      while i <= #lines do
+        if is_blank(lines[i]) then
+          definition_lines[#definition_lines + 1] = ""
+          blank_pending = true
+          i = i + 1
+        else
+          local indent = get_indentation_width(lines[i])
+          local next_footnote = get_footnote_definition(lines[i])
+          if next_footnote and indent <= footnote_indent then
+            break
+          end
+          if indent < footnote_indent and (blank_pending or is_block_start(lines[i])) then
+            break
+          end
+          definition_lines[#definition_lines + 1] = strip_indentation(lines[i], math.min(indent, footnote_indent))
+          blank_pending = false
+          i = i + 1
+        end
+      end
+      state.footnote_definitions[footnote_id] = {
+        blocks = parse_nested_lines(definition_lines)
+      }
+      goto continue
+    end
+
+    local ref_label, ref_url = get_reference_definition(line)
+    if ref_label then
+      state.references[ref_label] = ref_url
+      i = i + 1
+      goto continue
+    end
+
+    local fence_char, fence_len, info = get_fence(line)
+    if fence_char then
+      local code_lines = {}
+      i = i + 1
+      while i <= #lines do
+        local close_char, close_len = get_fence(lines[i])
+        if close_char == fence_char and close_len >= fence_len then
+          break
+        end
+        code_lines[#code_lines + 1] = lines[i]
+        i = i + 1
+      end
+      blocks[#blocks + 1] = {
+        type = "code",
+        info = info,
+        lines = code_lines
+      }
+      i = i + 1
+      goto continue
+    end
+
+    if is_indented_code_line(line) then
+      local code_lines = {}
+      while i <= #lines do
+        if is_blank(lines[i]) then
+          code_lines[#code_lines + 1] = ""
+          i = i + 1
+        elseif is_indented_code_line(lines[i]) then
+          code_lines[#code_lines + 1] = strip_indentation(lines[i], 4)
+          i = i + 1
+        else
+          break
+        end
+      end
+      blocks[#blocks + 1] = {
+        type = "code",
+        lines = code_lines
+      }
+      goto continue
+    end
+
+    local table_block, next_index = parse_table_block(lines, i)
+    if table_block then
+      blocks[#blocks + 1] = table_block
+      i = next_index
+      goto continue
+    end
+
+    local level, heading = get_heading(line)
+    if level then
+      blocks[#blocks + 1] = {
+        type = "heading",
+        level = level,
+        text = heading,
+        lines = { heading }
+      }
+      i = i + 1
+      goto continue
+    end
+
+    if is_rule(line) then
+      blocks[#blocks + 1] = { type = "rule" }
+      i = i + 1
+      goto continue
+    end
+
+    if is_blockquote(line) then
+      local quote_lines = {}
+      while i <= #lines and is_blockquote(lines[i]) do
+        quote_lines[#quote_lines + 1] = strip_blockquote_prefix(lines[i]) or ""
+        i = i + 1
+      end
+      local nested_blocks = parse_nested_lines(quote_lines)
+      blocks[#blocks + 1] = {
+        type = "quote",
+        blocks = nested_blocks,
+        text = get_first_text(nested_blocks)
+      }
+      goto continue
+    end
+
+    local list_item = get_list_item(line)
+    if list_item then
+      local list_type = list_item.type
+      local start_index = list_item.index or 1
+      local items = {}
+      while i <= #lines do
+        local marker = get_list_item(lines[i])
+        if not marker or marker.raw_indent ~= list_item.raw_indent then
+          break
+        end
+        if marker.type ~= list_type then
+          break
+        end
+
+        local item_lines = { marker.text }
+        local item_i = i + 1
+        local blank_pending = false
+        while item_i <= #lines do
+          if is_blank(lines[item_i]) then
+            item_lines[#item_lines + 1] = ""
+            blank_pending = true
+            item_i = item_i + 1
+          else
+            local next_marker = get_list_item(lines[item_i])
+            local indent = get_indentation_width(lines[item_i])
+            if next_marker and next_marker.raw_indent == marker.raw_indent then
+              break
+            end
+            if indent <= marker.raw_indent and (blank_pending or is_block_start(lines[item_i])) then
+              break
+            end
+            if indent > 0 then
+              local strip_width = math.min(indent, marker.content_indent)
+              if next_marker then
+                strip_width = math.min(indent, marker.raw_indent + 2)
+              end
+              item_lines[#item_lines + 1] = strip_indentation(lines[item_i], strip_width)
+            else
+              item_lines[#item_lines + 1] = ltrim(lines[item_i])
+            end
+            blank_pending = false
+            item_i = item_i + 1
+          end
+        end
+
+        local nested_blocks = parse_nested_lines(item_lines)
+        items[#items + 1] = {
+          index = marker.index or (start_index + #items),
+          text = get_first_text(nested_blocks) or marker.text,
+          checked = marker.checked,
+          raw_indent = marker.raw_indent or 0,
+          blocks = nested_blocks
+        }
+        i = item_i
+      end
+      normalize_list_nesting(items)
+      blocks[#blocks + 1] = {
+        type = list_type,
+        items = items
+      }
+      goto continue
+    end
+
+    if not is_block_start(line) and get_definition_item(lines[i + 1] or "") then
+      local items = {}
+      while i <= #lines and not is_block_start(lines[i]) and get_definition_item(lines[i + 1] or "") do
+        local term = trim(lines[i])
+        i = i + 1
+        local definitions = {}
+        while i <= #lines do
+          local def_text, def_indent = get_definition_item(lines[i])
+          if not def_text then
+            break
+          end
+          local def_lines = { def_text }
+          local def_i = i + 1
+          local blank_pending = false
+          while def_i <= #lines do
+            if is_blank(lines[def_i]) then
+              def_lines[#def_lines + 1] = ""
+              blank_pending = true
+              def_i = def_i + 1
+            else
+              local next_def = get_definition_item(lines[def_i])
+              local indent = get_indentation_width(lines[def_i])
+              if next_def and indent <= def_indent then
+                break
+              end
+              if indent < def_indent and (blank_pending or is_block_start(lines[def_i])) then
+                break
+              end
+              def_lines[#def_lines + 1] = strip_indentation(lines[def_i], math.min(indent, def_indent))
+              blank_pending = false
+              def_i = def_i + 1
+            end
+          end
+          definitions[#definitions + 1] = {
+            blocks = parse_nested_lines(def_lines)
+          }
+          i = def_i
+        end
+        items[#items + 1] = {
+          term = term,
+          definitions = definitions
+        }
+      end
+      blocks[#blocks + 1] = {
+        type = "definition_list",
+        items = items
+      }
+      goto continue
+    end
+
+    local paragraph = {}
+    local setext_level
+    while i <= #lines and not is_blank(lines[i]) do
+      if #paragraph == 0 and get_setext_heading_level(lines[i + 1] or "") then
+        paragraph[#paragraph + 1] = trim(lines[i])
+        setext_level = get_setext_heading_level(lines[i + 1] or "")
+        i = i + 2
+        break
+      end
+      if #paragraph > 0 and is_block_start(lines[i]) then
+        break
+      end
+      paragraph[#paragraph + 1] = ltrim(lines[i])
+      i = i + 1
+      if is_block_start(lines[i] or "") then
+        break
+      end
+    end
+    local text = trim(table.concat(paragraph, " "))
+    if setext_level then
+      blocks[#blocks + 1] = {
+        type = "heading",
+        level = setext_level,
+        text = text,
+        lines = { text }
+      }
+    else
+      blocks[#blocks + 1] = {
+        type = "paragraph",
+        text = text,
+        lines = paragraph
+      }
+    end
+
+    ::continue::
+  end
+
+  return blocks
+end
+
+local function prepare_blocks(blocks, references, footnotes)
+  for _, block in ipairs(blocks) do
+    if block.type == "paragraph" then
+      local trimmed_lines = {}
+      for i, line in ipairs(block.lines or { block.text }) do
+        trimmed_lines[i] = trim(line)
+      end
+
+      local image_row = parse_image_row(trimmed_lines, references)
+      if image_row then
+        block.type = "image_row"
+        block.images = image_row
+      else
+        local paragraph_segments = parse_inline_lines(block.lines or { block.text }, references, footnotes)
+        local image = extract_single_image(paragraph_segments)
+        if image then
+          block.type = "image"
+          block.alt = image.alt
+          block.url = image.url
+          block.link_url = image.link_url
+          block.alignment = "left"
+        else
+          block.segments = paragraph_segments
+        end
+      end
+    elseif block.type == "heading" then
+      block.segments = parse_inline_lines(block.lines or { block.text }, references, footnotes)
+    elseif block.type == "quote" then
+      prepare_blocks(block.blocks or {}, references, footnotes)
+    elseif block.type == "table" then
+      for i, cell in ipairs(block.headers) do
+        block.headers[i] = parse_cell_content(cell, references, footnotes)
+      end
+      for row_index, row in ipairs(block.rows) do
+        for cell_index, cell in ipairs(row) do
+          row[cell_index] = parse_cell_content(cell, references, footnotes)
+        end
+        block.rows[row_index] = row
+      end
+    elseif block.type == "definition_list" then
+      for _, item in ipairs(block.items) do
+        item.term_segments = parse_inline_lines({ item.term }, references, footnotes)
+        for _, definition in ipairs(item.definitions) do
+          prepare_blocks(definition.blocks or {}, references, footnotes)
+        end
+      end
+    elseif block.items then
+      for _, item in ipairs(block.items) do
+        if item.blocks then
+          prepare_blocks(item.blocks, references, footnotes)
+        else
+          item.segments = parse_inline_lines({ item.text }, references, footnotes)
+        end
+      end
+    end
+  end
+end
+
+local function build_footnotes_block(footnotes)
+  if #footnotes.order == 0 then
+    return nil
+  end
+
+  local items = {}
+  for number, id in ipairs(footnotes.order) do
+    local definition = footnotes.definitions[id]
+    items[#items + 1] = {
+      id = id,
+      index = number,
+      text = get_first_text(definition.blocks) or id,
+      blocks = definition.blocks,
+      raw_indent = 0
+    }
+  end
+  return {
+    type = "footnotes",
+    items = items
+  }
+end
+
+local function parse_document(text)
+  local state = {
+    references = {},
+    footnote_definitions = {}
+  }
+  local blocks = parse_blocks_from_lines(split_lines(text), state)
+  local footnotes = {
+    definitions = state.footnote_definitions,
+    numbers = {},
+    order = {}
+  }
+  prepare_blocks(blocks, state.references, footnotes)
+  local footnotes_block = build_footnotes_block(footnotes)
+  if footnotes_block then
+    prepare_blocks({ footnotes_block }, state.references, footnotes)
+    blocks[#blocks + 1] = footnotes_block
+  end
+  return blocks, state.references, footnotes
+end
+
+---Parses markdown text into the intermediate block structure used by the view.
+---@param text string
+---@return table[]
+function MarkdownView.parse_blocks(text)
+  local blocks = parse_document(text)
+  return blocks
+end
+
+local function get_inline_image(entry, max_height)
+  if entry.status ~= "ready" or not entry.image then
+    return nil
+  end
+
+  local width, height = entry.image:get_size()
+  local scale = height > max_height and (max_height / height) or 1
+  local scaled_width = math.max(math.floor(width * scale), 1)
+  local scaled_height = math.max(math.floor(height * scale), 1)
+  entry.inline_cache = entry.inline_cache or {}
+  local cache_key = string.format("%dx%d", scaled_width, scaled_height)
+  if entry.inline_cache[cache_key] then
+    return entry.inline_cache[cache_key], scaled_width, scaled_height
+  end
+
+  local image
+  if scale == 1 then
+    image = entry.image
+  elseif entry.type == "svg" then
+    image = canvas.load_svg_image(entry.path, scaled_width, scaled_height)
+  else
+    image = entry.image:scaled(scaled_width, scaled_height, "nearest")
+  end
+  entry.inline_cache[cache_key] = image
+  return image, scaled_width, scaled_height
+end
+
+local function tokenize_segments(self, segments, fontset, base_color, accent_color)
+  local tokens = {}
+
+  local function add_token(segment, text, is_space)
+    if text == "" and segment.kind ~= "linebreak" and segment.kind ~= "image" then
+      return
+    end
+
+    local font = fontset.normal
+    local color = base_color
+    local background
+
+    if segment.kind == "bold" then
+      font = segment.strikethrough and fontset.bold_strikethrough or fontset.bold
+    elseif segment.kind == "italic" then
+      font = segment.strikethrough and fontset.italic_strikethrough or fontset.italic
+    elseif segment.kind == "bold_italic" then
+      font = segment.strikethrough and fontset.bold_italic_strikethrough or fontset.bold_italic
+    elseif segment.kind == "code" then
+      font = segment.strikethrough and fontset.code_strikethrough or fontset.code
+      background = COLOR_BACKGROUND2
+    elseif segment.strikethrough then
+      font = fontset.strikethrough
+    end
+
+    if segment.kind == "linebreak" then
+      tokens[#tokens + 1] = { type = "linebreak" }
+      return
+    end
+
+    if segment.kind == "image" and segment.image_url then
+      local entry = self:ensure_image_entry({
+        alt = segment.alt,
+        url = segment.image_url
+      })
+      if entry.status == "ready" then
+        local max_height = math.max(common.round(font:get_height() * config.line_height), font:get_height())
+        local image, width, height = get_inline_image(entry, max_height)
+        if image then
+          tokens[#tokens + 1] = {
+            type = "image",
+            image = image,
+            width = width,
+            height = height,
+            url = segment.url,
+            is_space = false
+          }
+          return
+        end
+      end
+      text = segment.alt ~= "" and segment.alt or segment.image_url
+      font = fontset.italic or font
+      color = COLOR_DIM
+      is_space = false
+    end
+
+    if segment.url then
+      color = COLOR_LINK
+    end
+
+    tokens[#tokens + 1] = {
+      text = text,
+      font = font,
+      color = color,
+      background = background,
+      url = segment.url,
+      is_space = is_space
+    }
+  end
+
+  for _, segment in ipairs(segments) do
+    if segment.kind == "linebreak" then
+      add_token(segment, "", false)
+      goto continue
+    elseif segment.kind == "image" then
+      add_token(segment, segment.alt, false)
+      goto continue
+    elseif segment.kind == "code" then
+      add_token(segment, segment.text, false)
+      goto continue
+    end
+    local text = segment.text
+    local pos = 1
+    while pos <= #text do
+      local s, e = text:find("%s+", pos)
+      if s == pos then
+        add_token(segment, text:sub(s, e), true)
+        pos = e + 1
+      elseif s then
+        add_token(segment, text:sub(pos, s - 1), false)
+        pos = s
+      else
+        add_token(segment, text:sub(pos), false)
+        break
+      end
+    end
+    ::continue::
+  end
+
+  return tokens
+end
+
+local function append_line(lines, line, max_width)
+  while line.fragments[#line.fragments] and line.fragments[#line.fragments].is_space do
+    line.width = line.width - line.fragments[#line.fragments].width
+    table.remove(line.fragments)
+  end
+
+  if #line.fragments == 0 then
+    line.width = line.indent
+  end
+
+  local height = math.max(common.round(line.font_height * config.line_height), line.font_height)
+  lines[#lines + 1] = {
+    indent = line.indent,
+    width = math.max(line.width - line.indent, 0),
+    height = height,
+    fragments = line.fragments
+  }
+
+  return {
+    indent = line.next_indent,
+    width = line.next_indent,
+    font_height = line.default_font_height,
+    default_font_height = line.default_font_height,
+    next_indent = line.next_indent,
+    fragments = {}
+  }, math.max(max_width, line.width)
+end
+
+local function layout_text_lines(self, segments, fontset, base_color, accent_color, max_width, first_indent, next_indent)
+  local tokens = tokenize_segments(self, segments, fontset, base_color, accent_color)
+  local lines = {}
+  local used_width = 0
+  local line = {
+    indent = first_indent,
+    width = first_indent,
+    font_height = fontset.normal:get_height(),
+    default_font_height = fontset.normal:get_height(),
+    next_indent = next_indent,
+    fragments = {}
+  }
+
+  for _, token in ipairs(tokens) do
+    if token.type == "linebreak" then
+      line, used_width = append_line(lines, line, used_width)
+      goto continue
+    elseif token.type ~= "image" then
+      token.width = token.font:get_width(token.text)
+    end
+    if token.is_space and #line.fragments == 0 then
+      goto continue
+    end
+
+    if not token.is_space and #line.fragments > 0 and line.width + token.width > max_width then
+      line, used_width = append_line(lines, line, used_width)
+    elseif token.is_space and line.width + token.width > max_width then
+      line, used_width = append_line(lines, line, used_width)
+      goto continue
+    end
+
+    line.fragments[#line.fragments + 1] = token
+    line.width = line.width + token.width
+    if token.type == "image" then
+      line.font_height = math.max(line.font_height, token.height)
+    else
+      line.font_height = math.max(line.font_height, token.font:get_height())
+    end
+
+    ::continue::
+  end
+
+  if #line.fragments > 0 or #lines == 0 then
+    line, used_width = append_line(lines, line, used_width)
+  end
+
+  return lines, math.max(used_width, next_indent)
+end
+
+local function add_text_line(commands, x, y, line)
+  local links
+  local offset_x = 0
+  for _, fragment in ipairs(line.fragments) do
+    if fragment.url then
+      links = links or {}
+      links[#links + 1] = {
+        x = x + line.indent + offset_x,
+        y = y,
+        width = fragment.width,
+        height = line.height,
+        url = fragment.url
+      }
+    end
+    offset_x = offset_x + fragment.width
+  end
+  commands[#commands + 1] = {
+    type = "text",
+    x = x + line.indent,
+    y = y,
+    height = line.height,
+    links = links,
+    fragments = line.fragments
+  }
+end
+
+local function add_paragraph(commands, y, block, fontset, color, accent_color, max_width, first_indent, next_indent, spacing)
+  local lines, used_width = layout_text_lines(
+    block.view,
+    block.segments,
+    fontset,
+    color,
+    accent_color,
+    max_width,
+    first_indent,
+    next_indent
+  )
+
+  local block_height = 0
+  for _, line in ipairs(lines) do
+    add_text_line(commands, block.x or 0, y + block_height, line)
+    block_height = block_height + line.height
+  end
+  
+  return y + block_height + (spacing or BLOCK_SPACING), used_width
+end
+
+local function get_code_fragments(line, code_font, code_syntax, state)
+  local tokens
+  tokens, state = tokenizer.tokenize(code_syntax, line .. "\n", state)
+
+  local fragments = {}
+  local line_width = 0
+  local last_token = nil
+  local tokens_count = #tokens
+  if tokens_count > 0 and string.sub(tokens[tokens_count], -1) == "\n" then
+    last_token = tokens_count - 1
+  end
+
+  code_font:set_tab_size(config.indent_size)
+  for tidx, type, text in tokenizer.each_token(tokens) do
+    if tidx == last_token then
+      text = text:sub(1, -2)
+    end
+    if text ~= "" then
+      local font = style.syntax_fonts[type] or code_font
+      if font ~= code_font then
+        font:set_tab_size(config.indent_size)
+      end
+      local width = font:get_width(text, { tab_offset = line_width })
+      fragments[#fragments + 1] = {
+        text = text,
+        font = font,
+        color = make_syntax_color(type, make_syntax_color("normal")),
+        width = width
+      }
+      line_width = line_width + width
+    end
+  end
+
+  return fragments, line_width, state
+end
+
+local function add_code_block(commands, y, lines, font, info, max_width, x_offset)
+  x_offset = x_offset or 0
+  local code_width = 0
+  local line_height = math.max(common.round(font:get_height() * config.line_height), font:get_height())
+  local block_height = math.max(#lines, 1) * line_height + BLOCK_PADDING_Y * 2
+  local code_syntax = resolve_code_fence_syntax(info)
+  local tokenized_lines = {}
+  local state
+
+  if #lines == 0 then
+    lines = { "" }
+  end
+
+  for i, line in ipairs(lines) do
+    local fragments, line_width
+    fragments, line_width, state = get_code_fragments(line, font, code_syntax, state)
+    tokenized_lines[i] = fragments
+    code_width = math.max(code_width, line_width)
+  end
+
+  commands[#commands + 1] = {
+    type = "rect",
+    x = x_offset,
+    y = y,
+    width = math.max(code_width + BLOCK_PADDING_X * 2, max_width),
+    height = block_height,
+    color = COLOR_BACKGROUND2
+  }
+
+  local offset_y = y + BLOCK_PADDING_Y
+  for _, fragments in ipairs(tokenized_lines) do
+    commands[#commands + 1] = {
+      type = "text",
+      x = x_offset + BLOCK_PADDING_X,
+      y = offset_y,
+      height = line_height,
+      tabbed = true,
+      fragments = fragments
+    }
+    offset_y = offset_y + line_height
+  end
+
+  return y + block_height + BLOCK_SPACING, math.max(code_width + BLOCK_PADDING_X * 2, max_width)
+end
+
+local function measure_segments(self, segments, fontset, base_color, accent_color)
+  local tokens = tokenize_segments(self, segments, fontset, base_color, accent_color)
+  local min_width = 0
+  local preferred_width = 0
+
+  for _, token in ipairs(tokens) do
+    local width = token.type == "image" and token.width or token.font:get_width(token.text)
+    preferred_width = preferred_width + width
+    if token.type ~= "linebreak" and not token.is_space then
+      min_width = math.max(min_width, width)
+    end
+  end
+
+  return min_width, preferred_width
+end
+
+local function measure_table_cell(self, cell, fontset, base_color, accent_color)
+  if cell.type == "image" then
+    local entry = self:ensure_image_entry(cell)
+    if entry.status == "ready" and entry.image then
+      local width = entry.image:get_size()
+      return width, width
+    end
+
+    local label = cell.alt ~= "" and cell.alt or cell.url
+    local message = entry.status == "loading"
+      and ("Loading image: " .. label)
+      or ("Image unavailable: " .. label)
+    local fallback_width = fontset.normal:get_width(message)
+    return fallback_width, fallback_width
+  end
+
+  return measure_segments(self, cell.segments, fontset, base_color, accent_color)
+end
+
+local function compute_table_column_widths(self, block, body_fontset, header_fontset, accent_color, max_width)
+  local columns = #block.headers
+  local widths = {}
+  local minimums = {}
+  local preferreds = {}
+  local available = max_width - TABLE_BORDER * (columns + 1) - TABLE_CELL_PADDING_X * 2 * columns
+  available = math.max(available, columns)
+
+  for col = 1, columns do
+    local min_width, preferred_width = measure_table_cell(
+      self,
+      block.headers[col],
+      header_fontset,
+      COLOR_TEXT,
+      accent_color
+    )
+    for _, row in ipairs(block.rows) do
+      local cell_min, cell_preferred = measure_table_cell(
+        self,
+        row[col],
+        body_fontset,
+        COLOR_TEXT,
+        accent_color
+      )
+      min_width = math.max(min_width, cell_min)
+      preferred_width = math.max(preferred_width, cell_preferred)
+    end
+    minimums[col] = min_width
+    preferreds[col] = math.max(preferred_width, min_width)
+  end
+
+  local minimum_total = 0
+  local preferred_total = 0
+  for col = 1, columns do
+    minimum_total = minimum_total + minimums[col]
+    preferred_total = preferred_total + preferreds[col]
+  end
+
+  if minimum_total >= available then
+    local remaining = available
+    for col = 1, columns do
+      widths[col] = math.max(1, math.floor(available * (minimums[col] / minimum_total)))
+      remaining = remaining - widths[col]
+    end
+    local col = 1
+    while remaining > 0 do
+      widths[col] = widths[col] + 1
+      remaining = remaining - 1
+      col = col % columns + 1
+    end
+    return widths
+  end
+
+  for col = 1, columns do
+    widths[col] = minimums[col]
+  end
+
+  local extra = available - minimum_total
+  local desired_extra_total = math.max(preferred_total - minimum_total, 0)
+  if desired_extra_total == 0 then
+    desired_extra_total = columns
+    for col = 1, columns do
+      preferreds[col] = minimums[col] + 1
+    end
+  end
+
+  for col = 1, columns do
+    local desired_extra = preferreds[col] - minimums[col]
+    if desired_extra_total == columns and desired_extra == 0 then
+      desired_extra = 1
+    end
+    local add = math.floor(extra * (desired_extra / desired_extra_total))
+    widths[col] = widths[col] + add
+  end
+
+  local used = 0
+  for col = 1, columns do
+    used = used + widths[col]
+  end
+
+  local remaining = available - used
+  local col = 1
+  while remaining > 0 do
+    widths[col] = widths[col] + 1
+    remaining = remaining - 1
+    col = col % columns + 1
+  end
+
+  return widths
+end
+
+local function add_table_block(self, commands, y, block, body_fontset, accent_color, max_width, x_offset)
+  x_offset = x_offset or 0
+  local header_fontset = {
+    normal = body_fontset.bold,
+    bold = body_fontset.bold,
+    italic = body_fontset.bold_italic,
+    bold_italic = body_fontset.bold_italic,
+    code = body_fontset.code
+  }
+  local column_widths = compute_table_column_widths(
+    self,
+    block,
+    body_fontset,
+    header_fontset,
+    accent_color,
+    max_width
+  )
+  local column_offsets = {}
+  local total_width = TABLE_BORDER
+
+  for col = 1, #column_widths do
+    column_offsets[col] = total_width
+    total_width = total_width + column_widths[col] + TABLE_CELL_PADDING_X * 2 + TABLE_BORDER
+  end
+
+  local rows = {}
+  rows[1] = {
+    header = true,
+    cells = block.headers
+  }
+  for _, row in ipairs(block.rows) do
+    rows[#rows + 1] = {
+      header = false,
+      cells = row
+    }
+  end
+
+  local laid_out_rows = {}
+  local table_height = TABLE_BORDER
+  for row_index, row in ipairs(rows) do
+    local row_height = 0
+    local cell_layouts = {}
+    for col = 1, #column_widths do
+      local fontset = row.header and header_fontset or body_fontset
+      local cell = row.cells[col]
+      if cell.type == "image" then
+        local entry = self:ensure_image_entry(cell)
+        if entry.status == "ready" then
+          local image, image_width, image_height = self:get_scaled_image(entry, math.max(column_widths[col], 1))
+          if image then
+            row_height = math.max(row_height, image_height)
+            cell_layouts[col] = {
+              type = "image",
+              image = image,
+              width = image_width,
+              height = image_height,
+              link_url = cell.link_url
+            }
+          end
+        end
+
+        if not cell_layouts[col] then
+          local label = cell.alt ~= "" and cell.alt or cell.url
+          local message = entry.status == "loading"
+            and ("Loading image: " .. label)
+            or ("Image unavailable: " .. label)
+          local lines = layout_text_lines(
+            self,
+            {
+              { kind = "italic", text = message }
+            },
+            fontset,
+            COLOR_DIM,
+            accent_color,
+            math.max(column_widths[col], 1),
+            0,
+            0
+          )
+          local content_height = 0
+          for _, line in ipairs(lines) do
+            content_height = content_height + line.height
+          end
+          row_height = math.max(row_height, content_height)
+          cell_layouts[col] = {
+            type = "text",
+            lines = lines
+          }
+        end
+      else
+          local lines = layout_text_lines(
+            self,
+            cell.segments,
+            fontset,
+            COLOR_TEXT,
+            accent_color,
+          math.max(column_widths[col], 1),
+          0,
+          0
+        )
+        local content_height = 0
+        for _, line in ipairs(lines) do
+          content_height = content_height + line.height
+        end
+        row_height = math.max(row_height, content_height)
+        cell_layouts[col] = {
+          type = "text",
+          lines = lines
+        }
+      end
+    end
+    row_height = row_height + TABLE_CELL_PADDING_Y * 2
+    laid_out_rows[row_index] = {
+      header = row.header,
+      height = row_height,
+      cells = cell_layouts
+    }
+    table_height = table_height + row_height + TABLE_BORDER
+  end
+
+  local current_y = y + TABLE_BORDER
+  for row_index, row in ipairs(laid_out_rows) do
+    if row.header then
+      commands[#commands + 1] = {
+        type = "rect",
+        x = x_offset + TABLE_BORDER,
+        y = current_y,
+        width = total_width - TABLE_BORDER * 2,
+        height = row.height,
+        color = COLOR_BACKGROUND2
+      }
+    end
+
+    for col = 1, #column_widths do
+      local content_y = current_y + TABLE_CELL_PADDING_Y
+      local cell = row.cells[col]
+      local inner_width = column_widths[col]
+      local alignment = block.alignments[col] or "left"
+      if cell.type == "image" then
+        local image_x = x_offset + column_offsets[col] + TABLE_CELL_PADDING_X
+        if alignment == "center" then
+          image_x = image_x + math.max(math.floor((inner_width - cell.width) / 2), 0)
+        elseif alignment == "right" then
+          image_x = image_x + math.max(inner_width - cell.width, 0)
+        end
+        commands[#commands + 1] = {
+          type = "image",
+          x = image_x,
+          y = current_y + TABLE_CELL_PADDING_Y + math.max(math.floor((row.height - TABLE_CELL_PADDING_Y * 2 - cell.height) / 2), 0),
+          width = cell.width,
+          height = cell.height,
+          image = cell.image,
+          link_url = cell.link_url
+        }
+      else
+        for _, line in ipairs(cell.lines) do
+          local line_x = x_offset + column_offsets[col] + TABLE_CELL_PADDING_X
+          if alignment == "center" then
+            line_x = line_x + math.max(math.floor((inner_width - line.width) / 2), 0)
+          elseif alignment == "right" then
+            line_x = line_x + math.max(inner_width - line.width, 0)
+          end
+          add_text_line(
+            commands,
+            line_x,
+            content_y,
+            line
+          )
+          content_y = content_y + line.height
+        end
+      end
+    end
+
+    current_y = current_y + row.height + TABLE_BORDER
+  end
+
+  local line_y = y
+  commands[#commands + 1] = {
+    type = "rect",
+    x = x_offset,
+    y = line_y,
+    width = total_width,
+    height = TABLE_BORDER,
+    color = COLOR_DIVIDER
+  }
+  for _, row in ipairs(laid_out_rows) do
+    line_y = line_y + row.height + TABLE_BORDER
+    commands[#commands + 1] = {
+      type = "rect",
+      x = x_offset,
+      y = line_y,
+      width = total_width,
+      height = TABLE_BORDER,
+      color = COLOR_DIVIDER
+    }
+  end
+
+  local line_x = 0
+  for _ = 0, #column_widths do
+    commands[#commands + 1] = {
+      type = "rect",
+      x = x_offset + line_x,
+      y = y,
+      width = TABLE_BORDER,
+      height = table_height,
+      color = COLOR_DIVIDER
+    }
+    if column_offsets[_ + 1] then
+      line_x = column_offsets[_ + 1] + column_widths[_ + 1] + TABLE_CELL_PADDING_X * 2
+    end
+  end
+
+  return y + table_height + BLOCK_SPACING, total_width
+end
+
+local function render_blocks(self, commands, y, blocks, width, x_offset, fonts, accent_color, anchors)
+  local content_width = 0
+  x_offset = x_offset or 0
+
+  for _, block in ipairs(blocks) do
+    local available_width = math.max(width - x_offset, 1)
+    if block.type == "heading" then
+      local fontset = fonts.heading[block.level]
+      local used_width
+      y, used_width = add_paragraph(
+        commands,
+        y,
+        {
+          view = self,
+          x = x_offset,
+          segments = block.segments
+        },
+        fontset,
+        accent_color,
+        accent_color,
+        available_width,
+        0,
+        0
+      )
+      content_width = math.max(content_width, x_offset + used_width)
+      if block.level <= 2 then
+        commands[#commands + 1] = {
+          type = "rect",
+          x = x_offset,
+          y = y - BLOCK_SPACING + RULE_GAP / 2,
+          width = available_width,
+          height = RULE_HEIGHT,
+          color = COLOR_DIVIDER
+        }
+        y = y + RULE_GAP
+      end
+    elseif block.type == "paragraph" then
+      local used_width
+      y, used_width = add_paragraph(
+        commands,
+        y,
+        {
+          view = self,
+          x = x_offset,
+          segments = block.segments
+        },
+        fonts.body,
+        COLOR_TEXT,
+        accent_color,
+        available_width,
+        0,
+        0,
+        PARAGRAPH_SPACING
+      )
+      content_width = math.max(content_width, x_offset + used_width)
+    elseif block.type == "quote" then
+      local quote_start = y
+      local nested_width
+      y, nested_width = render_blocks(
+        self,
+        commands,
+        y,
+        block.blocks or {},
+        width,
+        x_offset + QUOTE_BAR_WIDTH + QUOTE_GAP,
+        fonts,
+        accent_color,
+        anchors
+      )
+      commands[#commands + 1] = {
+        type = "rect",
+        x = x_offset,
+        y = quote_start,
+        width = QUOTE_BAR_WIDTH,
+        height = math.max(y - quote_start - BLOCK_SPACING, RULE_HEIGHT),
+        color = COLOR_DIVIDER
+      }
+      content_width = math.max(content_width, nested_width, x_offset + QUOTE_BAR_WIDTH)
+    elseif block.type == "unordered_list" or block.type == "ordered_list" or block.type == "footnotes" then
+      if block.type == "footnotes" then
+        commands[#commands + 1] = {
+          type = "rect",
+          x = x_offset,
+          y = y + RULE_GAP,
+          width = available_width,
+          height = RULE_HEIGHT,
+          color = COLOR_DIVIDER
+        }
+        y = y + RULE_GAP * 2 + RULE_HEIGHT
+      end
+
+      for _, item in ipairs(block.items) do
+        local nested_offset = block.type == "footnotes" and 0 or LIST_INDENT * (item.nesting or 0)
+        local marker
+        local marker_size
+        if block.type == "ordered_list" or block.type == "footnotes" then
+          marker = string.format("%d.", item.index)
+        elseif item.checked ~= nil then
+          marker_size = math.max(common.round(fonts.body.normal:get_height() * CHECKBOX_SIZE_RATIO), 1)
+        else
+          marker = "\226\128\162"
+        end
+
+        local marker_width = (marker_size or fonts.body.normal:get_width(marker)) + style.padding.x
+        local marker_x = x_offset + nested_offset + LIST_INDENT
+        local content_x = marker_x + marker_width
+        local item_start_y = y
+        if block.type == "footnotes" and item.id then
+          anchors["footnote-" .. item.id] = item_start_y
+        end
+
+        local item_blocks = item.blocks
+        if not item_blocks or #item_blocks == 0 then
+          item_blocks = {
+            {
+              type = "paragraph",
+              segments = item.segments or parse_inline_lines({ item.text or "" }, self.references, self.footnotes),
+              lines = { item.text or "" }
+            }
+          }
+        end
+
+        local item_width
+        y, item_width = render_blocks(
+          self,
+          commands,
+          y,
+          item_blocks,
+          width,
+          content_x,
+          fonts,
+          accent_color,
+          anchors
+        )
+        content_width = math.max(content_width, item_width, content_x)
+
+        if item.checked ~= nil then
+          commands[#commands + 1] = {
+            type = "checkbox",
+            x = marker_x,
+            y = item_start_y,
+            width = marker_size,
+            height = math.max(common.round(fonts.body.normal:get_height() * config.line_height), fonts.body.normal:get_height()),
+            checked = item.checked,
+            color = accent_color
+          }
+        else
+          commands[#commands + 1] = {
+            type = "text",
+            x = marker_x,
+            y = item_start_y,
+            height = math.max(common.round(fonts.body.normal:get_height() * config.line_height), fonts.body.normal:get_height()),
+            fragments = {
+              {
+                text = marker,
+                font = fonts.body.normal,
+                color = accent_color,
+                width = fonts.body.normal:get_width(marker)
+              }
+            }
+          }
+        end
+
+        y = y - BLOCK_SPACING + common.round(style.padding.y / 2)
+      end
+      y = y + BLOCK_SPACING
+    elseif block.type == "definition_list" then
+      for _, item in ipairs(block.items) do
+        local term_width
+        y, term_width = add_paragraph(
+          commands,
+          y,
+          {
+            view = self,
+            x = x_offset,
+            segments = item.term_segments
+          },
+          {
+            normal = fonts.body.bold,
+            bold = fonts.body.bold,
+            italic = fonts.body.bold_italic,
+            bold_italic = fonts.body.bold_italic,
+            code = fonts.body.code,
+            strikethrough = fonts.body.bold_strikethrough,
+            bold_strikethrough = fonts.body.bold_strikethrough,
+            italic_strikethrough = fonts.body.bold_italic_strikethrough,
+            bold_italic_strikethrough = fonts.body.bold_italic_strikethrough,
+            code_strikethrough = fonts.body.code_strikethrough
+          },
+          COLOR_TEXT,
+          accent_color,
+          available_width,
+          0,
+          0,
+          common.round(style.padding.y / 2)
+        )
+        content_width = math.max(content_width, x_offset + term_width)
+        for _, definition in ipairs(item.definitions) do
+          local definition_width
+          y, definition_width = render_blocks(
+            self,
+            commands,
+            y,
+            definition.blocks or {},
+            width,
+            x_offset + LIST_INDENT,
+            fonts,
+            accent_color,
+            anchors
+          )
+          content_width = math.max(content_width, definition_width)
+        end
+      end
+    elseif block.type == "code" then
+      local used_width
+      y, used_width = add_code_block(commands, y, block.lines, fonts.code, block.info, available_width, x_offset)
+      content_width = math.max(content_width, x_offset + used_width)
+    elseif block.type == "table" then
+      local used_width
+      y, used_width = add_table_block(self, commands, y, block, fonts.body, accent_color, available_width, x_offset)
+      content_width = math.max(content_width, x_offset + used_width)
+    elseif block.type == "image" then
+      local entry = self:ensure_image_entry(block)
+      if entry.status == "ready" then
+        local image, image_width, image_height = self:get_scaled_image(entry, available_width)
+        if image then
+          commands[#commands + 1] = {
+            type = "image",
+            x = x_offset + (block.alignment == "left" and 0 or math.max(math.floor((available_width - image_width) / 2), 0)),
+            y = y,
+            width = image_width,
+            height = image_height,
+            image = image,
+            link_url = block.link_url
+          }
+          y = y + image_height + BLOCK_SPACING
+          content_width = math.max(content_width, x_offset + image_width)
+        end
+      else
+        local label = block.alt ~= "" and block.alt or block.url
+        local message = entry.status == "loading"
+          and ("Loading image: " .. label)
+          or ("Image unavailable: " .. label)
+        local used_width
+        y, used_width = add_paragraph(
+          commands,
+          y,
+          {
+            view = self,
+            x = x_offset,
+            segments = { { kind = "italic", text = message } }
+          },
+          fonts.body,
+          COLOR_DIM,
+          accent_color,
+          available_width,
+          0,
+          0
+        )
+        content_width = math.max(content_width, x_offset + used_width)
+      end
+    elseif block.type == "image_row" then
+      local row_x = x_offset
+      local row_y = y + IMAGE_ROW_PADDING_Y
+      local row_height = 0
+      local row_width = 0
+      local label_font = fonts.body.italic
+      local label_height = math.max(common.round(label_font:get_height() * config.line_height), label_font:get_height())
+
+      for _, image_block in ipairs(block.images) do
+        local entry = self:ensure_image_entry(image_block)
+        local item_width, item_height, image
+        if entry.status == "ready" then
+          image, item_width, item_height = self:get_scaled_image(entry, available_width)
+        else
+          local label = image_block.alt ~= "" and image_block.alt or image_block.url
+          local message = entry.status == "loading"
+            and ("Loading image: " .. label)
+            or ("Image unavailable: " .. label)
+          item_width = label_font:get_width(message)
+          item_height = label_height
+          image = {
+            message = message,
+            font = label_font,
+            color = COLOR_DIM
+          }
+        end
+
+        if item_width and item_height then
+          if row_x > x_offset and row_x + item_width > width then
+            row_y = row_y + row_height + IMAGE_ROW_PADDING_Y
+            row_x = x_offset
+            row_height = 0
+          end
+
+          if entry.status == "ready" and image then
+            commands[#commands + 1] = {
+              type = "image",
+              x = row_x,
+              y = row_y,
+              width = item_width,
+              height = item_height,
+              image = image,
+              link_url = image_block.link_url
+            }
+          else
+            commands[#commands + 1] = {
+              type = "text",
+              x = row_x,
+              y = row_y,
+              height = item_height,
+              fragments = {
+                {
+                  text = image.message,
+                  font = image.font,
+                  color = image.color,
+                  width = item_width
+                }
+              }
+            }
+          end
+
+          row_x = row_x + item_width + style.padding.x
+          row_height = math.max(row_height, item_height)
+          row_width = math.max(row_width, row_x - style.padding.x)
+        end
+      end
+
+      y = row_y + row_height + IMAGE_ROW_PADDING_Y + BLOCK_SPACING
+      content_width = math.max(content_width, row_width)
+    elseif block.type == "rule" then
+      commands[#commands + 1] = {
+        type = "rect",
+        x = x_offset,
+        y = y + RULE_GAP,
+        width = available_width,
+        height = RULE_HEIGHT,
+        color = COLOR_DIVIDER
+      }
+      y = y + RULE_GAP * 2 + RULE_HEIGHT + BLOCK_SPACING
+      content_width = math.max(content_width, x_offset + available_width)
+    end
+  end
+
+  return y, content_width
+end
+
+local function make_fontset(font)
+  local size = font:get_size()
+  return {
+    normal = font,
+    bold = font:copy(size, { bold = true }),
+    italic = font:copy(size, { italic = true }),
+    bold_italic = font:copy(size, { bold = true, italic = true }),
+    code = style.code_font:copy(size),
+    strikethrough = font:copy(size, { strikethrough = true }),
+    bold_strikethrough = font:copy(size, { bold = true, strikethrough = true }),
+    italic_strikethrough = font:copy(size, { italic = true, strikethrough = true }),
+    bold_italic_strikethrough = font:copy(size, { bold = true, italic = true, strikethrough = true }),
+    code_strikethrough = style.code_font:copy(size, { strikethrough = true })
+  }
+end
+
+---Constructor.
+---@param source? string|core.markdownview.source
+---@param title? string
+function MarkdownView:new(source, title)
+  MarkdownView.super.new(self)
+  self.scrollable = true
+  self.doc = nil
+  self.image_cache = {}
+  self.path = nil
+  self.title = title
+  self.text = ""
+  self.blocks = {}
+  self.references = {}
+  self.footnotes = {
+    definitions = {},
+    numbers = {},
+    order = {}
+  }
+  self.layout = nil
+  self.font_cache = nil
+  self.last_doc_change_id = nil
+
+  if type(source) == "table" then
+    self.doc = source.doc
+    self.path = source.path
+    self.title = source.title or source.name or title
+    if self.doc then
+      self:refresh_from_doc()
+    elseif source.path then
+      self:load(source.path)
+    else
+      self:set_text(source.text or "")
+    end
+  elseif type(source) == "string" and system.get_file_info(source) then
+    self:load(source)
+  else
+    self:set_text(source or "")
+  end
+end
+
+---Returns the persisted view state for file-backed previews.
+---@return core.markdownview.state?
+function MarkdownView:get_state()
+  if self.doc or not self.path then
+    return nil
+  end
+  return {
+    path = self.path,
+    scroll = {
+      x = self.scroll.to.x,
+      y = self.scroll.to.y
+    }
+  }
+end
+
+---Restores a file-backed markdown preview from saved state.
+---@param state core.markdownview.state
+---@return core.markdownview?
+function MarkdownView.from_state(state)
+  if state.path and system.get_file_info(state.path) then
+    local view = MarkdownView(state.path)
+    view.scroll.x, view.scroll.to.x = state.scroll.x, state.scroll.x
+    view.scroll.y, view.scroll.to.y = state.scroll.y, state.scroll.y
+    return view
+  end
+  return nil
+end
+
+---Checks whether a file path should be opened by the markdown preview.
+---@param path string
+---@return boolean
+function MarkdownView.is_supported(path)
+  local ext = path:match("%.([^.]+)$")
+  if not ext then
+    return false
+  end
+  ext = ext:lower()
+  return ext == "md" or ext == "markdown"
+end
+
+---Invalidates the cached layout so it will be rebuilt on the next draw.
+function MarkdownView:invalidate_layout()
+  self.layout = nil
+end
+
+---Replaces the preview text and reparses the markdown document.
+---@param text string?
+function MarkdownView:set_text(text)
+  self.text = (text or ""):gsub("\r\n", "\n"):gsub("\r", "\n")
+  self.blocks, self.references, self.footnotes = parse_document(self.text)
+  self:invalidate_layout()
+end
+
+---Refreshes preview contents from the bound document.
+function MarkdownView:refresh_from_doc()
+  if not self.doc then
+    return
+  end
+
+  self.path = self.doc.abs_filename
+  self.title = common.basename(self.doc:get_name())
+  self.last_doc_change_id = self.doc:get_change_id()
+  self:set_text(self.doc:get_text(1, 1, math.huge, math.huge))
+end
+
+---Loads markdown contents from disk into the view.
+---@param path string
+---@return boolean loaded
+---@return string? errmsg
+function MarkdownView:load(path)
+  local file, err = io.open(path, "rb")
+  if not file then
+    return false, err
+  end
+  local text = file:read("*a") or ""
+  file:close()
+  self.path = path
+  self.title = self.title or common.basename(path)
+  self:set_text(text)
+  return true
+end
+
+---@return string
+function MarkdownView:get_name()
+  if self.path then
+    return common.basename(self.path) .. " Preview"
+  end
+  return (self.title or "Markdown") .. " Preview"
+end
+
+---Builds and caches the fonts used by the markdown renderer.
+---@return table
+function MarkdownView:get_font_cache()
+  if not self.font_cache then
+    local sizes = {
+      30 * SCALE,
+      24 * SCALE,
+      20 * SCALE,
+      18 * SCALE,
+      16 * SCALE,
+      15 * SCALE
+    }
+    self.font_cache = {
+      body = make_fontset(style.font),
+      quote = make_fontset(style.font),
+      code = style.code_font,
+      heading = {}
+    }
+    for i, size in ipairs(sizes) do
+      self.font_cache.heading[i] = make_fontset(style.font:copy(size, { bold = true }))
+    end
+  end
+  return self.font_cache
+end
+
+---Loads an image entry from a local file path.
+---@param entry table
+---@param path string
+function MarkdownView:load_image_from_path(entry, path)
+  local image, errmsg = canvas.load_image(path)
+  if not image then
+    entry.status = "error"
+    entry.errmsg = errmsg or "image could not be loaded"
+    return
+  end
+
+  local _, image_type = ImageView.is_supported(path)
+  entry.status = "ready"
+  entry.path = path
+  entry.type = image_type
+  entry.errmsg = nil
+  entry.image = image
+  entry.image_scaled = nil
+  entry.scaled_width = nil
+  entry.scaled_height = nil
+end
+
+---Starts downloading a remote image used by the markdown document.
+---@param entry table
+function MarkdownView:start_remote_image_download(entry)
+  http = http or require "core.http"
+  local cache_path = get_image_cache_path(entry.url)
+  entry.status = "loading"
+  entry.path = cache_path
+
+  http.download(entry.url, {
+    directory = IMAGE_CACHE_DIR,
+    filename = common.basename(cache_path),
+    on_done = function(ok, err, filename)
+      if ok and filename then
+        self:load_image_from_path(entry, filename)
+      else
+        entry.status = "error"
+        entry.errmsg = err or "image download failed"
+      end
+      self:invalidate_layout()
+    end
+  })
+end
+
+---Returns an image cache entry for the given markdown image block.
+---@param block table
+---@return table
+function MarkdownView:ensure_image_entry(block)
+  local entry = self.image_cache[block.url]
+  if entry then
+    return entry
+  end
+
+  entry = {
+    alt = block.alt,
+    url = block.url,
+    status = "idle"
+  }
+  self.image_cache[block.url] = entry
+
+  local project_target = self:resolve_project_link(block.url)
+  if project_target then
+    self:load_image_from_path(entry, project_target)
+    return entry
+  end
+
+  if block.url:match("^https?://") then
+    local cache_path = get_image_cache_path(block.url)
+    if system.get_file_info(cache_path) then
+      self:load_image_from_path(entry, cache_path)
+    else
+      self:start_remote_image_download(entry)
+    end
+    return entry
+  end
+
+  entry.status = "error"
+  entry.errmsg = "unsupported image source"
+  return entry
+end
+
+---Returns a scaled canvas for an image entry constrained to the given width.
+---@param entry table
+---@param max_width number
+---@return canvas? image
+---@return number? width
+---@return number? height
+function MarkdownView:get_scaled_image(entry, max_width)
+  if entry.status ~= "ready" or not entry.image then
+    return nil
+  end
+
+  local image_width, image_height = entry.image:get_size()
+  local scale = image_width > max_width and (max_width / image_width) or 1
+  local scaled_width = math.max(math.floor(image_width * scale), 1)
+  local scaled_height = math.max(math.floor(image_height * scale), 1)
+
+  if
+    entry.image_scaled
+    and entry.scaled_width == scaled_width
+    and entry.scaled_height == scaled_height
+  then
+    return entry.image_scaled, scaled_width, scaled_height
+  end
+
+  if scale == 1 then
+    entry.image_scaled = entry.image
+  elseif entry.type == "svg" then
+    entry.image_scaled = canvas.load_svg_image(entry.path, scaled_width, scaled_height)
+  else
+    entry.image_scaled = entry.image:scaled(scaled_width, scaled_height, "nearest")
+  end
+
+  entry.scaled_width = scaled_width
+  entry.scaled_height = scaled_height
+  return entry.image_scaled, scaled_width, scaled_height
+end
+
+---Builds the render command list for the current view width.
+---@return table
+function MarkdownView:ensure_layout()
+  local width = math.max(self.size.x - style.padding.x * 2, 1)
+  if self.layout and self.layout.width == width then
+    return self.layout
+  end
+
+  local fonts = self:get_font_cache()
+  local accent_color = COLOR_ACCENT
+  local commands = {}
+  local anchors = {}
+  local y, content_width = render_blocks(self, commands, 0, self.blocks, width, 0, fonts, accent_color, anchors)
+
+  self.layout = {
+    width = width,
+    height = y > 0 and (y - BLOCK_SPACING) or 0,
+    content_width = content_width,
+    commands = commands,
+    anchors = anchors
+  }
+
+  return self.layout
+end
+
+---@return number
+function MarkdownView:get_scrollable_size()
+  local layout = self:ensure_layout()
+  return layout.height + style.padding.y * 2
+end
+
+---@return number
+function MarkdownView:get_h_scrollable_size()
+  local layout = self:ensure_layout()
+  return layout.content_width + style.padding.x * 2
+end
+
+---Clears cached font and layout data after a scale change.
+function MarkdownView:on_scale_change()
+  self.font_cache = nil
+  self:invalidate_layout()
+end
+
+---Returns the URL under the given mouse position, if any.
+---@param x number
+---@param y number
+---@return string?
+function MarkdownView:get_link_at(x, y)
+  local layout = self:ensure_layout()
+  local ox, oy = self:get_content_offset()
+  local start_x = ox + style.padding.x
+  local start_y = oy + style.padding.y
+
+  for _, command in ipairs(layout.commands) do
+    if command.type == "image" and command.link_url then
+      local rx = start_x + command.x
+      local ry = start_y + command.y
+      if x >= rx and y >= ry and x < rx + command.width and y < ry + command.height then
+        return command.link_url
+      end
+    end
+    if command.links then
+      for _, link in ipairs(command.links) do
+        local rx = start_x + link.x
+        local ry = start_y + link.y
+        if x >= rx and y >= ry and x < rx + link.width and y < ry + link.height then
+          return link.url
+        end
+      end
+    end
+  end
+end
+
+---Resolves a markdown link to a project-local absolute path when possible.
+---@param url string
+---@return string?
+function MarkdownView:resolve_project_link(url)
+  local target = url:match("^[^#?]+")
+  if not target or target == "" then
+    return nil
+  end
+
+  if not common.is_absolute_path(target) and target:match("^[%a][%w+.-]*:") then
+    return nil
+  end
+
+  local abs_target
+  if common.is_absolute_path(target) then
+    abs_target = common.normalize_path(target)
+  else
+    local base_dir = self.path and common.dirname(self.path)
+    if not base_dir then
+      local project = core.current_project(self.path)
+      base_dir = project and project.path or system.absolute_path(".")
+    end
+    abs_target = system.absolute_path(base_dir .. PATHSEP .. target)
+      or common.normalize_path(base_dir .. PATHSEP .. target)
+  end
+
+  if not abs_target then
+    return nil
+  end
+
+  local project = core.current_project(self.path or abs_target)
+  if not (project and project.path) then
+    return nil
+  end
+
+  if not common.path_belongs_to(abs_target, project.path) then
+    return nil
+  end
+
+  local file_info = system.get_file_info(abs_target)
+  if not file_info or file_info.type ~= "file" then
+    return nil
+  end
+
+  return abs_target
+end
+
+---Opens a markdown link target, handling anchors, local files and external URLs.
+---@param url string
+function MarkdownView:open_link(url)
+  if url:sub(1, 1) == "#" then
+    local layout = self:ensure_layout()
+    local anchor = layout.anchors and layout.anchors[url:sub(2)]
+    if anchor then
+      self.scroll.to.y = anchor
+      self.scroll.y = anchor
+    end
+    return
+  end
+
+  local project_target = self:resolve_project_link(url)
+  if project_target then
+    if MarkdownView.is_supported(project_target) then
+      core.open_markdown(project_target)
+    else
+      core.open_file(project_target)
+    end
+  else
+    common.open_in_system(url)
+  end
+end
+
+---Updates hover state and status-bar tooltip for links.
+---@param url string?
+function MarkdownView:set_hovered_link(url)
+  if self.hovered_link_url == url then
+    return
+  end
+
+  self.hovered_link_url = url
+  if url then
+    core.status_view:show_tooltip("Open " .. url)
+  else
+    core.status_view:remove_tooltip()
+  end
+end
+
+---@param button string
+---@param x number
+---@param y number
+---@param clicks integer
+---@return boolean?
+function MarkdownView:on_mouse_pressed(button, x, y, clicks)
+  if MarkdownView.super.on_mouse_pressed(self, button, x, y, clicks) then
+    return true
+  end
+
+  if button == "left" then
+    local url = self:get_link_at(x, y)
+    if url then
+      self:open_link(url)
+      return true
+    end
+  end
+end
+
+---@param x number
+---@param y number
+---@param dx number
+---@param dy number
+---@return boolean?
+function MarkdownView:on_mouse_moved(x, y, dx, dy)
+  if MarkdownView.super.on_mouse_moved(self, x, y, dx, dy) then
+    return true
+  end
+  local url = self:get_link_at(x, y)
+  self:set_hovered_link(url)
+  self.cursor = url and "hand" or "arrow"
+end
+
+---Clears hover state when the mouse leaves the preview.
+function MarkdownView:on_mouse_left()
+  MarkdownView.super.on_mouse_left(self)
+  self:set_hovered_link(nil)
+  self.cursor = "arrow"
+end
+
+---Refreshes the preview when the bound document changes.
+function MarkdownView:update()
+  if self.doc and self.doc:get_change_id() ~= self.last_doc_change_id then
+    self:refresh_from_doc()
+  end
+  MarkdownView.super.update(self)
+end
+
+---Draws the markdown preview contents and scrollbars.
+function MarkdownView:draw()
+  self:draw_background(style.background)
+
+  local layout = self:ensure_layout()
+  local ox, oy = self:get_content_offset()
+  local clip_x, clip_y = self.position.x, self.position.y
+  local clip_w, clip_h = self.size.x, self.size.y
+  local start_x = ox + style.padding.x
+  local start_y = oy + style.padding.y
+
+  core.push_clip_rect(clip_x, clip_y, clip_w, clip_h)
+
+  for _, command in ipairs(layout.commands) do
+    local x = start_x + command.x
+    local y = start_y + command.y
+    if y + command.height >= clip_y and y <= clip_y + clip_h then
+      if command.type == "rect" then
+        renderer.draw_rect(x, y, command.width, command.height, resolve_color(command.color))
+      elseif command.type == "checkbox" then
+        local box_size = command.width
+        local box_x = x
+        local box_y = y + math.max(math.floor((command.height - box_size) / 2), 0)
+        local checkbox_color = resolve_color(command.color)
+        renderer.draw_rect(box_x, box_y, box_size, 1, checkbox_color)
+        renderer.draw_rect(box_x, box_y + box_size - 1, box_size, 1, checkbox_color)
+        renderer.draw_rect(box_x, box_y, 1, box_size, checkbox_color)
+        renderer.draw_rect(box_x + box_size - 1, box_y, 1, box_size, checkbox_color)
+        if command.checked then
+          local fill = math.max(box_size - 4, 1)
+          renderer.draw_rect(box_x + 2, box_y + 2, fill, fill, checkbox_color)
+        end
+      elseif command.type == "image" then
+        renderer.draw_canvas(command.image, x, y)
+      elseif command.type == "text" then
+        local cursor_x = x
+        local tab_offset = 0
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.type == "image" then
+            local draw_y = y + math.max(math.floor((command.height - fragment.height) / 2), 0)
+            renderer.draw_canvas(fragment.image, cursor_x, draw_y)
+            cursor_x = cursor_x + fragment.width
+          else
+            local font_height = fragment.font:get_height()
+            local draw_y = y + (command.height - font_height) / 2
+            if fragment.background then
+              renderer.draw_rect(
+                cursor_x - INLINE_CODE_PADDING_X,
+                draw_y - INLINE_CODE_PADDING_Y,
+                fragment.width + INLINE_CODE_PADDING_X * 2,
+                font_height + INLINE_CODE_PADDING_Y * 2,
+                resolve_color(fragment.background)
+              )
+            end
+            cursor_x = renderer.draw_text(
+              fragment.font,
+              fragment.text,
+              cursor_x,
+              draw_y,
+              resolve_color(fragment.color),
+              command.tabbed and { tab_offset = tab_offset } or nil
+            )
+          end
+          if command.tabbed then
+            tab_offset = cursor_x - x
+          end
+        end
+      end
+    end
+  end
+
+  core.pop_clip_rect()
+  self:draw_scrollbar()
+end
+
+return MarkdownView

--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -126,6 +126,7 @@ end
 ---@field scroll { x:number, y:number }
 
 ---@class core.markdownview.source
+---@field linked_doc core.doc?
 ---@field doc core.doc?
 ---@field path string?
 ---@field text string?
@@ -135,7 +136,7 @@ end
 ---@class core.markdownview : core.view
 ---@overload fun(source?: string|table, title?: string):core.markdownview
 ---@field super core.view
----@field doc core.doc?
+---@field linked_doc core.doc?
 ---@field image_cache table<string,table>
 ---@field path string?
 ---@field title string?
@@ -2714,7 +2715,7 @@ end
 function MarkdownView:new(source, title)
   MarkdownView.super.new(self)
   self.scrollable = true
-  self.doc = nil
+  self.linked_doc = nil
   self.image_cache = {}
   self.path = nil
   self.title = title
@@ -2731,10 +2732,10 @@ function MarkdownView:new(source, title)
   self.last_doc_change_id = nil
 
   if type(source) == "table" then
-    self.doc = source.doc
+    self.linked_doc = source.linked_doc or source.doc
     self.path = source.path
     self.title = source.title or source.name or title
-    if self.doc then
+    if self.linked_doc then
       self:refresh_from_doc()
     elseif source.path then
       self:load(source.path)
@@ -2751,7 +2752,7 @@ end
 ---Returns the persisted view state for file-backed previews.
 ---@return core.markdownview.state?
 function MarkdownView:get_state()
-  if self.doc or not self.path then
+  if self.linked_doc or not self.path then
     return nil
   end
   return {
@@ -2803,14 +2804,14 @@ end
 
 ---Refreshes preview contents from the bound document.
 function MarkdownView:refresh_from_doc()
-  if not self.doc then
+  if not self.linked_doc then
     return
   end
 
-  self.path = self.doc.abs_filename
-  self.title = common.basename(self.doc:get_name())
-  self.last_doc_change_id = self.doc:get_change_id()
-  self:set_text(self.doc:get_text(1, 1, math.huge, math.huge))
+  self.path = self.linked_doc.abs_filename
+  self.title = common.basename(self.linked_doc:get_name())
+  self.last_doc_change_id = self.linked_doc:get_change_id()
+  self:set_text(self.linked_doc:get_text(1, 1, math.huge, math.huge))
 end
 
 ---Loads markdown contents from disk into the view.
@@ -3184,7 +3185,7 @@ end
 
 ---Refreshes the preview when the bound document changes.
 function MarkdownView:update()
-  if self.doc and self.doc:get_change_id() ~= self.last_doc_change_id then
+  if self.linked_doc and self.linked_doc:get_change_id() ~= self.last_doc_change_id then
     self:refresh_from_doc()
   end
   MarkdownView.super.update(self)

--- a/data/plugins/contextmenu.lua
+++ b/data/plugins/contextmenu.lua
@@ -1,7 +1,10 @@
 -- mod-version:3
+local core = require "core"
 local command = require "core.command"
 local keymap = require "core.keymap"
 local ContextMenu = require "core.contextmenu"
+local DocView = require "core.docview"
+local MarkdownView = require "core.markdownview"
 local RootView = require "core.rootview"
 local config = require "core.config"
 
@@ -32,9 +35,12 @@ function RootView:draw(...)
   menu:draw()
 end
 
-command.add("core.docview!", {
-  ["context:show"] = function(dv)
-    menu:show(dv.position.x, dv.position.y)
+command.add(function()
+  local view = core.active_view
+  return view and (view:extends(DocView) or view:extends(MarkdownView)), view
+end, {
+  ["context:show"] = function(view)
+    menu:show(view.position.x, view.position.y)
   end
 })
 
@@ -67,6 +73,8 @@ local cmds = {
   { text = "Copy",    command = "doc:copy" },
   { text = "Paste",   command = "doc:paste" },
   ContextMenu.DIVIDER,
+  { text = "Preview Markdown", command = "markdown-view:preview" },
+  ContextMenu.DIVIDER,
   { text = "Find",    command = "find-replace:find"    },
   { text = "Replace", command = "find-replace:replace" }
 }
@@ -79,6 +87,10 @@ if config.plugins.scale ~= false and require("plugins.scale") then
 end
 
 menu:register("core.docview", cmds)
+
+menu:register("core.markdownview", {
+  { text = "View Raw", command = "markdown-view:view-raw" }
+})
 
 
 return menu

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -768,6 +768,25 @@ settings.add("Image Viewer",
   }
 )
 
+settings.add("Markdown Preview",
+  {
+    {
+      label = "Preview Mode",
+      description = "How markdown previews opened from a document should be placed.",
+      path = "markdown_preview_mode",
+      type = settings.type.SELECTION,
+      default = "right",
+      values = {
+        {"Right", "right"},
+        {"New Tab", "newtab"},
+        {"Bottom", "bottom"},
+        {"Top", "top"},
+        {"Left", "left"}
+      }
+    }
+  }
+)
+
 settings.add("Development",
   {
     {

--- a/data/plugins/treeview.lua
+++ b/data/plugins/treeview.lua
@@ -11,6 +11,7 @@ local RootView = require "core.rootview"
 local CommandView = require "core.commandview"
 local DocView = require "core.docview"
 local ImageView = require "core.imageview"
+local MarkdownView = require "core.markdownview"
 local DirWatch = require "core.dirwatch"
 
 ---Configuration options for `treeview` plugin.
@@ -664,6 +665,16 @@ menu:register(function() return core.active_view:is(TreeView) and treeitem() end
   ContextMenu.DIVIDER
 })
 
+menu:register(function()
+  local item = treeitem()
+  return core.active_view:is(TreeView)
+    and item
+    and item.type == "file"
+    and MarkdownView.is_supported(item.abs_filename)
+end, {
+  { text = "Preview Markdown", command = "treeview:preview-markdown" }
+})
+
 menu:register(
   function()
     local item = treeitem()
@@ -994,6 +1005,19 @@ command.add(
   end, {
   ["treeview:open-in-editor"] = function(item)
     core.root_view:open_doc(core.open_doc(item.abs_filename))
+  end
+})
+
+command.add(
+  function()
+    local item = treeitem()
+    if item and item.type == "file" and MarkdownView.is_supported(item.abs_filename) then
+      return (core.active_view == view or menu.show_context_menu), item
+    end
+    return false
+  end, {
+  ["treeview:preview-markdown"] = function(item)
+    core.open_markdown(item.abs_filename)
   end
 })
 

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -18,10 +18,19 @@ local function write_file(path, content)
   file:close()
 end
 
+local function path_belongs_to_root(path, root)
+  if not (path and root) then
+    return false
+  end
+  path = common.normalize_path(path)
+  root = common.normalize_path(root)
+  return path == root or common.path_belongs_to(path, root)
+end
+
 local function path_is_in_test_roots(context, path)
   return path and (
-    (context.temp_root and common.path_belongs_to(path, context.temp_root))
-    or (context.project_temp_root and common.path_belongs_to(path, context.project_temp_root))
+    path_belongs_to_root(path, context.temp_root)
+    or path_belongs_to_root(path, context.project_temp_root)
   )
 end
 
@@ -1274,14 +1283,14 @@ For more detailed instructions visit: https://pragtical.dev/docs/setup/building
 
     local doc_view = core.open_file(path)
     test.ok(doc_view:extends(DocView))
-    test.ok(command.is_valid("core:preview-markdown"))
+    test.ok(command.is_valid("markdown-view:preview"))
 
     doc_view.doc:insert(3, 1, "Unsaved change.\n")
-    command.perform("core:preview-markdown")
+    command.perform("markdown-view:preview")
 
     local preview
     for _, view in ipairs(core.root_view.root_node:get_children()) do
-      if view:extends(MarkdownView) and view.doc == doc_view.doc then
+      if view:extends(MarkdownView) and view.linked_doc == doc_view.doc then
         preview = view
         break
       end
@@ -1316,11 +1325,11 @@ For more detailed instructions visit: https://pragtical.dev/docs/setup/building
       local doc_view = core.open_file(path)
       local doc_node = core.root_view.root_node:get_node_for_view(doc_view)
 
-      command.perform("core:preview-markdown")
+      command.perform("markdown-view:preview")
 
       local preview
       for _, view in ipairs(core.root_view.root_node:get_children()) do
-        if view:extends(MarkdownView) and view.doc == doc_view.doc then
+        if view:extends(MarkdownView) and view.linked_doc == doc_view.doc then
           preview = view
           break
         end
@@ -1342,6 +1351,130 @@ For more detailed instructions visit: https://pragtical.dev/docs/setup/building
       preview_node:close_view(core.root_view.root_node, preview)
       doc_node = core.root_view.root_node:get_node_for_view(doc_view)
       doc_node:close_view(core.root_view.root_node, doc_view)
+    end
+
+    config.markdown_preview_mode = original_mode
+  end)
+
+  test.test("view raw opens the markdown doc and links standalone previews", function(context)
+    local path = context.temp_root .. PATHSEP .. "raw-link.md"
+    write_file(path, "# Preview\n\nInitial text.\n")
+
+    local preview = core.open_markdown(path)
+    test.not_nil(preview)
+    test.is_nil(preview.linked_doc)
+
+    local preview_node = core.root_view.root_node:get_node_for_view(preview)
+    preview_node:set_active_view(preview)
+
+    test.ok(command.is_valid("markdown-view:view-raw"))
+    command.perform("markdown-view:view-raw")
+
+    local raw_view = core.root_view.root_node:get_node_for_view(core.active_view).active_view
+    test.ok(raw_view:extends(DocView))
+    test.equal(common.normalize_path(raw_view.doc.abs_filename), common.normalize_path(path))
+    test.equal(common.normalize_path(preview.linked_doc.abs_filename), common.normalize_path(path))
+
+    raw_view.doc:insert(3, 1, "Linked text.\n")
+    preview:update()
+    test.match(preview.text, "Linked text")
+  end)
+
+  test.test("view raw focuses an already open markdown doc", function(context)
+    local path = context.temp_root .. PATHSEP .. "raw-existing.md"
+    write_file(path, "# Preview\n\nInitial text.\n")
+
+    local raw_view = core.open_file(path)
+    test.ok(raw_view:extends(DocView))
+    local doc_node = core.root_view.root_node:get_node_for_view(raw_view)
+    local preview = doc_node:split("right", MarkdownView(path)).active_view
+    test.ok(preview:extends(MarkdownView))
+    test.is_nil(preview.linked_doc)
+
+    local preview_node = core.root_view.root_node:get_node_for_view(preview)
+    preview_node:set_active_view(preview)
+    command.perform("markdown-view:view-raw")
+
+    test.ok(core.active_view:extends(DocView))
+    test.equal(core.active_view.doc, raw_view.doc)
+    test.equal(preview.linked_doc, core.active_view.doc)
+  end)
+
+  test.test("view raw re-establishes the preview doc link", function(context)
+    local path = context.temp_root .. PATHSEP .. "raw-relink.md"
+    write_file(path, "# Preview\n\nInitial text.\n")
+
+    local raw_view = core.open_file(path)
+    local original_doc = raw_view.doc
+    local doc_node = core.root_view.root_node:get_node_for_view(raw_view)
+    local preview = doc_node:split("right", MarkdownView({
+      linked_doc = raw_view.doc,
+      path = path,
+      title = raw_view.doc:get_name()
+    })).active_view
+    local preview_node = core.root_view.root_node:get_node_for_view(preview)
+
+    preview_node:set_active_view(preview)
+    core.root_view.root_node:get_node_for_view(raw_view):close_view(core.root_view.root_node, raw_view)
+
+    command.perform("markdown-view:view-raw")
+
+    test.ok(core.active_view:extends(DocView))
+    test.equal(common.normalize_path(preview.linked_doc.abs_filename), common.normalize_path(path))
+    test.equal(common.normalize_path(core.active_view.doc.abs_filename), common.normalize_path(path))
+  end)
+
+  test.test("view raw is invalid for markdown previews without a path", function()
+    local preview = MarkdownView("# Preview\n\nText only.\n")
+    local node = core.root_view:get_active_node_default()
+    node:add_view(preview)
+
+    test.equal(core.active_view, preview)
+    test.not_ok(command.is_valid("markdown-view:view-raw"))
+
+    core.root_view.root_node:get_node_for_view(preview):close_view(core.root_view.root_node, preview)
+  end)
+
+  test.test("view raw places doc views according to config.markdown_preview_mode", function(context)
+    local path = context.temp_root .. PATHSEP .. "raw-placement.md"
+    write_file(path, "# Preview\n")
+
+    local original_mode = config.markdown_preview_mode
+    local modes = {
+      right = "left",
+      left = "right",
+      top = "down",
+      bottom = "up",
+      newtab = "newtab"
+    }
+
+    for mode, direction in pairs(modes) do
+      config.markdown_preview_mode = mode
+      local node = core.root_view:get_active_node_default()
+      local preview = MarkdownView(path)
+      node:add_view(preview)
+      node = core.root_view.root_node:get_node_for_view(preview)
+      node:set_active_view(preview)
+
+      command.perform("markdown-view:view-raw")
+
+      local raw_view = core.active_view
+      test.ok(raw_view:extends(DocView), mode)
+      local raw_node = core.root_view.root_node:get_node_for_view(raw_view)
+      if direction == "newtab" then
+        test.equal(raw_node, node)
+      else
+        local parent = raw_node:get_parent_node(core.root_view.root_node)
+        test.not_nil(parent, mode)
+        local split_type = (direction == "left" or direction == "right") and "hsplit" or "vsplit"
+        local split_child = (direction == "left" or direction == "up") and parent.a or parent.b
+        test.equal(parent.type, split_type)
+        test.equal(split_child, raw_node)
+      end
+
+      raw_node:close_view(core.root_view.root_node, raw_view)
+      node = core.root_view.root_node:get_node_for_view(preview)
+      node:close_view(core.root_view.root_node, preview)
     end
 
     config.markdown_preview_mode = original_mode

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -1,0 +1,1349 @@
+local common = require "core.common"
+local core = require "core"
+local command = require "core.command"
+local config = require "core.config"
+local http = require "core.http"
+local style = require "core.style"
+local test = require "core.test"
+local DocView = require "core.docview"
+local MarkdownView = require "core.markdownview"
+
+local temp_root
+local project_temp_root
+
+local function write_file(path, content)
+  local file, err = io.open(path, "wb")
+  test.not_nil(file, err)
+  file:write(content)
+  file:close()
+end
+
+local function path_is_in_test_roots(context, path)
+  return path and (
+    (context.temp_root and common.path_belongs_to(path, context.temp_root))
+    or (context.project_temp_root and common.path_belongs_to(path, context.project_temp_root))
+  )
+end
+
+local function close_test_views_and_docs(context)
+  local views = core.root_view.root_node:get_children()
+  for i = #views, 1, -1 do
+    local view = views[i]
+    local path = view.path or (view.doc and view.doc.abs_filename)
+    if path_is_in_test_roots(context, path) then
+      local node = core.root_view.root_node:get_node_for_view(view)
+      if node then
+        if view:extends(DocView) and view.doc:is_dirty() then
+          view.doc:clean()
+        end
+        node:remove_view(core.root_view.root_node, view)
+      end
+    end
+  end
+
+  for i = #core.docs, 1, -1 do
+    local doc = core.docs[i]
+    if path_is_in_test_roots(context, doc.abs_filename) then
+      table.remove(core.docs, i)
+      doc:on_close()
+    end
+  end
+end
+
+local function remove_test_path(path)
+  local ok, err
+  for _ = 1, 20 do
+    if not system.get_file_info(path) then
+      return true
+    end
+    collectgarbage("collect")
+    ok, err = common.rm(path, true)
+    if ok or not system.get_file_info(path) then
+      return true
+    end
+    system.sleep(0.05)
+  end
+  return false, err
+end
+
+test.describe("markdownview", function()
+  test.before_each(function(context)
+    temp_root = USERDIR
+      .. PATHSEP .. "markdownview-tests-"
+      .. system.get_process_id() .. "-"
+      .. math.floor(system.get_time() * 1000000)
+    local ok, err = common.mkdirp(temp_root)
+    test.ok(ok, err)
+    context.temp_root = temp_root
+
+    project_temp_root = core.root_project().path
+      .. PATHSEP .. "markdownview-tests-"
+      .. system.get_process_id() .. "-"
+      .. math.floor(system.get_time() * 1000000)
+    ok, err = common.mkdirp(project_temp_root)
+    test.ok(ok, err)
+    context.project_temp_root = project_temp_root
+  end)
+
+  test.after_each(function(context)
+    close_test_views_and_docs(context)
+    if PLATFORM ~= "Windows" then
+      if context.temp_root and system.get_file_info(context.temp_root) then
+        local ok, err = remove_test_path(context.temp_root)
+        test.ok(ok, err)
+      end
+      if context.project_temp_root and system.get_file_info(context.project_temp_root) then
+        local ok, err = remove_test_path(context.project_temp_root)
+        test.ok(ok, err)
+      end
+    end
+  end)
+
+  test.test("parses the supported markdown blocks", function()
+    test.ok(MarkdownView.is_supported("README.md"))
+    test.ok(MarkdownView.is_supported("README.markdown"))
+    test.not_ok(MarkdownView.is_supported("README.txt"))
+
+    local blocks = MarkdownView.parse_blocks([[
+# Heading
+
+Paragraph with **bold**, *italic*, [link](https://example.com) and `code`.
+
+- first item
+- second item
+
+> quoted text
+
+---
+
+```lua
+print("hello")
+```
+]])
+
+    test.equal(#blocks, 6)
+    test.equal(blocks[1].type, "heading")
+    test.equal(blocks[1].level, 1)
+    test.equal(blocks[2].type, "paragraph")
+    test.equal(blocks[3].type, "unordered_list")
+    test.equal(#blocks[3].items, 2)
+    test.equal(blocks[4].type, "quote")
+    test.equal(blocks[5].type, "rule")
+    test.equal(blocks[6].type, "code")
+    test.equal(blocks[6].info, "lua")
+    test.equal(blocks[6].lines[1], 'print("hello")')
+  end)
+
+  test.test("parses task list items", function()
+    local blocks = MarkdownView.parse_blocks([[
+- [ ] Open task
+- [x] Done task
+]])
+
+    test.equal(#blocks, 1)
+    test.equal(blocks[1].type, "unordered_list")
+    test.equal(#blocks[1].items, 2)
+    test.equal(blocks[1].items[1].checked, false)
+    test.equal(blocks[1].items[1].text, "Open task")
+    test.equal(blocks[1].items[2].checked, true)
+    test.equal(blocks[1].items[2].text, "Done task")
+  end)
+
+  test.test("parses nested list indentation", function()
+    local blocks = MarkdownView.parse_blocks([[
+- Parent
+  - Child
+    - Grandchild
+- Sibling
+]])
+
+    test.equal(#blocks, 1)
+    test.equal(blocks[1].type, "unordered_list")
+    test.equal(blocks[1].items[1].nesting, 0)
+    test.equal(blocks[1].items[2].nesting, 0)
+    test.equal(blocks[1].items[1].blocks[2].type, "unordered_list")
+    test.equal(blocks[1].items[1].blocks[2].items[1].text, "Child")
+    test.equal(blocks[1].items[1].blocks[2].items[1].blocks[2].type, "unordered_list")
+    test.equal(blocks[1].items[1].blocks[2].items[1].blocks[2].items[1].text, "Grandchild")
+  end)
+
+  test.test("parses nested list items after marker-aligned continuation indent", function()
+    local blocks = MarkdownView.parse_blocks([[
+*   Parent
+
+    *   Child
+    *   Sibling
+]])
+
+    test.equal(#blocks, 1)
+    test.equal(blocks[1].type, "unordered_list")
+    test.equal(blocks[1].items[1].blocks[2].type, "unordered_list")
+    test.equal(blocks[1].items[1].blocks[2].items[1].text, "Child")
+    test.equal(blocks[1].items[1].blocks[2].items[2].text, "Sibling")
+  end)
+
+  test.test("parses indented code blocks", function()
+    local blocks = MarkdownView.parse_blocks([[
+Paragraph
+
+    local x = 1
+    print(x)
+]])
+
+    test.equal(#blocks, 2)
+    test.equal(blocks[1].type, "paragraph")
+    test.equal(blocks[2].type, "code")
+    test.equal(blocks[2].lines[1], "local x = 1")
+    test.equal(blocks[2].lines[2], "print(x)")
+  end)
+
+  test.test("parses definition lists", function()
+    local blocks = MarkdownView.parse_blocks([[
+Term
+: first line
+  second line
+]])
+
+    test.equal(#blocks, 1)
+    test.equal(blocks[1].type, "definition_list")
+    test.equal(#blocks[1].items, 1)
+    test.equal(blocks[1].items[1].term, "Term")
+    test.equal(blocks[1].items[1].definitions[1].blocks[1].type, "paragraph")
+    test.equal(blocks[1].items[1].definitions[1].blocks[1].text, "first line second line")
+  end)
+
+  test.test("parses nested blockquotes", function()
+    local blocks = MarkdownView.parse_blocks([[
+> Parent
+> > Child
+]])
+
+    test.equal(#blocks, 1)
+    test.equal(blocks[1].type, "quote")
+    test.equal(blocks[1].blocks[1].type, "paragraph")
+    test.equal(blocks[1].blocks[1].text, "Parent")
+    test.equal(blocks[1].blocks[2].type, "quote")
+    test.equal(blocks[1].blocks[2].blocks[1].text, "Child")
+  end)
+
+  test.test("parses setext headings", function()
+    local blocks = MarkdownView.parse_blocks([[
+Heading One
+===================
+
+Heading Two
+-------------
+]])
+
+    test.equal(#blocks, 2)
+    test.equal(blocks[1].type, "heading")
+    test.equal(blocks[1].level, 1)
+    test.equal(blocks[1].text, "Heading One")
+    test.equal(blocks[2].type, "heading")
+    test.equal(blocks[2].level, 2)
+    test.equal(blocks[2].text, "Heading Two")
+  end)
+
+  test.test("skips html comments", function()
+    local blocks = MarkdownView.parse_blocks([[
+<!--                DO NOT EDIT THIS FILE MANUALLY                -->
+# Heading
+<!--
+multi-line
+comment
+-->
+Paragraph text.
+]])
+
+    test.equal(#blocks, 2)
+    test.equal(blocks[1].type, "heading")
+    test.equal(blocks[1].text, "Heading")
+    test.equal(blocks[2].type, "paragraph")
+    test.equal(blocks[2].text, "Paragraph text.")
+  end)
+
+  test.test("renders layout and restores file-backed state", function(context)
+    local path = context.temp_root .. PATHSEP .. "sample.md"
+    write_file(path, "# Title\n\nParagraph with `inline code`.\n")
+
+    local view = MarkdownView(path)
+    view.size.x = 420
+    view.size.y = 240
+
+    test.equal(view:get_name(), "sample.md Preview")
+    test.ok(view:get_scrollable_size() > 0)
+    test.ok(view:get_h_scrollable_size() > 0)
+
+    local state = view:get_state()
+    test.not_nil(state)
+    test.equal(state.path, path)
+
+    local restored = MarkdownView.from_state(state)
+    test.not_nil(restored)
+    restored.size.x = 420
+    restored.size.y = 240
+    test.equal(restored:get_name(), "sample.md Preview")
+    test.ok(restored:get_scrollable_size() > 0)
+  end)
+
+  test.test("syntax-colors fenced code blocks", function()
+    local view = MarkdownView([[
+```lua
+local lua_var = 1
+```
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local code_line
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" and command.tabbed then
+        code_line = command
+        break
+      end
+    end
+
+    test.not_nil(code_line)
+    local colors_by_text = {}
+    for _, fragment in ipairs(code_line.fragments) do
+      local text = fragment.text:match("^%s*(.-)%s*$")
+      if text ~= "" then
+        colors_by_text[text] = fragment.color
+      end
+    end
+
+    test.equal(MarkdownView.resolve_color(colors_by_text["local"]), style.syntax["keyword"])
+    test.equal(MarkdownView.resolve_color(colors_by_text["lua_var"]), style.syntax["normal"])
+    test.equal(MarkdownView.resolve_color(colors_by_text["="]), style.syntax["operator"])
+    test.equal(MarkdownView.resolve_color(colors_by_text["1"]), style.syntax["number"])
+  end)
+
+  test.test("uses updated style colors without rebuilding layout", function()
+    local view = MarkdownView("plain `code` [link](https://example.com)")
+    view.size.x = 420
+    view.size.y = 240
+    view.position.x = 0
+    view.position.y = 0
+    view:ensure_layout()
+
+    local original_text = style.text
+    local original_background2 = style.background2
+    local original_link = style.syntax["function"]
+    local new_text = { 10, 20, 30, 255 }
+    local new_background2 = { 40, 50, 60, 255 }
+    local new_link = { 70, 80, 90, 255 }
+    local captured_text_colors = {}
+    local captured_rect_colors = {}
+    local original_draw_text = renderer.draw_text
+    local original_draw_rect = renderer.draw_rect
+    local original_push_clip_rect = core.push_clip_rect
+    local original_pop_clip_rect = core.pop_clip_rect
+
+    style.text = new_text
+    style.background2 = new_background2
+    style.syntax["function"] = new_link
+    view.draw_background = function() end
+    view.draw_scrollbar = function() end
+    core.push_clip_rect = function() end
+    core.pop_clip_rect = function() end
+    renderer.draw_rect = function(_, _, _, _, color)
+      captured_rect_colors[#captured_rect_colors + 1] = color
+    end
+    renderer.draw_text = function(font, text, x, y, color, opts)
+      captured_text_colors[text] = color
+      return x + font:get_width(text, opts)
+    end
+
+    view:draw()
+
+    renderer.draw_text = original_draw_text
+    renderer.draw_rect = original_draw_rect
+    core.push_clip_rect = original_push_clip_rect
+    core.pop_clip_rect = original_pop_clip_rect
+    style.text = original_text
+    style.background2 = original_background2
+    style.syntax["function"] = original_link
+
+    test.equal(captured_text_colors["plain"], new_text)
+    test.equal(captured_text_colors["code"], new_text)
+    test.equal(captured_text_colors["link"], new_link)
+    test.ok(#captured_rect_colors > 0)
+    test.equal(captured_rect_colors[1], new_background2)
+  end)
+
+  test.test("renders strikethrough text", function()
+    local view = MarkdownView("~~gone~~ and ~~[linked](https://example.com)~~")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local plain_fragment
+    local linked_fragment
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.text == "gone" then
+            plain_fragment = fragment
+          elseif fragment.url == "https://example.com" then
+            linked_fragment = fragment
+          end
+        end
+      end
+    end
+
+    test.not_nil(plain_fragment)
+    test.not_nil(linked_fragment)
+    test.equal(plain_fragment.font, view:get_font_cache().body.strikethrough)
+    test.equal(linked_fragment.font, view:get_font_cache().body.strikethrough)
+  end)
+
+  test.test("treats single tilde as plain text", function()
+    local view = MarkdownView("single ~ tilde")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local found_tilde
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.text:find("~", 1, true) then
+            found_tilde = true
+          end
+        end
+      end
+    end
+
+    test.ok(found_tilde)
+  end)
+
+  test.test("treats lone exclamation as plain text", function()
+    local view = MarkdownView("Install and profit!")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local found_exclamation
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.text:find("!", 1, true) then
+            found_exclamation = true
+          end
+        end
+      end
+    end
+
+    test.ok(found_exclamation)
+  end)
+
+  test.test("treats trailing backslash as plain text", function()
+    local view = MarkdownView("ends with slash\\")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local found_backslash
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.text:find("\\", 1, true) then
+            found_backslash = true
+          end
+        end
+      end
+    end
+
+    test.ok(found_backslash)
+  end)
+
+  test.test("parses markdown tables", function()
+    local blocks = MarkdownView.parse_blocks([[
+| Plugin | Description |
+| --- | --- |
+| [`ppm`](plugins/ppm.lua?raw=1) | Plugin manager. |
+| [`linter`](plugins/linter.lua?raw=1) | Reports diagnostics in the editor. |
+]])
+
+    test.equal(#blocks, 1)
+    test.equal(blocks[1].type, "table")
+    test.equal(#blocks[1].headers, 2)
+    test.equal(#blocks[1].rows, 2)
+    test.equal(blocks[1].headers[1].text, "Plugin")
+    test.equal(blocks[1].rows[1][1].text, "[`ppm`](plugins/ppm.lua?raw=1)")
+  end)
+
+  test.test("renders markdown tables with cell links", function()
+    local view = MarkdownView([[
+| Plugin | Description |
+| --- | --- |
+| [`ppm`](plugins/ppm.lua?raw=1) | Plugin manager with [docs](https://example.com/docs). |
+| [`linter`](plugins/linter.lua?raw=1) | Reports diagnostics in the editor. |
+]])
+    view.size.x = 640
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local urls = {}
+    for _, command in ipairs(layout.commands) do
+      if command.links then
+        for _, link in ipairs(command.links) do
+          urls[#urls + 1] = link.url
+        end
+      end
+    end
+
+    test.same(urls, {
+      "plugins/ppm.lua?raw=1",
+      "https://example.com/docs",
+      "plugins/linter.lua?raw=1"
+    })
+    test.ok(layout.content_width > 0)
+    test.ok(view:get_scrollable_size() > 0)
+  end)
+
+  test.test("renders task list markers as checkboxes", function()
+    local view = MarkdownView([[
+- [ ] Open task
+- [x] Done task
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local markers = {}
+    for _, command in ipairs(layout.commands) do
+      if command.type == "checkbox" then
+        markers[#markers + 1] = {
+          checked = command.checked,
+          width = command.width,
+          height = command.height
+        }
+      end
+    end
+
+    test.equal(#markers, 2)
+    test.equal(markers[1].checked, false)
+    test.equal(markers[2].checked, true)
+    test.equal(markers[1].width, markers[2].width)
+    test.equal(markers[1].height, markers[2].height)
+  end)
+
+  test.test("renders nested list items with increasing indent", function()
+    local view = MarkdownView([[
+- [ ] Parent
+  - [x] Child
+    - [ ] Grandchild
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local xs = {}
+    for _, command in ipairs(layout.commands) do
+      if command.type == "checkbox" then
+        xs[#xs + 1] = command.x
+      end
+    end
+
+    table.sort(xs)
+    test.equal(#xs, 3)
+    test.ok(xs[2] > xs[1])
+    test.ok(xs[3] > xs[2])
+  end)
+
+  test.test("renders nested bullets instead of indented code for marker-aligned children", function()
+    local view = MarkdownView([[
+*   Parent
+
+    *   Linux path
+    *   Windows path
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local bullets = {}
+    local code_lines = 0
+    for _, command in ipairs(view:ensure_layout().commands) do
+      if command.type == "text" and command.fragments[1] then
+        if command.fragments[1].text == "\226\128\162" then
+          bullets[#bullets + 1] = command.x
+        end
+        if command.tabbed then
+          code_lines = code_lines + 1
+        end
+      end
+    end
+
+    table.sort(bullets)
+    test.equal(#bullets, 3)
+    test.ok(bullets[2] > bullets[1])
+    test.equal(code_lines, 0)
+  end)
+
+  test.test("renders hard line breaks as separate lines", function()
+    local view = MarkdownView([[
+First line  
+Second line
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local text_commands = {}
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        text_commands[#text_commands + 1] = command
+      end
+    end
+
+    test.ok(#text_commands >= 2)
+    test.ok(text_commands[2].y > text_commands[1].y)
+  end)
+
+  test.test("renders inline images inside paragraphs", function(context)
+    local image_path = context.project_temp_root .. PATHSEP .. "icon.png"
+    local source_path = context.project_temp_root .. PATHSEP .. "inline-image.md"
+    write_file(image_path, "not-a-real-png")
+    write_file(source_path, "Start ![Icon](icon.png) end\n")
+
+    local original_load_image = canvas.load_image
+    local loaded_path
+    canvas.load_image = function(path)
+      loaded_path = path
+      return {
+        get_size = function()
+          return 64, 32
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+
+    local view = MarkdownView(source_path)
+    view.size.x = 420
+    view.size.y = 240
+    local layout = view:ensure_layout()
+    canvas.load_image = original_load_image
+
+    local inline_image
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.type == "image" then
+            inline_image = fragment
+          end
+        end
+      end
+    end
+
+    test.equal(loaded_path, image_path)
+    test.not_nil(inline_image)
+    test.ok(inline_image.width > 0)
+    test.ok(inline_image.height > 0)
+  end)
+
+  test.test("supports multi-backtick code spans and link titles", function()
+    local view = MarkdownView("``code ` span`` and [link](https://example.com/a_(b) \"Title\")")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local code_texts = {}
+    local link_fragment
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.font == view:get_font_cache().body.code then
+            code_texts[#code_texts + 1] = fragment.text
+          elseif fragment.url == "https://example.com/a_(b)" then
+            link_fragment = fragment
+          end
+        end
+      end
+    end
+
+    test.same(code_texts, { "code ` span" })
+    test.not_nil(link_fragment)
+  end)
+
+  test.test("keeps inline code spans as a single wrapped fragment", function()
+    local view = MarkdownView('* 32 bit: `cmake -G "Visual Studio 12 2013" -DCMAKE_BUILD_TYPE=Release ..`')
+    view.size.x = 420
+    view.size.y = 240
+
+    local code_fragments = {}
+    for _, command in ipairs(view:ensure_layout().commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.font == view:get_font_cache().body.code then
+            code_fragments[#code_fragments + 1] = fragment.text
+          end
+        end
+      end
+    end
+
+    test.same(code_fragments, {
+      'cmake -G "Visual Studio 12 2013" -DCMAKE_BUILD_TYPE=Release ..'
+    })
+  end)
+
+  test.test("resolves inline links split across soft line breaks", function()
+    local view = MarkdownView([[
+- the [Mbed TLS mailing-list
+  archives](https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/).
+]])
+    view.size.x = 640
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local found
+    for _, command in ipairs(layout.commands) do
+      if command.links then
+        for _, link in ipairs(command.links) do
+          if link.url == "https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/" then
+            found = true
+          end
+        end
+      end
+    end
+
+    test.ok(found)
+  end)
+
+  test.test("resolves bare URLs after intraword underscores", function()
+    local view = MarkdownView("The API can be found in SDL_net.h and online at https://wiki.libsdl.org/SDL3_net")
+    view.size.x = 640
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local found
+    local saw_filename
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.text:find("SDL_net%.h") then
+            saw_filename = true
+          end
+        end
+      end
+      if command.links then
+        for _, link in ipairs(command.links) do
+          if link.url == "https://wiki.libsdl.org/SDL3_net" then
+            found = true
+          end
+        end
+      end
+    end
+
+    test.ok(saw_filename)
+    test.ok(found)
+  end)
+
+  test.test("renders table alignment markers", function()
+    local view = MarkdownView([[
+| Left | Right |
+| :--- | ---: |
+| a | b |
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local positions = {}
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        local text = command.fragments[1] and command.fragments[1].text
+        if text == "a" or text == "b" then
+          positions[text] = command.x
+        end
+      end
+    end
+
+    test.not_nil(positions["a"])
+    test.not_nil(positions["b"])
+    test.ok(positions["b"] > positions["a"])
+  end)
+
+  test.test("renders footnote references and anchors", function()
+    local view = MarkdownView([[
+Text with a footnote.[^note]
+
+[^note]: Footnote body
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local found_ref
+    for _, command in ipairs(layout.commands) do
+      if command.links then
+        for _, link in ipairs(command.links) do
+          if link.url == "#footnote-note" then
+            found_ref = link
+          end
+        end
+      end
+    end
+
+    test.not_nil(found_ref)
+    test.not_nil(layout.anchors["footnote-note"])
+    view:open_link("#footnote-note")
+    test.equal(view.scroll.to.y, layout.anchors["footnote-note"])
+  end)
+
+  test.test("renders images inside markdown tables", function(context)
+    local preview_dir = context.project_temp_root .. PATHSEP .. "previews"
+    local source_path = context.project_temp_root .. PATHSEP .. "colors.md"
+    local preview_path = preview_dir .. PATHSEP .. "abyss.svg"
+    local ok, err = common.mkdirp(preview_dir)
+    test.ok(ok, err)
+    write_file(preview_path, "<svg></svg>")
+    write_file(source_path, [[
+| Theme | Preview |
+| --- | --- |
+| [abyss](colors/abyss.lua?raw=1) | ![abyss_preview](previews/abyss.svg) |
+]])
+
+    local original_load_image = canvas.load_image
+    local loaded_path
+    canvas.load_image = function(path)
+      loaded_path = path
+      return {
+        get_size = function()
+          return 96, 48
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+
+    local view = MarkdownView(source_path)
+    view.size.x = 640
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    canvas.load_image = original_load_image
+
+    local image_command
+    for _, command in ipairs(layout.commands) do
+      if command.type == "image" then
+        image_command = command
+        break
+      end
+    end
+
+    test.equal(loaded_path, preview_path)
+    test.not_nil(image_command)
+    test.equal(image_command.width, 96)
+    test.equal(image_command.height, 48)
+  end)
+
+  test.test("renders project-local markdown images", function(context)
+    local image_path = context.project_temp_root .. PATHSEP .. "diagram.png"
+    local source_path = context.project_temp_root .. PATHSEP .. "source.md"
+    write_file(image_path, "not-a-real-png")
+    write_file(source_path, "![Diagram](diagram.png)\n")
+
+    local original_load_image = canvas.load_image
+    local loaded_path
+    canvas.load_image = function(path)
+      loaded_path = path
+      return {
+        get_size = function()
+          return 800, 400
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+
+    local view = MarkdownView(source_path)
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    canvas.load_image = original_load_image
+
+    test.equal(loaded_path, image_path)
+    test.equal(layout.commands[1].type, "image")
+    test.equal(layout.commands[1].x, 0)
+    test.equal(layout.commands[1].width, layout.width)
+    test.equal(layout.commands[1].height, math.floor(400 * (layout.width / 800)))
+  end)
+
+  test.test("downloads remote markdown images to the cache", function()
+    local original_download = http.download
+    local original_load_image = canvas.load_image
+    local download_opts
+    local loaded_path
+
+    http.download = function(url, options)
+      download_opts = {
+        url = url,
+        directory = options.directory,
+        filename = options.filename
+      }
+      if not system.get_file_info(options.directory) then
+        local ok, err = common.mkdirp(options.directory)
+        test.ok(ok, err)
+      end
+      local path = options.directory .. PATHSEP .. options.filename
+      write_file(path, "downloaded-image")
+      options.on_done(true, nil, path, {
+        status = 200,
+        headers = {},
+        url = url
+      })
+    end
+
+    canvas.load_image = function(path)
+      loaded_path = path
+      return {
+        get_size = function()
+          return 320, 160
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+
+    local view = MarkdownView("![Remote](https://example.com/assets/diagram.png)")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+
+    http.download = original_download
+    canvas.load_image = original_load_image
+
+    test.not_nil(download_opts)
+    test.equal(download_opts.url, "https://example.com/assets/diagram.png")
+    test.equal(download_opts.directory, USERDIR .. PATHSEP .. "cache")
+    test.equal(loaded_path, download_opts.directory .. PATHSEP .. download_opts.filename)
+    test.equal(layout.commands[1].type, "image")
+
+    if loaded_path and system.get_file_info(loaded_path) then
+      local ok, err = common.rm(loaded_path)
+      test.ok(ok, err)
+    end
+  end)
+
+  test.test("renders linked image reference rows and opens their target link", function()
+    local original_download = http.download
+    local original_load_image = canvas.load_image
+    local download_opts = {}
+    local opened
+
+    http.download = function(url, options)
+      download_opts[#download_opts + 1] = {
+        url = url,
+        directory = options.directory,
+        filename = options.filename
+      }
+      if not system.get_file_info(options.directory) then
+        local ok, err = common.mkdirp(options.directory)
+        test.ok(ok, err)
+      end
+      local path = options.directory .. PATHSEP .. options.filename
+      write_file(path, "downloaded-image")
+      options.on_done(true, nil, path, {
+        status = 200,
+        headers = {},
+        url = url
+      })
+    end
+
+    canvas.load_image = function()
+      return {
+        get_size = function()
+          return 140, 40
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+
+    local view = MarkdownView([=[
+[![Build Rolling]](https://github.com/pragtical/pragtical/actions/workflows/rolling.yml)
+[![Discord]](https://discord.gg/8V2yJtn3Fc)
+
+[Build Rolling]: https://github.com/pragtical/pragtical/actions/workflows/rolling.yml/badge.svg
+[Discord]: https://discord.com/api/guilds/1285023036071743542/widget.png?style=shield
+]=])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local first_image = layout.commands[1]
+    local second_image = layout.commands[2]
+    test.equal(first_image.type, "image")
+    test.equal(second_image.type, "image")
+    test.equal(first_image.x, 0)
+    test.ok(first_image.y > 0)
+    test.ok(second_image.x > first_image.x)
+    test.equal(second_image.y, first_image.y)
+    test.equal(first_image.link_url, "https://github.com/pragtical/pragtical/actions/workflows/rolling.yml")
+    test.equal(second_image.link_url, "https://discord.gg/8V2yJtn3Fc")
+    test.equal(#download_opts, 2)
+    test.equal(download_opts[1].url, "https://github.com/pragtical/pragtical/actions/workflows/rolling.yml/badge.svg")
+    test.equal(download_opts[2].url, "https://discord.com/api/guilds/1285023036071743542/widget.png?style=shield")
+
+    local original_open_in_system = common.open_in_system
+    common.open_in_system = function(url)
+      opened = url
+      return true
+    end
+
+    local x = view.position.x + style.padding.x + second_image.x + 1
+    local y = view.position.y + style.padding.y + second_image.y + 1
+    view:on_mouse_moved(x, y, 0, 0)
+    test.equal(view.cursor, "hand")
+    view:on_mouse_pressed("left", x, y, 1)
+
+    common.open_in_system = original_open_in_system
+    http.download = original_download
+    canvas.load_image = original_load_image
+
+    test.equal(opened, "https://discord.gg/8V2yJtn3Fc")
+
+    for _, item in ipairs(download_opts) do
+      local cache_path = item.directory .. PATHSEP .. item.filename
+      if system.get_file_info(cache_path) then
+        local ok, err = common.rm(cache_path)
+        test.ok(ok, err)
+      end
+    end
+  end)
+
+  test.test("resolves inline and reference links", function()
+    local view = MarkdownView([[
+[inline](https://example.com) and [docs][ref]
+For more detailed instructions visit: https://pragtical.dev/docs/setup/building
+
+[ref]: https://example.org
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local urls = {}
+    for _, command in ipairs(layout.commands) do
+      if command.links then
+        for _, link in ipairs(command.links) do
+          urls[#urls + 1] = link.url
+        end
+      end
+    end
+
+    test.same(urls, {
+      "https://example.com",
+      "https://example.org",
+      "https://pragtical.dev/docs/setup/building"
+    })
+
+    local first_link_fragment
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.url == "https://example.com" then
+            first_link_fragment = fragment
+            break
+          end
+        end
+      end
+    end
+
+    test.not_nil(first_link_fragment)
+    test.equal(MarkdownView.resolve_color(first_link_fragment.color), style.syntax["function"])
+  end)
+
+  test.test("resolves bold reference links", function()
+    local view = MarkdownView([[
+**[Get Pragtical]**
+
+[Get Pragtical]: https://github.com/pragtical/pragtical/releases
+]])
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local target
+    for _, command in ipairs(layout.commands) do
+      if command.links and command.links[1] then
+        target = command.links[1]
+        break
+      end
+    end
+
+    test.not_nil(target)
+    test.equal(target.url, "https://github.com/pragtical/pragtical/releases")
+
+    local link_fragment
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.url == target.url then
+            link_fragment = fragment
+            break
+          end
+        end
+      end
+    end
+
+    test.not_nil(link_fragment)
+    test.equal(link_fragment.font, view:get_font_cache().body.bold)
+  end)
+
+  test.test("opens clicked links in the system browser", function()
+    local view = MarkdownView("[inline](https://example.com)")
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local target
+    for _, command in ipairs(layout.commands) do
+      if command.links and command.links[1] then
+        target = command.links[1]
+        break
+      end
+    end
+
+    test.not_nil(target)
+
+    local opened
+    local original = common.open_in_system
+    local original_show_tooltip = core.status_view.show_tooltip
+    local original_remove_tooltip = core.status_view.remove_tooltip
+    local tooltip
+    local tooltip_removed = 0
+    common.open_in_system = function(url)
+      opened = url
+      return true
+    end
+    core.status_view.show_tooltip = function(_, text)
+      tooltip = text
+    end
+    core.status_view.remove_tooltip = function()
+      tooltip_removed = tooltip_removed + 1
+      tooltip = nil
+    end
+
+    local x = view.position.x + style.padding.x + target.x + 1
+    local y = view.position.y + style.padding.y + target.y + 1
+    view:on_mouse_moved(x, y, 0, 0)
+    test.equal(view.cursor, "hand")
+    test.equal(tooltip, "Open https://example.com")
+    view:on_mouse_pressed("left", x, y, 1)
+    test.equal(opened, "https://example.com")
+    view:on_mouse_left()
+    test.equal(tooltip_removed, 1)
+
+    common.open_in_system = original
+    core.status_view.show_tooltip = original_show_tooltip
+    core.status_view.remove_tooltip = original_remove_tooltip
+  end)
+
+  test.test("opens project markdown links in a new preview", function(context)
+    local target_path = context.project_temp_root .. PATHSEP .. "target.md"
+    local source_path = context.project_temp_root .. PATHSEP .. "source.md"
+    write_file(target_path, "# Target\n")
+    write_file(source_path, "[Preview][doc]\n\n[doc]: target.md\n")
+
+    local view = MarkdownView(source_path)
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local target = layout.commands[1].links[1]
+    test.not_nil(target)
+
+    local opened_markdown
+    local opened_file
+    local opened_external
+    local original_open_markdown = core.open_markdown
+    local original_open_file = core.open_file
+    local original_open_in_system = common.open_in_system
+
+    core.open_markdown = function(path)
+      opened_markdown = path
+    end
+    core.open_file = function(path)
+      opened_file = path
+    end
+    common.open_in_system = function(url)
+      opened_external = url
+    end
+
+    local x = view.position.x + style.padding.x + target.x + 1
+    local y = view.position.y + style.padding.y + target.y + 1
+    view:on_mouse_pressed("left", x, y, 1)
+
+    core.open_markdown = original_open_markdown
+    core.open_file = original_open_file
+    common.open_in_system = original_open_in_system
+
+    test.equal(opened_markdown, target_path)
+    test.is_nil(opened_file)
+    test.is_nil(opened_external)
+  end)
+
+  test.test("opens project file links in the editor", function(context)
+    local target_path = context.project_temp_root .. PATHSEP .. "notes.txt"
+    local source_path = context.project_temp_root .. PATHSEP .. "source.md"
+    write_file(target_path, "notes\n")
+    write_file(source_path, "[Notes](notes.txt)\n")
+
+    local view = MarkdownView(source_path)
+    view.size.x = 420
+    view.size.y = 240
+
+    local layout = view:ensure_layout()
+    local target = layout.commands[1].links[1]
+    test.not_nil(target)
+
+    local opened_markdown
+    local opened_file
+    local opened_external
+    local original_open_markdown = core.open_markdown
+    local original_open_file = core.open_file
+    local original_open_in_system = common.open_in_system
+
+    core.open_markdown = function(path)
+      opened_markdown = path
+    end
+    core.open_file = function(path)
+      opened_file = path
+    end
+    common.open_in_system = function(url)
+      opened_external = url
+    end
+
+    local x = view.position.x + style.padding.x + target.x + 1
+    local y = view.position.y + style.padding.y + target.y + 1
+    view:on_mouse_pressed("left", x, y, 1)
+
+    core.open_markdown = original_open_markdown
+    core.open_file = original_open_file
+    common.open_in_system = original_open_in_system
+
+    test.equal(opened_file, target_path)
+    test.is_nil(opened_markdown)
+    test.is_nil(opened_external)
+  end)
+
+  test.test("opens markdown files as text docs", function(context)
+    local path = context.temp_root .. PATHSEP .. "opened.md"
+    write_file(path, "# Opened\n\nFrom core.open_file.\n")
+
+    local node = core.root_view:get_active_node_default()
+    local view = core.open_file(path)
+    test.ok(view:extends(DocView))
+    node:close_view(core.root_view.root_node, view)
+  end)
+
+  test.test("previews the active markdown doc", function(context)
+    local path = context.temp_root .. PATHSEP .. "preview.md"
+    write_file(path, "# Preview\n\nInitial text.\n")
+
+    local doc_view = core.open_file(path)
+    test.ok(doc_view:extends(DocView))
+    test.ok(command.is_valid("core:preview-markdown"))
+
+    doc_view.doc:insert(3, 1, "Unsaved change.\n")
+    command.perform("core:preview-markdown")
+
+    local preview
+    for _, view in ipairs(core.root_view.root_node:get_children()) do
+      if view:extends(MarkdownView) and view.doc == doc_view.doc then
+        preview = view
+        break
+      end
+    end
+
+    test.not_nil(preview)
+    test.equal(preview:get_name(), "preview.md Preview")
+    preview:update()
+    test.match(preview.text, "Unsaved change")
+
+    local preview_node = core.root_view.root_node:get_node_for_view(preview)
+    local doc_node = core.root_view.root_node:get_node_for_view(doc_view)
+    preview_node:close_view(core.root_view.root_node, preview)
+    doc_node:close_view(core.root_view.root_node, doc_view)
+  end)
+
+  test.test("places markdown previews according to config.markdown_preview_mode", function(context)
+    local path = context.temp_root .. PATHSEP .. "preview-placement.md"
+    write_file(path, "# Preview\n")
+
+    local original_mode = config.markdown_preview_mode
+    local modes = {
+      right = "right",
+      left = "left",
+      top = "up",
+      bottom = "down",
+      newtab = "newtab"
+    }
+
+    for mode, direction in pairs(modes) do
+      config.markdown_preview_mode = mode
+      local doc_view = core.open_file(path)
+      local doc_node = core.root_view.root_node:get_node_for_view(doc_view)
+
+      command.perform("core:preview-markdown")
+
+      local preview
+      for _, view in ipairs(core.root_view.root_node:get_children()) do
+        if view:extends(MarkdownView) and view.doc == doc_view.doc then
+          preview = view
+          break
+        end
+      end
+
+      test.not_nil(preview, mode)
+      local preview_node = core.root_view.root_node:get_node_for_view(preview)
+      if direction == "newtab" then
+        test.equal(preview_node, doc_node)
+      else
+        local parent = preview_node:get_parent_node(core.root_view.root_node)
+        test.not_nil(parent, mode)
+        local split_type = (direction == "left" or direction == "right") and "hsplit" or "vsplit"
+        local split_child = (direction == "left" or direction == "up") and parent.a or parent.b
+        test.equal(parent.type, split_type)
+        test.equal(split_child, preview_node)
+      end
+
+      preview_node:close_view(core.root_view.root_node, preview)
+      doc_node = core.root_view.root_node:get_node_for_view(doc_view)
+      doc_node:close_view(core.root_view.root_node, doc_view)
+    end
+
+    config.markdown_preview_mode = original_mode
+  end)
+end)

--- a/scripts/lua/tests/system.lua
+++ b/scripts/lua/tests/system.lua
@@ -2,6 +2,7 @@ local common = require "core.common"
 local test = require "core.test"
 
 local temp_root
+local original_cwd
 
 local function assert_callable(value, name)
   local value_type = type(value)
@@ -11,16 +12,25 @@ end
 
 test.describe("system", function()
   test.before_each(function(context)
+    original_cwd = system.getcwd()
+    if not original_cwd then
+      original_cwd = USERDIR
+      system.chdir(original_cwd)
+    end
     temp_root = USERDIR
       .. PATHSEP .. "system-tests-"
       .. system.get_process_id() .. "-"
       .. math.floor(system.get_time() * 1000000)
     local ok, err = common.mkdirp(temp_root)
     test.ok(ok, err)
+    context.original_cwd = original_cwd
     context.temp_root = temp_root
   end)
 
   test.after_each(function(context)
+    if context.original_cwd then
+      system.chdir(context.original_cwd)
+    end
     if context.temp_root and system.get_file_info(context.temp_root) then
       local ok, err = common.rm(context.temp_root, true)
       test.ok(ok, err)
@@ -47,7 +57,6 @@ test.describe("system", function()
   end)
 
   test.test("handles filesystem utilities", function(context)
-    local cwd = system.getcwd()
     local absolute = system.absolute_path(context.temp_root)
     test.not_nil(absolute)
 
@@ -73,8 +82,9 @@ test.describe("system", function()
 
     system.chdir(nested)
     test.equal(system.getcwd():gsub("[/\\]+$", ""), nested:gsub("[/\\]+$", ""))
-    system.chdir(cwd)
-    test.equal(system.getcwd():gsub("[/\\]+$", ""), cwd:gsub("[/\\]+$", ""))
+    system.chdir(context.original_cwd)
+    test.equal(system.getcwd():gsub("[/\\]+$", ""),
+      context.original_cwd:gsub("[/\\]+$", ""))
 
     if PLATFORM == "Linux" then
       test.type(system.get_fs_type(nested), "string")


### PR DESCRIPTION
MarkdownView adds a native Markdown preview pane to Pragtical. It introduces `core.markdownview`, which parses and renders Markdown with headings, nested lists, task lists, blockquotes, fenced and indented code blocks, tables, footnotes, inline images, local and remote image loading, and clickable links. Fenced code blocks get syntax coloring, project Markdown links open in another preview, non-Markdown file links open in the editor, and the feature is exposed through `markdown-view:preview` for an active Markdown doc, `markdown-view:view-raw` from a Markdown preview, and Preview Markdown in the treeview and document context menus.

`markdown-view:preview` is bound to `ctrl+alt+m` (`cmd+option+m` on macOS) for easy access. Use `config.markdown_preview_mode` to control how Markdown previews are opened relative to the current document; valid options are `top`, `right`, `bottom`, `left`, and `newtab`. This config flag defaults to `right`, is available in the settings GUI under Markdown Preview, and `markdown-view:view-raw` also follows the same placement behavior when it needs to open a raw Markdown document next to a preview.

Depends on: #398

### Preview

https://github.com/user-attachments/assets/3275bf44-7f47-4b6b-a8bd-ae9f596762ea
