### PR TITLE
Another batch of thread api fixes

### DIFF
--- a/scripts/lua/tests/thread.lua
+++ b/scripts/lua/tests/thread.lua
@@ -56,4 +56,251 @@ test.describe("thread", function()
     test.equal(supply_worker:wait(), 11)
     test.ok(thread.get_cpu_count() > 0)
   end)
+
+  test.test("supply returns after pop consumes the value", function()
+    local suffix = tostring(system.get_process_id()) .. "-" .. math.floor(system.get_time() * 1000000)
+    local channel_name = "thread-tests-supply-pop-" .. suffix
+    local channel = thread.get_channel(channel_name)
+    channel:clear()
+
+    -- Worker uses pop() instead of wait() to consume the value.
+    -- Before the fix, supply() would block forever because pop()
+    -- did not increment the received counter.
+    local worker = thread.create("supply-pop-worker", function(cn)
+      local ch = thread.get_channel(cn)
+      -- Wait until a value appears, then pop it
+      ch:wait()
+      ch:pop()
+      return 42
+    end, channel_name)
+    test.not_nil(worker)
+
+    -- supply should return once the worker has consumed the value
+    test.ok(channel:supply("item"))
+    test.equal(worker:wait(), 42)
+  end)
+
+  test.test("wait and pop only acknowledge a supplied value once", function()
+    local suffix = tostring(system.get_process_id()) .. "-" .. math.floor(system.get_time() * 1000000)
+    local data_name = "thread-tests-supply-ack-data-" .. suffix
+    local consumer_status_name = "thread-tests-supply-ack-consumer-" .. suffix
+    local supplier_status_name = "thread-tests-supply-ack-supplier-" .. suffix
+    local control_name = "thread-tests-supply-ack-control-" .. suffix
+    local data = thread.get_channel(data_name)
+    local consumer_status = thread.get_channel(consumer_status_name)
+    local supplier_status = thread.get_channel(supplier_status_name)
+    local control = thread.get_channel(control_name)
+    data:clear()
+    consumer_status:clear()
+    supplier_status:clear()
+    control:clear()
+
+    local consumer = thread.create("supply-ack-consumer", function(dn, csn, cn)
+      local ch = thread.get_channel(dn)
+      local status = thread.get_channel(csn)
+      local ctrl = thread.get_channel(cn)
+
+      ch:wait()
+      ch:pop()
+      status:push("first")
+
+      ctrl:wait()
+      ctrl:pop()
+
+      ch:wait()
+      ch:pop()
+      status:push("second")
+      return 0
+    end, data_name, consumer_status_name, control_name)
+    test.not_nil(consumer)
+
+    test.ok(data:supply("one"))
+    test.equal(consumer_status:wait(), "first")
+    consumer_status:pop()
+
+    local supplier = thread.create("supply-ack-supplier", function(dn, ssn)
+      local ch = thread.get_channel(dn)
+      local status = thread.get_channel(ssn)
+      status:push("started")
+      ch:supply("two")
+      status:push("returned")
+      return 0
+    end, data_name, supplier_status_name)
+    test.not_nil(supplier)
+
+    test.equal(supplier_status:wait(), "started")
+    supplier_status:pop()
+
+    for _ = 1, 100 do
+      if data:first() == "two" or supplier_status:first() == "returned" then
+        break
+      end
+      coroutine.yield()
+    end
+
+    test.equal(data:first(), "two")
+    for _ = 1, 20 do
+      if supplier_status:first() == "returned" then
+        break
+      end
+      coroutine.yield(0.01)
+    end
+    test.is_nil(supplier_status:first())
+
+    control:push("go")
+    test.equal(supplier_status:wait(), "returned")
+    supplier_status:pop()
+    test.equal(consumer_status:wait(), "second")
+    consumer_status:pop()
+    test.equal(supplier:wait(), 0)
+    test.equal(consumer:wait(), 0)
+  end)
+
+  test.test("many producers can push to the same channel", function()
+    local suffix = tostring(system.get_process_id()) .. "-" .. math.floor(system.get_time() * 1000000)
+    local channel_name = "thread-tests-many-producers-" .. suffix
+    local channel = thread.get_channel(channel_name)
+    channel:clear()
+
+    local producer_count = 8
+    local per_producer = 25
+    local total = producer_count * per_producer
+    local workers = {}
+
+    for i = 1, producer_count do
+      local worker = thread.create("many-push-" .. i, function(cn, idx, count)
+        local ch = thread.get_channel(cn)
+        idx = math.floor(idx)
+        count = math.floor(count)
+        for n = 1, count do
+          ch:push(idx .. ":" .. n)
+        end
+        return count
+      end, channel_name, i, per_producer)
+      test.not_nil(worker)
+      workers[i] = worker
+    end
+
+    local seen = {}
+    local received = 0
+    for _ = 1, total do
+      local value = channel:wait()
+      channel:pop()
+      test.type(value, "string")
+      test.is_nil(seen[value])
+      seen[value] = true
+      received = received + 1
+    end
+
+    for i = 1, producer_count do
+      test.equal(workers[i]:wait(), per_producer)
+    end
+
+    test.equal(received, total)
+    test.is_nil(channel:first())
+  end)
+
+  test.test("many suppliers unblock after one consumer reads their values", function()
+    local suffix = tostring(system.get_process_id()) .. "-" .. math.floor(system.get_time() * 1000000)
+    local data_name = "thread-tests-many-suppliers-data-" .. suffix
+    local data = thread.get_channel(data_name)
+    data:clear()
+
+    local supplier_count = 6
+    local per_supplier = 12
+    local total = supplier_count * per_supplier
+
+    local consumer = thread.create("many-supply-consumer", function(cn, count)
+      local ch = thread.get_channel(cn)
+      count = math.floor(count)
+      for _ = 1, count do
+        ch:wait()
+        ch:pop()
+      end
+      return count
+    end, data_name, total)
+    test.not_nil(consumer)
+
+    local suppliers = {}
+    for i = 1, supplier_count do
+      local supplier = thread.create("many-supply-" .. i, function(cn, idx, count)
+        local ch = thread.get_channel(cn)
+        idx = math.floor(idx)
+        count = math.floor(count)
+        for n = 1, count do
+          ch:supply(idx .. ":" .. n)
+        end
+        return count
+      end, data_name, i, per_supplier)
+      test.not_nil(supplier)
+      suppliers[i] = supplier
+    end
+
+    for i = 1, supplier_count do
+      test.equal(suppliers[i]:wait(), per_supplier)
+    end
+
+    test.equal(consumer:wait(), total)
+    test.is_nil(data:first())
+  end)
+
+  test.test("thread methods are safe after wait", function()
+    local suffix = tostring(system.get_process_id()) .. "-" .. math.floor(system.get_time() * 1000000)
+    local channel_name = "thread-tests-post-wait-" .. suffix
+    local channel = thread.get_channel(channel_name)
+    channel:clear()
+
+    local worker = thread.create("post-wait-worker", function(cn)
+      local ch = thread.get_channel(cn)
+      ch:push("done")
+      return 99
+    end, channel_name)
+    test.not_nil(worker)
+
+    -- Consume the channel value so the worker can finish
+    test.equal(channel:wait(), "done")
+    test.equal(worker:wait(), 99)
+
+    -- After wait(), the SDL_Thread pointer is NULLed out.
+    -- These should not crash; they return nil or safe values.
+    test.is_nil(worker:get_id())
+    test.is_nil(worker:get_name())
+    test.type(tostring(worker), "string")
+  end)
+
+  test.test("concurrent channel access does not crash", function()
+    local suffix = tostring(system.get_process_id()) .. "-" .. math.floor(system.get_time() * 1000000)
+    local channel_name = "thread-tests-concurrent-" .. suffix
+    local channel = thread.get_channel(channel_name)
+    channel:clear()
+
+    -- Spawn multiple threads that all push to the same channel
+    local count = 4
+    local workers = {}
+    for i = 1, count do
+      local w = thread.create("concurrent-push-" .. i, function(cn, idx)
+        local ch = thread.get_channel(cn)
+        ch:push("value-" .. idx)
+        return idx
+      end, channel_name, i)
+      test.not_nil(w)
+      workers[i] = w
+    end
+
+    -- Read all values back via wait (blocks until each is available)
+    local values = {}
+    for i = 1, count do
+      local v = channel:wait()
+      table.insert(values, v)
+      channel:pop()
+    end
+
+    -- All workers should finish cleanly
+    for i = 1, count do
+      test.type(workers[i]:wait(), "number")
+    end
+
+    -- We should have received exactly 'count' values
+    test.equal(#values, count)
+  end)
 end)

