### PR TITLE
Use MarkdownView for autocomplete description box

### DIFF
--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -132,6 +132,7 @@ end
 ---@field text string?
 ---@field title string?
 ---@field name string?
+---@field font renderer.font?
 
 ---@class core.markdownview : core.view
 ---@overload fun(source?: string|table, title?: string):core.markdownview
@@ -146,6 +147,7 @@ end
 ---@field footnotes table
 ---@field layout table?
 ---@field font_cache table?
+---@field font renderer.font?
 ---@field last_doc_change_id integer?
 ---@field hovered_link_url string?
 local MarkdownView = View:extend()
@@ -2709,6 +2711,85 @@ local function make_fontset(font)
   }
 end
 
+local function make_shared_fontset(font)
+  return {
+    normal = font,
+    bold = font,
+    italic = font,
+    bold_italic = font,
+    code = font,
+    strikethrough = font,
+    bold_strikethrough = font,
+    italic_strikethrough = font,
+    bold_italic_strikethrough = font,
+    code_strikethrough = font
+  }
+end
+
+local function draw_layout_commands(commands, start_x, start_y, clip_x, clip_y, clip_w, clip_h)
+  core.push_clip_rect(clip_x, clip_y, clip_w, clip_h)
+
+  for _, command in ipairs(commands) do
+    local x = start_x + command.x
+    local y = start_y + command.y
+    if y + command.height >= clip_y and y <= clip_y + clip_h then
+      if command.type == "rect" then
+        renderer.draw_rect(x, y, command.width, command.height, resolve_color(command.color))
+      elseif command.type == "checkbox" then
+        local box_size = command.width
+        local box_x = x
+        local box_y = y + math.max(math.floor((command.height - box_size) / 2), 0)
+        local checkbox_color = resolve_color(command.color)
+        renderer.draw_rect(box_x, box_y, box_size, 1, checkbox_color)
+        renderer.draw_rect(box_x, box_y + box_size - 1, box_size, 1, checkbox_color)
+        renderer.draw_rect(box_x, box_y, 1, box_size, checkbox_color)
+        renderer.draw_rect(box_x + box_size - 1, box_y, 1, box_size, checkbox_color)
+        if command.checked then
+          local fill = math.max(box_size - 4, 1)
+          renderer.draw_rect(box_x + 2, box_y + 2, fill, fill, checkbox_color)
+        end
+      elseif command.type == "image" then
+        renderer.draw_canvas(command.image, x, y)
+      elseif command.type == "text" then
+        local cursor_x = x
+        local tab_offset = 0
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.type == "image" then
+            local draw_y = y + math.max(math.floor((command.height - fragment.height) / 2), 0)
+            renderer.draw_canvas(fragment.image, cursor_x, draw_y)
+            cursor_x = cursor_x + fragment.width
+          else
+            local font_height = fragment.font:get_height()
+            local draw_y = y + (command.height - font_height) / 2
+            if fragment.background then
+              renderer.draw_rect(
+                cursor_x - INLINE_CODE_PADDING_X,
+                draw_y - INLINE_CODE_PADDING_Y,
+                fragment.width + INLINE_CODE_PADDING_X * 2,
+                font_height + INLINE_CODE_PADDING_Y * 2,
+                resolve_color(fragment.background)
+              )
+            end
+            cursor_x = renderer.draw_text(
+              fragment.font,
+              fragment.text,
+              cursor_x,
+              draw_y,
+              resolve_color(fragment.color),
+              command.tabbed and { tab_offset = tab_offset } or nil
+            )
+          end
+          if command.tabbed then
+            tab_offset = cursor_x - x
+          end
+        end
+      end
+    end
+  end
+
+  core.pop_clip_rect()
+end
+
 ---Constructor.
 ---@param source? string|core.markdownview.source
 ---@param title? string
@@ -2729,12 +2810,14 @@ function MarkdownView:new(source, title)
   }
   self.layout = nil
   self.font_cache = nil
+  self.font = nil
   self.last_doc_change_id = nil
 
   if type(source) == "table" then
     self.linked_doc = source.linked_doc or source.doc
     self.path = source.path
     self.title = source.title or source.name or title
+    self.font = source.font
     if self.linked_doc then
       self:refresh_from_doc()
     elseif source.path then
