### PR TITLE
Add generated settings views

### DIFF
--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -65,7 +65,8 @@ settings.type = {
   FONT = 7,
   FILE = 8,
   DIRECTORY = 9,
-  COLOR = 10
+  COLOR = 10,
+  SUBCONFIG = 11
 }
 
 ---@alias settings.types
@@ -79,6 +80,7 @@ settings.type = {
 ---| `settings.type.FILE`
 ---| `settings.type.DIRECTORY`
 ---| `settings.type.COLOR`
+---| `settings.type.SUBCONFIG`
 
 ---Represents a setting to render on a settings pane.
 ---@class settings.option
@@ -112,6 +114,10 @@ settings.type = {
 ---@field public icon string
 ---Command or function executed when a BUTTON is clicked
 ---@field public on_click nil | string | fun(button:string, x:integer, y:integer)
+---Title used when opening a SUBCONFIG view.
+---@field public title string
+---Spec used when opening a SUBCONFIG view.
+---@field public spec settings.config_spec|settings.option[]
 ---Optional function executed when the option value is applied.
 ---@field public on_apply nil | fun(value:any)
 ---When FILE or DIRECTORY this flag tells the path should exist.
@@ -119,6 +125,15 @@ settings.type = {
 ---Lua patterns used on FILE or DIRECTORY to filter browser results and
 ---also force the selection to match one of the filters.
 ---@field public filters table<integer,string>
+
+---Represents a standalone settings specification.
+---@class settings.config_spec
+---Title displayed by the generated configuration view.
+---@field public name string
+---Optional config path prefix prepended to all option paths.
+---@field public path_prefix string
+---Optional named sections. Each section value is a `settings.option[]`.
+---@field public sections table<string, settings.option[]>|table<integer, table>
 
 ---Add a new settings section to the settings UI
 ---@param section string
@@ -1441,14 +1456,40 @@ function Settings:new()
   self:setup_about()
 end
 
----Helper function to add control for both core and plugin settings.
----@oaram pane widget
+---Resolve a settings option path from a render context.
 ---@param option settings.option
----@param plugin_name? string | nil
-local function add_control(pane, option, plugin_name)
+---@param context? string|table
+---@return string|nil
+local function resolve_option_path(option, context)
+  if type(option.path) ~= "string" then return nil end
+  if type(context) == "string" then
+    return "plugins." .. context .. "." .. option.path
+  end
+  if type(context) == "table" and type(context.path_prefix) == "string" and context.path_prefix ~= "" then
+    return context.path_prefix .. "." .. option.path
+  end
+  return option.path
+end
+
+---Resolve a generated config path prefix against an inherited render context.
+---@param path_prefix string
+---@param context? string|table
+---@return string
+local function resolve_path_prefix(path_prefix, context)
+  if path_prefix:find("^plugins%.") then return path_prefix end
+  if type(context) == "string" and context ~= "" then
+    return "plugins." .. context .. "." .. path_prefix
+  end
+  return path_prefix
+end
+
+---Helper function to add control for core, plugin, and standalone settings.
+---@param pane widget
+---@param option settings.option
+---@param context? string|table Plugin name or standalone render context.
+local function add_control(pane, option, context)
   local found = false
-  local path = type(plugin_name) ~= "nil" and
-    "plugins." .. plugin_name .. "." .. option.path or option.path
+  local path = resolve_option_path(option, context)
   local option_value = nil
   if type(path) ~= "nil" then
     option_value = get_config_value(config, path, option.default)
@@ -1519,6 +1560,16 @@ local function add_control(pane, option, plugin_name)
       elseif command_type == "function" then
         button.on_click = option.on_click
       end
+    end
+    widget = button
+    found = true
+
+  elseif option.type == settings.type.SUBCONFIG then
+    ---@type widget.button
+    local button = Button(pane, option.label)
+    button:set_icon("P")
+    function button:on_click()
+      settings.show_config(option.title or option.label, option.spec, context)
     end
     widget = button
     found = true
@@ -2160,6 +2211,159 @@ local contributors_list = {
   end
 end
 
+---Layout settings controls inside a widget.
+---@param childs widget[]
+---@param width number
+local function layout_settings_childs(childs, width)
+  local prev_child = nil
+  for pos=#childs, 1, -1 do
+    local child = childs[pos]
+    local x, y = 10, (10 * SCALE)
+    if prev_child then
+      if
+        (prev_child:is(Label) and not prev_child.desc)
+        or
+        (child:is(Label) and child.desc)
+      then
+        y = prev_child:get_bottom() + (10 * SCALE)
+      elseif not child:is(Line) then
+        y = prev_child:get_bottom() + (30 * SCALE)
+      end
+    end
+    if child:is(Line) then
+      x = 0
+    elseif
+      child:is(ItemsList) or child:is(FilePicker)
+      or
+      child:is(TextBox) or child:is(Container)
+    then
+      child:set_size(width - 20)
+    end
+    child:set_position(x, y)
+    prev_child = child
+  end
+end
+
+---Layout settings controls inside a folding book.
+---@param section widget.foldingbook
+local function layout_settings_section(section)
+  section:set_size(
+    section.parent.size.x - style.padding.x,
+    section:get_real_height()
+  )
+  section:set_position(style.padding.x / 2, 0)
+
+  for _, pane in ipairs(section.panes) do
+    layout_settings_childs(pane.container.childs, pane.container:get_width())
+  end
+end
+
+---@class settings.configview : widget
+---@field private sections widget.foldingbook?
+---@field private config_spec settings.config_spec
+local ConfigView = Widget:extend()
+
+---Return whether a table looks like a settings option.
+---@param value any
+---@return boolean
+local function is_option(value)
+  return type(value) == "table" and type(value.label) == "string"
+end
+
+---Return standalone config sections from a spec.
+---@param title string
+---@param spec settings.config_spec|settings.option[]
+---@return table[]
+local function config_spec_sections(title, spec)
+  if type(spec.sections) ~= "table" then
+    return {
+      {
+        name = spec.name or title,
+        options = spec
+      }
+    }
+  end
+
+  local result = {}
+  if #spec.sections > 0 then
+    for index, section in ipairs(spec.sections) do
+      if type(section) == "table" then
+        table.insert(result, {
+          name = section.name or section.label or tostring(index),
+          options = section.options or section
+        })
+      end
+    end
+  else
+    local names = {}
+    for name in pairs(spec.sections) do table.insert(names, name) end
+    table.sort(names)
+    for _, name in ipairs(names) do
+      table.insert(result, {
+        name = tostring(name),
+        options = spec.sections[name]
+      })
+    end
+  end
+  return result
+end
+
+---Create a generated settings view from a config spec.
+---@param title string
+---@param spec settings.config_spec|settings.option[]
+---@param context? string|table Plugin name or standalone render context inherited from the opener.
+function ConfigView:new(title, spec, context)
+  ConfigView.super.new(self, nil, false)
+  self.name = title
+  self.defer_draw = false
+  self.border.width = 0
+  self.draggable = false
+  self.scrollable = true
+  self.config_spec = spec
+
+  context = type(context) == "table" and common.merge({}, context) or context
+  if type(spec.path_prefix) == "string" and spec.path_prefix ~= "" then
+    context = { path_prefix = resolve_path_prefix(spec.path_prefix, context) }
+  end
+
+  if type(spec.sections) == "table" then
+    self.sections = FoldingBook(self)
+    self.sections.border.width = 0
+    self.sections.scrollable = false
+    for _, section in ipairs(config_spec_sections(title, spec)) do
+      local pane = self.sections:add_pane(section.name, section.name)
+      for _, option in ipairs(section.options or {}) do
+        if is_option(option) then
+          add_control(pane, option, context)
+        end
+      end
+    end
+  else
+    for _, option in ipairs(spec) do
+      if is_option(option) then
+        add_control(self, option, context)
+      end
+    end
+  end
+end
+
+function ConfigView:draw_background()
+  ConfigView.super.draw_background(self, style.background)
+end
+
+---Reposition generated settings controls.
+function ConfigView:update()
+  if not ConfigView.super.update(self) then return end
+  if self.sections then
+    layout_settings_section(self.sections)
+  else
+    layout_settings_childs(self.childs, self:get_width())
+  end
+  if self.size.x == 0 and self.size.y == 0 then
+    self:schedule_update(true)
+  end
+end
+
 ---Reposition and resize core and plugin widgets.
 function Settings:update()
   if not Settings.super.update(self) then return end
@@ -2168,12 +2372,6 @@ function Settings:update()
 
   for _, section in ipairs({self.core_sections, self.plugin_sections}) do
     if section.parent:is_visible() then
-      section:set_size(
-        section.parent.size.x - (style.padding.x),
-        section:get_real_height()
-      )
-      section:set_position(style.padding.x / 2, 0)
-
       if section == self.plugin_sections and command.is_valid("plugin-manager:show") then
         -- accomodate plugin manager button
         self.plugin_button:set_position(
@@ -2182,35 +2380,7 @@ function Settings:update()
         )
       end
 
-      for _, pane in ipairs(section.panes) do
-        local prev_child = nil
-        for pos=#pane.container.childs, 1, -1 do
-          local child = pane.container.childs[pos]
-          local x, y = 10, (10 * SCALE)
-          if prev_child then
-            if
-              (prev_child:is(Label) and not prev_child.desc)
-              or
-              (child:is(Label) and child.desc)
-            then
-              y = prev_child:get_bottom() + (10 * SCALE)
-            elseif not child:is(Line) then
-              y = prev_child:get_bottom() + (30 * SCALE)
-            end
-          end
-          if child:is(Line) then
-            x = 0
-          elseif
-            child:is(ItemsList) or child:is(FilePicker)
-            or
-            child:is(TextBox) or child:is(Container)
-          then
-            child:set_size(pane.container:get_width() - 20)
-          end
-          child:set_position(x, y)
-          prev_child = child
-        end
-      end
+      layout_settings_section(section)
     end
   end
 
@@ -2237,6 +2407,34 @@ end
 function Settings:try_close(do_close)
   self.super.try_close(self, do_close)
   self:hide()
+end
+
+---Open a settings view in the active node.
+---@param view widget
+local function open_settings_view(view)
+  view:show()
+  local node = core.root_view:get_active_node_default()
+  node:add_view(view)
+  node:set_active_view(view)
+end
+
+---Show a generated configuration view.
+---@param title string
+---@param spec settings.config_spec|settings.option[]
+---@param context? string|table Plugin name or standalone render context inherited from the opener.
+---@return settings.configview|nil view
+function settings.show_config(title, spec, context)
+  if type(title) ~= "string" or title == "" then
+    core.error("Settings: show_config requires a title")
+    return nil
+  end
+  if type(spec) ~= "table" then
+    core.error("Settings: show_config requires a config spec table")
+    return nil
+  end
+  local view = ConfigView(title, spec, context)
+  open_settings_view(view)
+  return view
 end
 
 --------------------------------------------------------------------------------

--- a/scripts/lua/tests/settings.lua
+++ b/scripts/lua/tests/settings.lua
@@ -1,0 +1,229 @@
+local test = require "core.test"
+local config = require "core.config"
+local settings = require "plugins.settings"
+local Button = require "widget.button"
+local TextBox = require "widget.textbox"
+local Toggle = require "widget.toggle"
+
+local function find_child(view, class)
+  local childs = view.childs
+  if view.sections then
+    childs = view.sections.panes[1].container.childs
+  end
+  for _, child in ipairs(childs) do
+    if child:is(class) then return child end
+  end
+end
+
+test.describe("settings", function()
+  local old_test_settings
+  local old_settings_config
+
+  test.before_each(function()
+    old_test_settings = config.plugins.test_settings
+    old_settings_config = settings.config
+    config.plugins.test_settings = {}
+    settings.config = {}
+    os.remove(USERDIR .. "/user_settings.lua")
+  end)
+
+  test.after_each(function()
+    config.plugins.test_settings = old_test_settings
+    settings.config = old_settings_config
+    os.remove(USERDIR .. "/user_settings.lua")
+  end)
+
+  test.it("shows standalone config views and persists prefixed values", function()
+    local applied
+    local view = settings.show_config("Generated Settings", {
+      name = "Generated",
+      path_prefix = "plugins.test_settings",
+      {
+        label = "Model",
+        path = "model",
+        type = settings.type.STRING,
+        default = "default",
+        get_value = function(value)
+          return value .. "-view"
+        end,
+        set_value = function(value)
+          return value .. "-saved"
+        end,
+        on_apply = function(value)
+          applied = value
+        end
+      }
+    })
+
+    test.equal(view.sections, nil)
+
+    local textbox = find_child(view, TextBox)
+    test.not_nil(textbox)
+    test.equal(textbox:get_text(), "default-view")
+
+    textbox:on_change("custom")
+
+    test.equal(config.plugins.test_settings.model, "custom-saved")
+    test.equal(settings.config.plugins.test_settings.model, "custom-saved")
+    test.equal(applied, "custom-saved")
+
+    local saved = dofile(USERDIR .. "/user_settings.lua")
+    test.equal(saved.config.plugins.test_settings.model, "custom-saved")
+  end)
+
+  test.it("shows standalone config views with named sections", function()
+    local view = settings.show_config("Sectioned Settings", {
+      path_prefix = "plugins.test_settings",
+      sections = {
+        General = {
+          {
+            label = "Enabled",
+            path = "enabled",
+            type = settings.type.TOGGLE,
+            default = false
+          }
+        }
+      }
+    })
+
+    test.not_nil(view.sections)
+
+    local toggle = find_child(view, Toggle)
+    test.not_nil(toggle)
+    toggle:on_change(true)
+
+    test.equal(config.plugins.test_settings.enabled, true)
+    test.equal(settings.config.plugins.test_settings.enabled, true)
+  end)
+
+  test.it("opens sub config views from settings options", function()
+    local old_show_config = settings.show_config
+    local opened_title
+    local opened_view
+
+    settings.show_config = function(title, spec, context)
+      opened_title = title
+      opened_view = old_show_config(title, spec, context)
+      return opened_view
+    end
+
+    local view = old_show_config("Parent Settings", {
+      path_prefix = "plugins.test_settings",
+      {
+        label = "Open Preferences",
+        title = "Project Preferences",
+        type = settings.type.SUBCONFIG,
+        spec = {
+          path_prefix = "plugins.test_settings.project",
+          {
+            label = "Project Name",
+            path = "name",
+            type = settings.type.STRING,
+            default = "Demo"
+          }
+        }
+      }
+    })
+
+    local button = find_child(view, Button)
+    test.not_nil(button)
+    test.equal(button.label, "Open Preferences")
+    test.equal(button.icon.code, "P")
+
+    button:on_click()
+    settings.show_config = old_show_config
+
+    test.equal(opened_title, "Project Preferences")
+    test.not_nil(opened_view)
+
+    local textbox = find_child(opened_view, TextBox)
+    test.not_nil(textbox)
+    test.equal(textbox:get_text(), "Demo")
+
+    textbox:on_change("Website")
+
+    test.equal(config.plugins.test_settings.project.name, "Website")
+    test.equal(settings.config.plugins.test_settings.project.name, "Website")
+  end)
+
+  test.it("resolves sub config prefixes relative to plugin context", function()
+    local old_show_config = settings.show_config
+    local opened_view
+
+    settings.show_config = function(title, spec, context)
+      opened_view = old_show_config(title, spec, context)
+      return opened_view
+    end
+
+    local view = old_show_config("Parent Settings", {
+      {
+        label = "Open Preferences",
+        title = "Project Preferences",
+        type = settings.type.SUBCONFIG,
+        spec = {
+          path_prefix = "project",
+          {
+            label = "Project Name",
+            path = "name",
+            type = settings.type.STRING,
+            default = "Demo"
+          }
+        }
+      }
+    }, "test_settings")
+
+    local button = find_child(view, Button)
+    test.not_nil(button)
+    button:on_click()
+    settings.show_config = old_show_config
+
+    local textbox = find_child(opened_view, TextBox)
+    test.not_nil(textbox)
+    textbox:on_change("Website")
+
+    test.equal(config.plugins.test_settings.project.name, "Website")
+    test.equal(settings.config.plugins.test_settings.project.name, "Website")
+    test.equal(config.project, nil)
+  end)
+
+  test.it("inherits plugin paths for sub config views without a prefix", function()
+    local old_show_config = settings.show_config
+    local opened_view
+
+    settings.show_config = function(title, spec, context)
+      opened_view = old_show_config(title, spec, context)
+      return opened_view
+    end
+
+    local view = old_show_config("Parent Settings", {
+      {
+        label = "Open Preferences",
+        title = "Project Preferences",
+        type = settings.type.SUBCONFIG,
+        spec = {
+          {
+            label = "Project Name",
+            path = "name",
+            type = settings.type.STRING,
+            default = "Demo"
+          }
+        }
+      }
+    }, "test_settings")
+
+    local button = find_child(view, Button)
+    test.not_nil(button)
+    button:on_click()
+    settings.show_config = old_show_config
+
+    local textbox = find_child(opened_view, TextBox)
+    test.not_nil(textbox)
+    test.equal(textbox:get_text(), "Demo")
+
+    textbox:on_change("Website")
+
+    test.equal(config.plugins.test_settings.name, "Website")
+    test.equal(settings.config.plugins.test_settings.name, "Website")
+    test.equal(config.name, nil)
+  end)
+end)


### PR DESCRIPTION
Introduce a reusable settings config view that can render standalone option specs, named sections, and sub-config buttons while preserving plugin-relative path resolution.

Factor the existing settings layout logic so generated views and the main settings pane share the same control positioning behavior.

Add Lua tests for prefixed persistence, sectioned specs, and nested sub-config path handling.

### Preview

https://github.com/user-attachments/assets/004dcd00-fe03-4016-a344-8575fb979b9d

https://github.com/user-attachments/assets/c3457f24-bfc3-41fd-a257-8dc61d3d1c93
