### PR TITLE
fix: fix clang-cl and MSVC build errors on Windows

### DIFF
--- a/src/api/system.c
+++ b/src/api/system.c
@@ -18,6 +18,7 @@
 #include "../system_events.h"
 #ifdef _WIN32
   #include <direct.h>
+  #include <io.h>
   #include <windows.h>
   #include <fileapi.h>
   #include "../utfconv.h"

--- a/src/rencache.c
+++ b/src/rencache.c
@@ -10,9 +10,11 @@
   #ifndef alignof
     #define alignof _Alignof
   #endif
-  /* max_align_t is a compiler defined type, but
-  ** MSVC doesn't provide it, so we'll have to improvise */
-  typedef long double max_align_t;
+  #ifndef __clang__
+    /* max_align_t is a compiler defined type, but
+    ** MSVC doesn't provide it, so we'll have to improvise */
+    typedef long double max_align_t;
+  #endif
 #else
   #include <stdalign.h>
 #endif

--- a/src/tokenizer/arena.c
+++ b/src/tokenizer/arena.c
@@ -9,7 +9,9 @@
   #ifndef alignof
     #define alignof _Alignof
   #endif
-  typedef long double max_align_t;
+  #ifndef __clang__
+    typedef long double max_align_t;
+  #endif
 #else
   #include <stdalign.h>
 #endif


### PR DESCRIPTION
Fixes build errors when compiling with clang-cl (LLVM with MSVC toolchain) on Windows. clang-cl sets `_MSC_VER` for compatibility but is stricter than MSVC in two ways:

- **`src/api/system.c`**: Add `#include <io.h>` on Windows so `_chsize` is explicitly declared. clang-cl errors on implicit function declarations; MSVC silently accepted this because it pulled in the declaration as a side effect of other headers.

- **`src/rencache.c`** and **`src/tokenizer/arena.c`**: Guard the `max_align_t` typedef with `#ifndef __clang__`. clang-cl defines `_MSC_VER` but already provides `max_align_t` in its own headers (as `double`), causing a redefinition conflict with the existing `long double` typedef. Plain MSVC does not define `max_align_t`, so the workaround is still applied there.

All three fixes are backward compatible — MSVC and GCC builds are unaffected.

Tested on Windows with:
- MSVC (`cl`) ✅
- clang-cl 22.1.0 (`CC=clang-cl CXX=clang-cl`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)