@@ -2839,10 +2922,35 @@ function MarkdownView:get_name()
   return (self.title or "Markdown") .. " Preview"
 end
 
+---Sets a fixed font object for all rendered markdown fonts.
+---@param font? renderer.font
+function MarkdownView:set_font(font)
+  if self.font == font then
+    return
+  end
+  self.font = font
+  self.font_cache = nil
+  self:invalidate_layout()
+end
+
 ---Builds and caches the fonts used by the markdown renderer.
 ---@return table
 function MarkdownView:get_font_cache()
   if not self.font_cache then
+    if self.font then
+      local fontset = make_shared_fontset(self.font)
+      self.font_cache = {
+        body = fontset,
+        quote = fontset,
+        code = self.font,
+        heading = {}
+      }
+      for i = 1, 6 do
+        self.font_cache.heading[i] = fontset
+      end
+      return self.font_cache
+    end
+
     local sizes = {
       30 * SCALE,
       24 * SCALE,
@@ -3018,6 +3126,54 @@ end
 function MarkdownView:get_h_scrollable_size()
   local layout = self:ensure_layout()
   return layout.content_width + style.padding.x * 2
+end
+
+---Returns the rendered size for the given outer width.
+---@param width number
+---@return number width
+---@return number height
+function MarkdownView:get_rendered_size(width)
+  self.size.x = width
+  local layout = self:ensure_layout()
+  return layout.content_width + style.padding.x * 2,
+    layout.height + style.padding.y * 2
+end
+
+---Draws the markdown contents at an arbitrary rectangle.
+---@param x number
+---@param y number
+---@param width number
+---@param height number
+---@param background? renderer.color
+---@param show_scrollbars? boolean
+function MarkdownView:draw_at(x, y, width, height, background, show_scrollbars)
+  self.position.x = x
+  self.position.y = y
+  self.size.x = width
+  self.size.y = height
+
+  if background then
+    renderer.draw_rect(x, y, width, height, background)
+  end
+
+  local layout = self:ensure_layout()
+  if show_scrollbars then
+    self:clamp_scroll_position()
+    self:update_scrollbar()
+  end
+  local ox, oy = self:get_content_offset()
+  draw_layout_commands(
+    layout.commands,
+    ox + style.padding.x,
+    oy + style.padding.y,
+    x,
+    y,
+    width,
+    height
+  )
+  if show_scrollbars then
+    self:draw_scrollbar()
+  end
 end
 
 ---Clears cached font and layout data after a scale change.
@@ -3202,67 +3358,7 @@ function MarkdownView:draw()
   local start_x = ox + style.padding.x
   local start_y = oy + style.padding.y
 
-  core.push_clip_rect(clip_x, clip_y, clip_w, clip_h)
-
-  for _, command in ipairs(layout.commands) do
-    local x = start_x + command.x
-    local y = start_y + command.y
-    if y + command.height >= clip_y and y <= clip_y + clip_h then
-      if command.type == "rect" then
-        renderer.draw_rect(x, y, command.width, command.height, resolve_color(command.color))
-      elseif command.type == "checkbox" then
-        local box_size = command.width
-        local box_x = x
-        local box_y = y + math.max(math.floor((command.height - box_size) / 2), 0)
-        local checkbox_color = resolve_color(command.color)
-        renderer.draw_rect(box_x, box_y, box_size, 1, checkbox_color)
-        renderer.draw_rect(box_x, box_y + box_size - 1, box_size, 1, checkbox_color)
-        renderer.draw_rect(box_x, box_y, 1, box_size, checkbox_color)
-        renderer.draw_rect(box_x + box_size - 1, box_y, 1, box_size, checkbox_color)
-        if command.checked then
-          local fill = math.max(box_size - 4, 1)
-          renderer.draw_rect(box_x + 2, box_y + 2, fill, fill, checkbox_color)
-        end
-      elseif command.type == "image" then
-        renderer.draw_canvas(command.image, x, y)
-      elseif command.type == "text" then
-        local cursor_x = x
-        local tab_offset = 0
-        for _, fragment in ipairs(command.fragments) do
-          if fragment.type == "image" then
-            local draw_y = y + math.max(math.floor((command.height - fragment.height) / 2), 0)
-            renderer.draw_canvas(fragment.image, cursor_x, draw_y)
-            cursor_x = cursor_x + fragment.width
-          else
-            local font_height = fragment.font:get_height()
-            local draw_y = y + (command.height - font_height) / 2
-            if fragment.background then
-              renderer.draw_rect(
-                cursor_x - INLINE_CODE_PADDING_X,
-                draw_y - INLINE_CODE_PADDING_Y,
-                fragment.width + INLINE_CODE_PADDING_X * 2,
-                font_height + INLINE_CODE_PADDING_Y * 2,
-                resolve_color(fragment.background)
-              )
-            end
-            cursor_x = renderer.draw_text(
-              fragment.font,
-              fragment.text,
-              cursor_x,
-              draw_y,
-              resolve_color(fragment.color),
-              command.tabbed and { tab_offset = tab_offset } or nil
-            )
-          end
-          if command.tabbed then
-            tab_offset = cursor_x - x
-          end
-        end
-      end
-    end
-  end
-
-  core.pop_clip_rect()
+  draw_layout_commands(layout.commands, start_x, start_y, clip_x, clip_y, clip_w, clip_h)
   self:draw_scrollbar()
 end
 

--- a/data/plugins/autocomplete.lua
+++ b/data/plugins/autocomplete.lua
@@ -7,6 +7,7 @@ local keymap = require "core.keymap"
 local style = require "core.style"
 local Doc = require "core.doc"
 local DocView = require "core.docview"
+local MarkdownView = require "core.markdownview"
 local RootView = require "core.rootview"
 
 ---@class plugins.autocomplete.symbolinfo
@@ -393,12 +394,23 @@ local suggestions_offset = 1
 local suggestions_idx = 1
 local suggestions = {}
 local last_line, last_col
+local desc_view
+local desc_view_text
+local desc_view_font
+local desc_rect
+local desc_font_size = config.plugins.autocomplete.desc_font_size
+local previous_scale = SCALE
+local desc_font = style.code_font:copy(desc_font_size * SCALE)
 
 
 local function reset_suggestions(skip_close)
   suggestions_offset = 1
   suggestions_idx = 1
   suggestions = {}
+  desc_rect = nil
+  desc_view = nil
+  desc_view_text = nil
+  desc_view_font = nil
 
   triggered_manually = false
 
@@ -587,120 +599,65 @@ local function get_suggestions_rect(av)
     has_icons
 end
 
-local function wrap_line(line, max_chars)
-  if #line > max_chars then
-    local lines = {}
-    local line_len = #line
-    local new_line = ""
-    local prev_char = ""
-    local position = 0
-    local indent = line:match("^%s+")
-    for char in line:gmatch(".") do
-      position = position + 1
-      if #new_line < max_chars then
-        new_line = new_line .. char
-        prev_char = char
-        if position >= line_len then
-          table.insert(lines, new_line)
-        end
-      else
-        if
-          not prev_char:match("%s")
-          and
-          not string.sub(line, position+1, 1):match("%s")
-          and
-          position < line_len
-        then
-          new_line = new_line .. "-"
-        end
-        table.insert(lines, new_line)
-        if indent then
-          new_line = indent .. char
-        else
-          new_line = char
-        end
-      end
-    end
-    return lines
-  end
-  return line
+local function point_over_rect(x, y, rect)
+  return rect
+    and x >= rect.x and y >= rect.y
+    and x <= rect.x + rect.w and y <= rect.y + rect.h
 end
 
-local previous_scale = SCALE
-local desc_font = style.code_font:copy(
-  config.plugins.autocomplete.desc_font_size * SCALE
-)
-local function draw_description_box(text, sx, sy, sw, sh)
-  if previous_scale ~= SCALE then
-    desc_font = style.code_font:copy(
-      config.plugins.autocomplete.desc_font_size * SCALE
-    )
+local function get_description_view(text)
+  local font_size = config.plugins.autocomplete.desc_font_size
+  if previous_scale ~= SCALE or desc_font_size ~= font_size then
+    desc_font = style.code_font:copy(font_size * SCALE)
+    desc_font_size = font_size
     previous_scale = SCALE
   end
 
-  local ww = system.get_window_size(core.window)
+  if
+    not desc_view
+    or desc_view_text ~= text
+    or desc_view_font ~= desc_font
+  then
+    desc_view = MarkdownView({
+      text = text,
+      title = "Completion Documentation",
+      font = desc_font
+    })
+    desc_view_text = text
+    desc_view_font = desc_font
+  end
+  return desc_view
+end
 
-  local font = desc_font
-  local lh = font:get_height()
-  local y = sy + style.padding.y
-  local x = sx + sw + style.padding.x / 4
-  local width = 0
-  local char_width = font:get_width(" ")
-  local draw_left = false;
+local function draw_description_box(text, sx, sy, sw, sh)
+  local ww, wh = system.get_window_size(core.window)
+  local gap = style.padding.x / 4
+  local max_width = math.max(260 * SCALE, ww * 0.35)
+  local x = sx + sw + gap
+  local y = sy
+  local width
 
-  local max_chars = 0
   if sw > (ww - style.padding.x * 2) * 0.5 then
-    sy = sy + sh + style.padding.x / 4
-    y = sy + style.padding.y
     x = sx
-    max_chars = ((ww - x - style.padding.x * 4) / char_width)
+    y = sy + sh + gap
+    width = math.min(sw, ww - x - style.padding.x * 2)
   elseif sx < ww - sx - sw then
-    max_chars = (((ww) - x) / char_width) - 5
+    width = math.min(max_width, ww - x - style.padding.x * 2)
   else
-    draw_left = true;
-    max_chars = (
-      (sx - (style.padding.x / 4) - style.scrollbar_size)
-      / char_width
-    ) - 5
+    width = math.min(max_width, sx - gap - style.padding.x * 2)
+    x = sx - gap - width
   end
 
-  local lines = {}
-  for line in string.gmatch(text.."\n", "(.-)\n") do
-    local wrapper_lines = wrap_line(line, max_chars)
-    if type(wrapper_lines) == "table" then
-      for _, wrapped_line in pairs(wrapper_lines) do
-        width = math.max(width, font:get_width(wrapped_line))
-        table.insert(lines, wrapped_line)
-      end
-    else
-      width = math.max(width, font:get_width(line))
-      table.insert(lines, line)
-    end
-  end
+  width = math.max(width, 160 * SCALE)
 
-  if draw_left then
-    x = sx - (style.padding.x / 4) - width - (style.padding.x * 2)
-  end
+  local view = get_description_view(text)
+  local _, content_height = view:get_rendered_size(width)
+  local max_height = math.max(120 * SCALE, wh * 0.55)
+  local available_height = wh - y - style.padding.y
+  local height = math.min(content_height, max_height, math.max(available_height, 1))
 
-  local height = #lines * font:get_height()
-
-  -- draw background rect
-  renderer.draw_rect(
-    x,
-    sy,
-    width + style.padding.x * 2,
-    height + style.padding.y * 2,
-    style.background3
-  )
-
-  -- draw text
-  for _, line in pairs(lines) do
-    common.draw_text(
-      font, style.text, line, "left",
-      x + style.padding.x, y, width, lh
-    )
-    y = y + lh
-  end
+  view:draw_at(x, y, width, height, style.background3, true)
+  desc_rect = { x = x, y = y, w = width, h = height }
 end
 
 local function draw_suggestions_box(av)
@@ -713,6 +670,7 @@ local function draw_suggestions_box(av)
   -- draw background rect
   local rx, ry, rw, rh, has_icons = get_suggestions_rect(av)
   renderer.draw_rect(rx, ry, rw, rh, style.background3)
+  desc_rect = nil
 
   -- draw text
   local font = av:get_font()
@@ -855,12 +813,68 @@ end
 local on_text_input = RootView.on_text_input
 local on_text_remove = Doc.remove
 local on_doc_close = Doc.on_close
+local on_mouse_pressed = RootView.on_mouse_pressed
+local on_mouse_released = RootView.on_mouse_released
+local on_mouse_moved = RootView.on_mouse_moved
+local on_mouse_wheel = RootView.on_mouse_wheel
 local update = RootView.update
 local draw = RootView.draw
 
 RootView.on_text_input = function(...)
   on_text_input(...)
   show_autocomplete()
+end
+
+RootView.on_mouse_pressed = function(self, button, x, y, clicks)
+  if desc_view and point_over_rect(x, y, desc_rect) then
+    if desc_view:on_mouse_pressed(button, x, y, clicks) then
+      return true
+    end
+  end
+  return on_mouse_pressed(self, button, x, y, clicks)
+end
+
+RootView.on_mouse_released = function(self, button, x, y)
+  if desc_view then
+    desc_view:on_mouse_released(button, x, y)
+  end
+  return on_mouse_released(self, button, x, y)
+end
+
+RootView.on_mouse_moved = function(self, x, y, dx, dy)
+  if desc_view and (point_over_rect(x, y, desc_rect) or desc_view:scrollbar_dragging()) then
+    local handled = desc_view:on_mouse_moved(x, y, dx, dy)
+    if handled then
+      core.request_cursor(desc_view.cursor)
+      core.redraw = true
+      return true
+    end
+    local result = on_mouse_moved(self, x, y, dx, dy)
+    core.request_cursor(desc_view.cursor)
+    core.redraw = true
+    return result
+  elseif desc_view then
+    desc_view:on_mouse_left()
+  end
+  return on_mouse_moved(self, x, y, dx, dy)
+end
+
+RootView.on_mouse_wheel = function(self, y, x)
+  if desc_view and point_over_rect(core.root_view.mouse.x, core.root_view.mouse.y, desc_rect) then
+    if keymap.modkeys["shift"] then
+      x = y
+      y = 0
+    end
+    if y and y ~= 0 then
+      desc_view.scroll.to.y = desc_view.scroll.to.y + y * -config.mouse_wheel_scroll
+    end
+    if x and x ~= 0 then
+      desc_view.scroll.to.x = desc_view.scroll.to.x + x * -config.mouse_wheel_scroll
+    end
+    core.redraw = true
+    return true
+  end
+  return on_mouse_wheel(self, y, x)
 end
 
 Doc.remove = function(self, line1, col1, line2, col2)
@@ -882,6 +896,10 @@ end
 
 RootView.update = function(...)
   update(...)
+
+  if desc_view then
+    desc_view:update()
+  end
 
   local av = get_active_view()
   if av then

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -328,6 +328,51 @@ local lua_var = 1
     test.equal(MarkdownView.resolve_color(colors_by_text["1"]), style.syntax["number"])
   end)
 