--- a/src/api/channel.c
+++ b/src/api/channel.c
@@ -19,6 +19,7 @@
 #include "channel.h"
 
 #include <errno.h>
+#include <stdbool.h>
 #include <string.h>
 
 typedef struct channel_value_pair {
@@ -33,6 +34,7 @@ typedef struct channel_value_pair {
 
 typedef struct channel_value {
   int type;
+  bool received;
 
   union {
     char boolean;
@@ -253,42 +255,54 @@ static int channelGiven(unsigned int target, unsigned int current)
   return !(t.i < 0 && c.i > 0);
 }
 
-static const ChannelValue* channelFirst(const Channel* c)
+static void channelAcknowledge(Channel* c, ChannelValue* v)
 {
-  ChannelValue* v;
-
-  SDL_LockMutex(c->mutex);
-  if (c->queue.first == NULL){
-    SDL_UnlockMutex(c->mutex);
-    return NULL;
+  if (v && !v->received) {
+    v->received = true;
+    ++c->received;
   }
-
-  v = c->queue.first;
-  SDL_UnlockMutex(c->mutex);
-
-  return v;
 }
 
-static const ChannelValue* channelLast(const Channel *c)
+/* Push the first channel value onto the Lua stack while holding the lock.
+ * Returns 1 (always pushes one value: the value or nil). */
+static int channelFirst(const Channel* c, lua_State* L)
 {
-  ChannelValue* last = NULL;
-
   SDL_LockMutex(c->mutex);
   if (c->queue.first == NULL) {
+    lua_pushnil(L);
     SDL_UnlockMutex(c->mutex);
-    return NULL;
+    return 1;
+  }
+
+  channelValuePush(L, c->queue.first);
+  SDL_UnlockMutex(c->mutex);
+
+  return 1;
+}
+
+/* Push the last channel value onto the Lua stack while holding the lock.
+ * Returns 1 (always pushes one value: the value or nil). */
+static int channelLast(const Channel *c, lua_State* L)
+{
+  SDL_LockMutex(c->mutex);
+  if (c->queue.first == NULL) {
+    lua_pushnil(L);
+    SDL_UnlockMutex(c->mutex);
+    return 1;
   }
 
   /* queue.last points to the `next` of the last element, so we can backtrack */
-  last = (ChannelValue*)((uintptr_t)c->queue.last - offsetof(ChannelValue, next));
-
+  ChannelValue* last = (ChannelValue*)((uintptr_t)c->queue.last - offsetof(ChannelValue, next));
+  channelValuePush(L, last);
   SDL_UnlockMutex(c->mutex);
 
-  return last;
+  return 1;
 }
 
-static int channelPush(Channel* c, ChannelValue* v)
+static unsigned int channelPush(Channel* c, ChannelValue* v)
 {
+  unsigned int id;
+
   SDL_LockMutex(c->mutex);
 
   v->next = NULL;
@@ -297,29 +311,35 @@ static int channelPush(Channel* c, ChannelValue* v)
   /* set the last element to new next */
   c->queue.last = &v->next;
 
+  id = ++c->sent;
+
   SDL_UnlockMutex(c->mutex);
   SDL_BroadcastCondition(c->cond);
 
-  return ++c->sent;
+  return id;
 }
 
-static const ChannelValue* channelWait(Channel *c)
+/* Wait for a value and push it onto the Lua stack while holding the lock.
+ * Returns 1 (always pushes one value: the value or nil). */
+static int channelWait(Channel *c, lua_State* L)
 {
   SDL_LockMutex(c->mutex);
   while (c->queue.first == NULL)
     SDL_WaitCondition(c->cond, c->mutex);
 
-  ++c->received;
+  channelAcknowledge(c, c->queue.first);
+
+  channelValuePush(L, c->queue.first);
 
   SDL_UnlockMutex(c->mutex);
   SDL_BroadcastCondition(c->cond);
 
-  return c->queue.first;
+  return 1;
 }
 
 static void channelSupply(Channel* c, ChannelValue* v)
 {
-  unsigned id;
+  unsigned int id;
 
   /* channelPush handles its own locking; avoid locking twice (deadlock) */
   id = channelPush(c, v);
@@ -360,6 +380,7 @@ static void channelPop(Channel* c)
   }
 
   ChannelValue* previous_first = c->queue.first;
+  channelAcknowledge(c, previous_first);
 
   c->queue.first = previous_first->next;
 
@@ -535,14 +556,8 @@ int m_channel_first(lua_State *L)
   Channel* self = ((ChannelContainer*)luaL_checkudata(
     L, 1, API_TYPE_CHANNEL
   ))->channel;
-  const ChannelValue* v;
 
-  if ((v = channelFirst(self)) == NULL)
-    lua_pushnil(L);
-  else
-    channelValuePush(L, v);
-
-  return 1;
+  return channelFirst(self, L);
 }
 
 /*
@@ -556,14 +571,8 @@ int m_channel_last(lua_State *L)
   Channel* self = ((ChannelContainer*)luaL_checkudata(
     L, 1, API_TYPE_CHANNEL
   ))->channel;
-  const ChannelValue* v;
 
-  if ((v = channelLast(self)) == NULL)
-    lua_pushnil(L);
-  else
-    channelValuePush(L, v);
-
-  return 1;
+  return channelLast(self, L);
 }
 
 /*
@@ -662,16 +671,8 @@ int m_channel_wait(lua_State *L)
   Channel* self = ((ChannelContainer*)luaL_checkudata(
     L, 1, API_TYPE_CHANNEL
   ))->channel;
-  const ChannelValue* v;
 
-  if ((v = channelWait(self)) == NULL)
-    lua_pushnil(L);
-  else
-    channelValuePush(L, v);
-
-  SDL_BroadcastCondition(self->cond);
-
-  return 1;
+  return channelWait(self, L);
 }
 
 /* --------------------------------------------------------
@@ -687,8 +688,7 @@ int mm_channel_gc(lua_State *L)
     L, 1, API_TYPE_CHANNEL
   ))->channel;
 
-  (void)SDL_AtomicDecRef(&self->ref);
-  if (SDL_GetAtomicInt(&self->ref) == 0)
+  if (SDL_AtomicDecRef(&self->ref))
     channelFree(self);
 
   return 0;

--- a/src/api/thread.c
+++ b/src/api/thread.c
@@ -85,9 +85,7 @@ static const char* reader(lua_State *L, LoadState *state, size_t *size)
 
 static void destroy(LuaThread *t)
 {
-  (void)SDL_AtomicDecRef(&t->ref);
-
-  if (SDL_GetAtomicInt(&t->ref) <= 0) {
+  if (SDL_AtomicDecRef(&t->ref)) {
     lua_close(t->L);
     SDL_free(t);
   }
@@ -391,7 +389,8 @@ static int f_thread_create(lua_State *L)
 
   thread->ptr = SDL_CreateThread((SDL_ThreadFunction)callback, name, thread);
   if (thread->ptr == NULL) {
-    luaL_error(L, SDL_GetError());
+    lua_pushnil(L);
+    lua_pushstring(L, SDL_GetError());
     goto failure;
   }
 
@@ -438,6 +437,11 @@ static int m_thread_get_id(lua_State *L)
     L, 1, API_TYPE_THREAD
   ))->thread;
 
+  if (self->ptr == NULL) {
+    lua_pushnil(L);
+    return 1;
+  }
+
   lua_pushinteger(L, SDL_GetThreadID(self->ptr));
 
   return 1;
@@ -454,6 +458,11 @@ static int m_thread_get_name(lua_State *L)
   LuaThread* self = ((ThreadContainer*)luaL_checkudata(
     L, 1, API_TYPE_THREAD
   ))->thread;
+
+  if (self->ptr == NULL) {
+    lua_pushnil(L);
+    return 1;
+  }
 
   lua_pushstring(L, SDL_GetThreadName(self->ptr));
 
@@ -474,6 +483,7 @@ static int m_thread_wait(lua_State *L)
   int status;
 
   SDL_WaitThread(self->ptr, &status);
+  self->ptr = NULL;
   self->clean = true;
 
   lua_pushinteger(L, status);
@@ -516,6 +526,7 @@ static int mm_thread_gc(lua_State *L)
   if (!self->clean) {
     self->clean = true;
     SDL_DetachThread(self->ptr);
+    self->ptr = NULL;
   }
 
   /* this can take place before or after the thread callback ends
@@ -534,7 +545,10 @@ static int mm_thread_tostring(lua_State *L)
     L, 1, API_TYPE_THREAD
   ))->thread;
 
-  lua_pushfstring(L, "thread %d", SDL_GetThreadID(self->ptr));
+  if (self->ptr == NULL)
+    lua_pushstring(L, "thread <finished>");
+  else
+    lua_pushfstring(L, "thread %d", SDL_GetThreadID(self->ptr));
 
   return 1;
 }


### PR DESCRIPTION
- Fix channel.c: Refactor channelFirst/channelLast/channelWait to push to Lua stack under lock
- Fix channel.c: TOCTOU on refcount in mm_channel_gc
- Fix channel.c: Track per-value acknowledgements so wait/pop only unblock supply once per queued value
- Fix channel.c: Move ++c->sent inside lock in channelPush
- Fix thread.c: TOCTOU on refcount in destroy()
- Fix thread.c: Null out self->ptr after WaitThread/DetachThread + add NULL checks
- Fix thread.c: luaL_error longjmp leak in f_thread_create
- Add thread tests for supply acknowledgement and concurrent channel producer/supplier stress cases