### PR TITLE
Filter non used events on the events queue

### DIFF
--- a/src/system_events.c
+++ b/src/system_events.c
@@ -16,15 +16,75 @@
  * SDL_PeepEvents() loop used to do in f_poll_event().
  * ------------------------------------------------------------------------- */
 
-/* 256 slots give plenty of headroom for a full key-repeat burst plus several
- * pending mouse-motion and touch events without allocating heap memory. */
-#define SYSTEM_EVENT_QUEUE_SIZE 256
+/* 512 slots give plenty of headroom for a full key-repeat burst plus several
+ * pending mouse-motion and touch events without allocating heap memory.
+ * Unhandled event types are filtered out in system_push_event() so they
+ * never waste queue slots. */
+#define SYSTEM_EVENT_QUEUE_SIZE 512
 
 static SDL_Event system_event_queue[SYSTEM_EVENT_QUEUE_SIZE];
 static int       system_event_queue_read  = 0;
 static int       system_event_queue_count = 0;
 
+/* Keep this in sync with the switch in f_poll_event() (src/api/system.c).
+ * Only types listed here are allowed into the ring buffer; everything else
+ * is silently discarded at the SDL callback boundary. */
+static bool system_event_is_handled(uint32_t type) {
+  switch (type) {
+    /* Core lifecycle */
+    case SDL_EVENT_QUIT:
+
+    /* Window events that f_poll_event handles */
+    case SDL_EVENT_WINDOW_RESIZED:
+    case SDL_EVENT_WINDOW_DISPLAY_CHANGED:
+    case SDL_EVENT_WINDOW_EXPOSED:
+    case SDL_EVENT_WINDOW_MINIMIZED:
+    case SDL_EVENT_WINDOW_MAXIMIZED:
+    case SDL_EVENT_WINDOW_RESTORED:
+    case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+    case SDL_EVENT_WINDOW_FOCUS_LOST:
+    case SDL_EVENT_WINDOW_FOCUS_GAINED:
+    case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
+    case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+
+    /* Mobile lifecycle */
+    case SDL_EVENT_WILL_ENTER_FOREGROUND:
+    case SDL_EVENT_DID_ENTER_FOREGROUND:
+    case SDL_EVENT_WILL_ENTER_BACKGROUND:
+    case SDL_EVENT_DID_ENTER_BACKGROUND:
+
+    /* Drag & drop */
+    case SDL_EVENT_DROP_FILE:
+
+    /* Keyboard */
+    case SDL_EVENT_KEY_DOWN:
+    case SDL_EVENT_KEY_UP:
+    case SDL_EVENT_TEXT_INPUT:
+    case SDL_EVENT_TEXT_EDITING:
+
+    /* Mouse */
+    case SDL_EVENT_MOUSE_BUTTON_DOWN:
+    case SDL_EVENT_MOUSE_BUTTON_UP:
+    case SDL_EVENT_MOUSE_MOTION:
+    case SDL_EVENT_MOUSE_WHEEL:
+
+    /* Touch */
+    case SDL_EVENT_FINGER_DOWN:
+    case SDL_EVENT_FINGER_UP:
+    case SDL_EVENT_FINGER_MOTION:
+      return true;
+
+    default:
+      /* Custom events (>= SDL_EVENT_USER) are always allowed through */
+      return type >= SDL_EVENT_USER;
+  }
+}
+
 void system_push_event(const SDL_Event *event) {
+  /* Discard event types that f_poll_event() never consumes */
+  if (!system_event_is_handled(event->type))
+    return;
+
   /* Coalesce consecutive mouse-motion events for the same window */
   if (event->type == SDL_EVENT_MOUSE_MOTION) {
     for (int i = system_event_queue_count - 1; i >= 0; i--) {


### PR DESCRIPTION
This change prevents the queue getting full with
events that we don't even use.