+  test.test("uses a fixed font object for all markdown font roles when configured", function()
+    local fixed_font = style.code_font:copy(12 * SCALE)
+    local view = MarkdownView({
+      text = [[
+# Heading
+
+Paragraph with `inline`.
+
+```lua
+local lua_var = 1
+```
+]],
+      font = fixed_font
+    })
+    view.size.x = 420
+    view.size.y = 240
+
+    local fonts = view:get_font_cache()
+
+    test.equal(fonts.body.normal, fixed_font)
+    test.equal(fonts.body.bold, fixed_font)
+    test.equal(fonts.body.italic, fixed_font)
+    test.equal(fonts.body.strikethrough, fixed_font)
+    test.equal(fonts.body.code, fixed_font)
+    test.equal(fonts.code, fixed_font)
+    test.equal(fonts.heading[1].normal, fixed_font)
+    test.equal(fonts.heading[1].bold, fixed_font)
+
+    for _, command in ipairs(view:ensure_layout().commands) do
+      if command.type == "text" then
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.font then
+            test.equal(fragment.font, fixed_font)
+          end
+        end
+      end
+    end
+
+    local default_view = MarkdownView("# Heading\n\nParagraph")
+    test.ok(
+      default_view:get_font_cache().heading[1].normal:get_size()
+      > default_view:get_font_cache().body.normal:get_size()
+    )
+  end)
+
   test.test("uses updated style colors without rebuilding layout", function()
     local view = MarkdownView("plain `code` [link](https://example.com)")
     view.size.x = 420


### PR DESCRIPTION
Modifies MarkdownView to allow its usage as a floating view. This allows it to wire it into different places like the autocomplete description box as in the LSP plugin.

Note: In the future we should implement floating views to ease the implementation on the autocomplete plugin.

### Preview

https://github.com/user-attachments/assets/12bb6b36-4248-4326-bc0b-821d83ecd6d1