### PR TITLE
Add MarkdownView copy interactions

### DIFF
--- a/data/core/commands/markdown.lua
+++ b/data/core/commands/markdown.lua
@@ -110,6 +110,41 @@ end, {
 })
 
 command.add(function()
+  if core.active_view:extends(MarkdownView) and core.active_view:has_selection() then
+    return true, core.active_view
+  end
+  return false
+end, {
+  ["markdown-view:copy"] = function(mv)
+    mv:copy_selection()
+  end
+})
+
+local function markdown_context_target_predicate(kind)
+  return function()
+    local mv = core.active_view
+    local target = mv and mv.markdown_context_target
+    local url = target and target[kind .. "_url"]
+    if mv and mv:extends(MarkdownView) and url then
+      return true, mv, target
+    end
+    return false
+  end
+end
+
+command.add(markdown_context_target_predicate("link"), {
+  ["markdown-view:copy-link"] = function(_, target)
+    system.set_clipboard(target.link_url)
+  end
+})
+
+command.add(markdown_context_target_predicate("image"), {
+  ["markdown-view:copy-image-link"] = function(_, target)
+    system.set_clipboard(target.image_url)
+  end
+})
+
+command.add(function()
   if not core.active_view:extends(MarkdownView) then
     return false
   end

--- a/data/core/keymap-macos.lua
+++ b/data/core/keymap-macos.lua
@@ -51,7 +51,7 @@ local function keymap_macos(keymap)
     ["cmd+z"] = "doc:undo",
     ["cmd+y"] = "doc:redo",
     ["cmd+x"] = "doc:cut",
-    ["cmd+c"] = "doc:copy",
+    ["cmd+c"] = { "markdown-view:copy", "doc:copy" },
     ["cmd+v"] = "doc:paste",
     ["ctrl+insert"] = "doc:copy",
     ["shift+insert"] = "doc:paste",

--- a/data/core/keymap.lua
+++ b/data/core/keymap.lua
@@ -343,7 +343,7 @@ keymap.add_direct {
   ["ctrl+z"] = "doc:undo",
   ["ctrl+y"] = "doc:redo",
   ["ctrl+x"] = "doc:cut",
-  ["ctrl+c"] = "doc:copy",
+  ["ctrl+c"] = { "markdown-view:copy", "doc:copy" },
   ["ctrl+v"] = "doc:paste",
   ["insert"] = "doc:toggle-overwrite",
   ["ctrl+insert"] = "doc:copy",

--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -151,6 +151,9 @@ end
 ---@field font renderer.font?
 ---@field last_doc_change_id integer?
 ---@field hovered_link_url string?
+---@field selection_anchor integer?
+---@field selection_cursor integer?
+---@field selecting boolean?
 local MarkdownView = View:extend()
 
 function MarkdownView:__tostring() return "MarkdownView" end
@@ -1747,6 +1750,7 @@ local function tokenize_segments(self, segments, fontset, base_color, accent_col
             image = image,
             width = width,
             height = height,
+            image_url = segment.image_url,
             url = segment.url,
             is_space = false
           }
@@ -2287,6 +2291,7 @@ local function add_table_block(self, commands, y, block, body_fontset, accent_co
           width = cell.width,
           height = cell.height,
           image = cell.image,
+          image_url = cell.url,
           link_url = cell.link_url
         }
       else
@@ -2583,6 +2588,7 @@ render_blocks = function(self, commands, y, blocks, width, x_offset, fonts, acce
             width = image_width,
             height = image_height,
             image = image,
+            image_url = block.url,
             link_url = block.link_url
           }
           y = y + image_height + BLOCK_SPACING
@@ -2653,6 +2659,7 @@ render_blocks = function(self, commands, y, blocks, width, x_offset, fonts, acce
               width = item_width,
               height = item_height,
               image = image,
+              image_url = image_block.url,
               link_url = image_block.link_url
             }
           else
@@ -2792,6 +2799,156 @@ local function draw_layout_commands(commands, start_x, start_y, clip_x, clip_y, 
   core.pop_clip_rect()
 end
 
+local function command_text(command)
+  local text = {}
+  for _, fragment in ipairs(command.fragments or {}) do
+    if fragment.text and fragment.text ~= "" then
+      text[#text + 1] = fragment.text
+    end
+  end
+  return table.concat(text)
+end
+
+local function collect_selectable_lines(self)
+  local lines = {}
+  local text = {}
+  local position = 1
+
+  local function append_commands(commands)
+    for _, command in ipairs(commands or {}) do
+      if command.type == "text" then
+        local line_text = command_text(command)
+        if line_text ~= "" then
+          if #text > 0 then
+            text[#text + 1] = "\n"
+            position = position + 1
+          end
+          lines[#lines + 1] = {
+            command = command,
+            text = line_text,
+            start = position,
+            stop = position + #line_text
+          }
+          text[#text + 1] = line_text
+          position = position + #line_text
+        end
+      end
+    end
+  end
+
+  append_commands(self:ensure_layout().commands)
+  local partial_layout = self:ensure_partial_layout()
+  if partial_layout then
+    append_commands(partial_layout.commands)
+  end
+
+  return lines, table.concat(text)
+end
+
+local function measure_fragment_prefix(command, fragment, text, width)
+  if command.tabbed then
+    return fragment.font:get_width(text, { tab_offset = width })
+  end
+  return fragment.font:get_width(text)
+end
+
+local function text_offset_x(command, offset)
+  local width = 0
+  local remaining = offset
+
+  for _, fragment in ipairs(command.fragments or {}) do
+    local text = fragment.text or ""
+    if text ~= "" then
+      if remaining <= 0 then
+        break
+      elseif remaining >= #text then
+        width = width + fragment.width
+        remaining = remaining - #text
+      else
+        local prefix = text:sub(1, remaining)
+        while remaining > 0 and common.is_utf8_cont(text, remaining + 1) do
+          remaining = remaining - 1
+          prefix = text:sub(1, remaining)
+        end
+        width = width + measure_fragment_prefix(command, fragment, prefix, width)
+        break
+      end
+    end
+  end
+
+  return width
+end
+
+local function nearest_text_position(command, line, x)
+  local relative_x = x - command.x
+  if relative_x <= 0 then
+    return line.start
+  end
+
+  local position = line.start
+  local cursor_x = 0
+  for _, fragment in ipairs(command.fragments or {}) do
+    local text = fragment.text or ""
+    for char in common.utf8_chars(text) do
+      local next_x = cursor_x + measure_fragment_prefix(command, fragment, char, cursor_x)
+      if relative_x < cursor_x + (next_x - cursor_x) / 2 then
+        return position
+      end
+      cursor_x = next_x
+      position = position + #char
+    end
+  end
+  return line.stop
+end
+
+local function sorted_selection(self)
+  local anchor, cursor = self.selection_anchor, self.selection_cursor
+  if not anchor or not cursor or anchor == cursor then
+    return nil
+  end
+  return math.min(anchor, cursor), math.max(anchor, cursor)
+end
+
+local function draw_selection(self, start_x, start_y, clip_x, clip_y, clip_w, clip_h)
+  local selection_start, selection_stop = sorted_selection(self)
+  if not selection_start then
+    return
+  end
+
+  core.push_clip_rect(clip_x, clip_y, clip_w, clip_h)
+  for _, line in ipairs(collect_selectable_lines(self)) do
+    local from = math.max(selection_start, line.start)
+    local to = math.min(selection_stop, line.stop)
+    if from < to then
+      local command = line.command
+      local x1 = start_x + command.x + text_offset_x(command, from - line.start)
+      local x2 = start_x + command.x + text_offset_x(command, to - line.start)
+      renderer.draw_rect(x1, start_y + command.y, math.max(x2 - x1, 1), command.height, style.selection)
+    end
+  end
+  core.pop_clip_rect()
+end
+
+local function image_fragment_at(command, x, y)
+  if command.type ~= "text" or not command.fragments then
+    return nil
+  end
+  if y < command.y or y >= command.y + command.height then
+    return nil
+  end
+
+  local fragment_x = command.x
+  for _, fragment in ipairs(command.fragments) do
+    local width = fragment.width or 0
+    if fragment.type == "image" and fragment.image_url
+      and x >= fragment_x and x < fragment_x + width
+    then
+      return fragment
+    end
+    fragment_x = fragment_x + width
+  end
+end
+
 ---Constructor.
 ---@param source? string|core.markdownview.source
 ---@param title? string
@@ -2814,6 +2971,9 @@ function MarkdownView:new(source, title)
   self.font_cache = nil
   self.font = nil
   self.last_doc_change_id = nil
+  self.selection_anchor = nil
+  self.selection_cursor = nil
+  self.selecting = false
 
   if type(source) == "table" then
     self.linked_doc = source.linked_doc or source.doc
@@ -3396,6 +3556,15 @@ function MarkdownView:draw_at(x, y, width, height, background, show_scrollbars)
     self:update_scrollbar()
   end
   local ox, oy = self:get_content_offset()
+  draw_selection(
+    self,
+    ox + style.padding.x,
+    oy + style.padding.y,
+    x,
+    y,
+    width,
+    height
+  )
   draw_layout_commands(
     layout.commands,
     ox + style.padding.x,
@@ -3428,6 +3597,82 @@ function MarkdownView:on_scale_change()
   self:invalidate_layout()
 end
 
+---Returns whether the preview has selected text.
+---@return boolean
+function MarkdownView:has_selection()
+  return sorted_selection(self) ~= nil
+end
+
+---Clears the active text selection.
+function MarkdownView:clear_selection()
+  self.selection_anchor = nil
+  self.selection_cursor = nil
+  self.selecting = false
+  core.redraw = true
+end
+
+---Returns the selected rendered text.
+---@return string
+function MarkdownView:get_selected_text()
+  local selection_start, selection_stop = sorted_selection(self)
+  if not selection_start then
+    return ""
+  end
+  local _, text = collect_selectable_lines(self)
+  return text:sub(selection_start, selection_stop - 1)
+end
+
+---Copies the selected rendered text to the system clipboard.
+---@return boolean copied
+function MarkdownView:copy_selection()
+  local text = self:get_selected_text()
+  if text == "" then
+    return false
+  end
+  system.set_clipboard(text)
+  return true
+end
+
+---Returns the selectable text position nearest to the given mouse position.
+---@param x number
+---@param y number
+---@return integer
+function MarkdownView:get_text_position_at(x, y)
+  local lines = collect_selectable_lines(self)
+  if #lines == 0 then
+    return 1
+  end
+
+  local ox, oy = self:get_content_offset()
+  local content_x = x - ox - style.padding.x
+  local content_y = y - oy - style.padding.y
+  local closest = lines[1]
+  local closest_distance = math.huge
+
+  for _, line in ipairs(lines) do
+    local command = line.command
+    if content_y >= command.y and content_y < command.y + command.height then
+      return nearest_text_position(command, line, content_x)
+    end
+
+    local distance
+    if content_y < command.y then
+      distance = command.y - content_y
+    else
+      distance = content_y - (command.y + command.height)
+    end
+    if distance < closest_distance then
+      closest = line
+      closest_distance = distance
+    end
+  end
+
+  if content_y < closest.command.y then
+    return closest.start
+  end
+  return closest.stop
+end
+
 ---Returns the URL under the given mouse position, if any.
 ---@param x number
 ---@param y number
@@ -3452,6 +3697,52 @@ function MarkdownView:get_link_at(x, y)
         local ry = start_y + link.y
         if x >= rx and y >= ry and x < rx + link.width and y < ry + link.height then
           return link.url
+        end
+      end
+    end
+  end
+end
+
+---Returns a context-copy target under the given mouse position, if any.
+---@param x number
+---@param y number
+---@return { link_url: string?, image_url: string? }?
+function MarkdownView:get_context_target_at(x, y)
+  local layout = self:ensure_layout()
+  local ox, oy = self:get_content_offset()
+  local start_x = ox + style.padding.x
+  local start_y = oy + style.padding.y
+  local content_x = x - start_x
+  local content_y = y - start_y
+
+  for _, command in ipairs(layout.commands) do
+    if command.type == "image" and command.image_url then
+      if content_x >= command.x and content_y >= command.y
+        and content_x < command.x + command.width
+        and content_y < command.y + command.height
+      then
+        return {
+          image_url = command.image_url,
+          link_url = command.link_url
+        }
+      end
+    end
+
+    local image_fragment = image_fragment_at(command, content_x, content_y)
+    if image_fragment then
+      return {
+        image_url = image_fragment.image_url,
+        link_url = image_fragment.url
+      }
+    end
+
+    if command.links then
+      for _, link in ipairs(command.links) do
+        if content_x >= link.x and content_y >= link.y
+          and content_x < link.x + link.width
+          and content_y < link.y + link.height
+        then
+          return { link_url = link.url }
         end
       end
     end
@@ -3561,6 +3852,26 @@ function MarkdownView:on_mouse_pressed(button, x, y, clicks)
       self:open_link(url)
       return true
     end
+
+    local position = self:get_text_position_at(x, y)
+    self.selection_anchor = position
+    self.selection_cursor = position
+    self.selecting = true
+    core.redraw = true
+    return true
+  end
+end
+
+---@param button string
+---@param x number
+---@param y number
+---@return boolean?
+function MarkdownView:on_mouse_released(button, x, y)
+  MarkdownView.super.on_mouse_released(self, button, x, y)
+  if button == "left" and self.selecting then
+    self.selecting = false
+    core.redraw = true
+    return true
   end
 end
 
@@ -3573,16 +3884,25 @@ function MarkdownView:on_mouse_moved(x, y, dx, dy)
   if MarkdownView.super.on_mouse_moved(self, x, y, dx, dy) then
     return true
   end
+  if self.selecting then
+    local position = self:get_text_position_at(x, y)
+    if self.selection_cursor ~= position then
+      self.selection_cursor = position
+      core.redraw = true
+    end
+    self.cursor = "ibeam"
+    return true
+  end
   local url = self:get_link_at(x, y)
   self:set_hovered_link(url)
-  self.cursor = url and "hand" or "arrow"
+  self.cursor = url and "hand" or "ibeam"
 end
 
 ---Clears hover state when the mouse leaves the preview.
 function MarkdownView:on_mouse_left()
   MarkdownView.super.on_mouse_left(self)
   self:set_hovered_link(nil)
-  self.cursor = "arrow"
+  self.cursor = "ibeam"
 end
 
 ---Refreshes the preview when the bound document changes.
@@ -3604,6 +3924,7 @@ function MarkdownView:draw()
   local start_x = ox + style.padding.x
   local start_y = oy + style.padding.y
 
+  draw_selection(self, start_x, start_y, clip_x, clip_y, clip_w, clip_h)
   draw_layout_commands(layout.commands, start_x, start_y, clip_x, clip_y, clip_w, clip_h)
   local partial_layout = self:ensure_partial_layout()
   if partial_layout then

--- a/data/plugins/contextmenu.lua
+++ b/data/plugins/contextmenu.lua
@@ -88,6 +88,26 @@ end
 
 menu:register("core.docview", cmds)
 
+local function markdown_context_target_predicate(kind)
+  return function(x, y)
+    local view = core.active_view
+    if not (view and view:extends(MarkdownView)) then
+      return false
+    end
+    view.markdown_context_target = view:get_context_target_at(x, y)
+    return view.markdown_context_target
+      and view.markdown_context_target[kind .. "_url"] ~= nil
+  end
+end
+
+menu:register(markdown_context_target_predicate("link"), {
+  { text = "Copy Link", command = "markdown-view:copy-link" }
+})
+
+menu:register(markdown_context_target_predicate("image"), {
+  { text = "Copy Image Link", command = "markdown-view:copy-image-link" }
+})
+
 menu:register("core.markdownview", {
   { text = "View Raw", command = "markdown-view:view-raw" }
 })

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -3,6 +3,7 @@ local core = require "core"
 local command = require "core.command"
 local config = require "core.config"
 local http = require "core.http"
+local keymap = require "core.keymap"
 local style = require "core.style"
 local test = require "core.test"
 local DocView = require "core.docview"
@@ -242,6 +243,172 @@ print("hello")
     test.equal(view.layout, layout)
     test.ok(#view.layout.commands > before_commands)
     test.equal(#view.blocks, 4)
+  end)
+
+  test.test("selects rendered text with the mouse", function()
+    local view = MarkdownView("# Title\n\nParagraph one")
+    view.position.x = 0
+    view.position.y = 0
+    view.size.x = 400
+    view.size.y = 300
+    local layout = view:ensure_layout()
+    local paragraph_command
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        local text = {}
+        for _, fragment in ipairs(command.fragments) do
+          text[#text + 1] = fragment.text or ""
+        end
+        if table.concat(text) == "Paragraph one" then
+          paragraph_command = command
+          break
+        end
+      end
+    end
+
+    test.not_nil(paragraph_command)
+    local y = style.padding.y + paragraph_command.y + paragraph_command.height / 2
+    view:on_mouse_pressed("left", style.padding.x + paragraph_command.x, y, 1)
+    view:on_mouse_moved(style.padding.x + paragraph_command.x + 1000, y, 1000, 0)
+    view:on_mouse_released("left", style.padding.x + paragraph_command.x + 1000, y)
+
+    test.equal(view:get_selected_text(), "Paragraph one")
+  end)
+
+  test.test("copies selected rendered text", function()
+    local view = MarkdownView("# Title\n\nParagraph one")
+    view.size.x = 400
+    view.selection_anchor = 1
+    view.selection_cursor = 6
+
+    test.equal(view:copy_selection(), true)
+    test.equal(system.get_clipboard(), "Title")
+
+    local node = core.root_view:get_active_node_default()
+    node:add_view(view)
+    node:set_active_view(view)
+    system.set_clipboard("")
+    test.equal(command.perform("markdown-view:copy"), true)
+    test.equal(system.get_clipboard(), "Title")
+    local copy_shortcut = PLATFORM == "Mac OS X" and "cmd+c" or "ctrl+c"
+    test.equal(keymap.map[copy_shortcut][1], "markdown-view:copy")
+    test.equal(keymap.map[copy_shortcut][2], "doc:copy")
+    node:remove_view(core.root_view.root_node, view)
+  end)
+
+  test.test("shows context copy entries for markdown targets", function(context)
+    local contextmenu = require "plugins.contextmenu"
+    local link_view = MarkdownView("[inline](https://example.com)")
+    link_view.position.x = 0
+    link_view.position.y = 0
+    link_view.size.x = 420
+    link_view.size.y = 240
+    core.set_active_view(link_view)
+
+    local link
+    for _, command_item in ipairs(link_view:ensure_layout().commands) do
+      if command_item.links then
+        link = command_item.links[1]
+        break
+      end
+    end
+    test.not_nil(link)
+
+    local function has_menu_item(text)
+      for _, item in ipairs(contextmenu.items or {}) do
+        if item.text == text then
+          return true
+        end
+      end
+      return false
+    end
+
+    local x = style.padding.x + link.x + 1
+    local y = style.padding.y + link.y + 1
+    test.equal(contextmenu:show(x, y), true)
+    test.equal(has_menu_item("Copy Link"), true)
+    test.equal(has_menu_item("Copy Image Link"), false)
+    contextmenu:hide()
+
+    local image_path = context.project_temp_root .. PATHSEP .. "diagram.png"
+    local source_path = context.project_temp_root .. PATHSEP .. "source.md"
+    write_file(image_path, "not-a-real-png")
+    write_file(source_path, "[![Diagram](diagram.png)](https://example.com/diagram)\n")
+
+    local original_load_image = canvas.load_image
+    canvas.load_image = function()
+      return {
+        get_size = function()
+          return 80, 40
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+
+    local image_view = MarkdownView(source_path)
+    image_view.position.x = 0
+    image_view.position.y = 0
+    image_view.size.x = 420
+    image_view.size.y = 240
+    local image = image_view:ensure_layout().commands[1]
+    canvas.load_image = original_load_image
+    core.set_active_view(image_view)
+
+    x = style.padding.x + image.x + 1
+    y = style.padding.y + image.y + 1
+    test.equal(contextmenu:show(x, y), true)
+    test.equal(has_menu_item("Copy Link"), true)
+    test.equal(has_menu_item("Copy Image Link"), true)
+    test.equal(image_view.markdown_context_target.link_url, "https://example.com/diagram")
+    test.equal(image_view.markdown_context_target.image_url, "diagram.png")
+    contextmenu:hide()
+
+    write_file(source_path, "![Diagram](diagram.png)\n")
+    image_view = MarkdownView(source_path)
+    image_view.position.x = 0
+    image_view.position.y = 0
+    image_view.size.x = 420
+    image_view.size.y = 240
+    canvas.load_image = function()
+      return {
+        get_size = function()
+          return 80, 40
+        end,
+        scaled = function(_, width, height)
+          return {
+            get_size = function()
+              return width, height
+            end
+          }
+        end
+      }
+    end
+    image = image_view:ensure_layout().commands[1]
+    canvas.load_image = original_load_image
+    core.set_active_view(image_view)
+    x = style.padding.x + image.x + 1
+    y = style.padding.y + image.y + 1
+    test.equal(contextmenu:show(x, y), true)
+    test.equal(has_menu_item("Copy Link"), false)
+    test.equal(has_menu_item("Copy Image Link"), true)
+    contextmenu:hide()
+
+    local plain_view = MarkdownView("plain text")
+    plain_view.position.x = 0
+    plain_view.position.y = 0
+    plain_view.size.x = 420
+    plain_view.size.y = 240
+    core.set_active_view(plain_view)
+    contextmenu:show(style.padding.x + 1, style.padding.y + 1)
+    test.equal(has_menu_item("Copy Link"), false)
+    test.equal(has_menu_item("Copy Image Link"), false)
+    contextmenu:hide()
   end)
 
   test.test("parses nested list indentation", function()
@@ -1026,6 +1193,7 @@ Text with a footnote.[^note]
     test.equal(layout.commands[1].x, 0)
     test.equal(layout.commands[1].width, layout.width)
     test.equal(layout.commands[1].height, math.floor(400 * (layout.width / 800)))
+    test.equal(layout.commands[1].image_url, "diagram.png")
   end)
 
   test.test("downloads remote markdown images to the cache", function()
@@ -1151,6 +1319,8 @@ Text with a footnote.[^note]
     test.equal(second_image.y, first_image.y)
     test.equal(first_image.link_url, "https://github.com/pragtical/pragtical/actions/workflows/rolling.yml")
     test.equal(second_image.link_url, "https://discord.gg/8V2yJtn3Fc")
+    test.equal(first_image.image_url, "https://github.com/pragtical/pragtical/actions/workflows/rolling.yml/badge.svg")
+    test.equal(second_image.image_url, "https://discord.com/api/guilds/1285023036071743542/widget.png?style=shield")
     test.equal(#download_opts, 2)
     test.equal(download_opts[1].url, "https://github.com/pragtical/pragtical/actions/workflows/rolling.yml/badge.svg")
     test.equal(download_opts[2].url, "https://discord.com/api/guilds/1285023036071743542/widget.png?style=shield")
@@ -1163,6 +1333,18 @@ Text with a footnote.[^note]
 
     local x = view.position.x + style.padding.x + second_image.x + 1
     local y = view.position.y + style.padding.y + second_image.y + 1
+    local target = view:get_context_target_at(x, y)
+    test.equal(target.link_url, "https://discord.gg/8V2yJtn3Fc")
+    test.equal(target.image_url, "https://discord.com/api/guilds/1285023036071743542/widget.png?style=shield")
+    view.markdown_context_target = target
+    core.set_active_view(view)
+    system.set_clipboard("")
+    test.equal(command.perform("markdown-view:copy-link"), true)
+    test.equal(system.get_clipboard(), target.link_url)
+    system.set_clipboard("")
+    test.equal(command.perform("markdown-view:copy-image-link"), true)
+    test.equal(system.get_clipboard(), target.image_url)
+
     view:on_mouse_moved(x, y, 0, 0)
     test.equal(view.cursor, "hand")
     view:on_mouse_pressed("left", x, y, 1)
@@ -1297,6 +1479,15 @@ For more detailed instructions visit: https://pragtical.dev/docs/setup/building
 
     local x = view.position.x + style.padding.x + target.x + 1
     local y = view.position.y + style.padding.y + target.y + 1
+    local context_target = view:get_context_target_at(x, y)
+    test.equal(context_target.link_url, "https://example.com")
+    test.equal(context_target.image_url, nil)
+    view.markdown_context_target = context_target
+    core.set_active_view(view)
+    system.set_clipboard("")
+    test.equal(command.perform("markdown-view:copy-link"), true)
+    test.equal(system.get_clipboard(), "https://example.com")
+
     view:on_mouse_moved(x, y, 0, 0)
     test.equal(view.cursor, "hand")
     test.equal(tooltip, "Open https://example.com")


### PR DESCRIPTION
Allow rendered MarkdownView text to be selected with the mouse and copied through a dedicated markdown-view:copy command. The selection layer hit-tests rendered text commands, draws the normal selection highlight, and exposes helpers for retrieving or copying selected rendered text.

Bind markdown-view:copy before doc:copy on the platform copy shortcut so its predicate can handle MarkdownView selections without replacing the document copy command. Keep existing link-click behavior intact.

Add MarkdownView context menu actions for copying link targets. The menu now shows Copy Link over rendered text links and linked images, and Copy Image Link over rendered images. Linked images expose both actions so users can copy either the outer link target or image source.

Add markdownview tests for mouse selection, copy commands, copy shortcut ordering, context menu visibility, and link/image URL copying.