### PR TITLE
Process API: default background to true on Windows

### DIFF
--- a/docs/api/process.lua
+++ b/docs/api/process.lua
@@ -105,7 +105,8 @@ process.REDIRECT_STDOUT = 4
 ---@field public env? table<string, string> | fun(system_env: table<string, string>): string Environment overrides, or a callback returning a NUL-separated environment block.
 ---@field public detach? boolean Run the process detached in the background.
 ---Run the process in the background. Background processes do not inherit
----the terminal and their exit code will always return 0.
+---the terminal and their exit code will always return 0. Defaults to true
+---on windows since a lot of console applications cause cmd window to open.
 ---@field public background? boolean
 
 ---

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -1116,6 +1116,12 @@ static int process_start(lua_State *L) {
       background = lua_toboolean(L, -1);
       SDL_SetBooleanProperty(props, SDL_PROP_PROCESS_CREATE_BACKGROUND_BOOLEAN, background);
     }
+#ifdef _WIN32
+    else {
+      /* default to true on windows, annoying cmd window for everything... */
+      SDL_SetBooleanProperty(props, SDL_PROP_PROCESS_CREATE_BACKGROUND_BOOLEAN, true);
+    }
+#endif
     lua_pop(L, 2);
   }
 


### PR DESCRIPTION
On windows many terminal applications cause a cmd window to open when invoked thru the process API so we default this option to true if not set by user to prevent this annoyance.