### PR TITLE
build: c11 fallback for MSVC + silence C4146/C4113 warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('pragtical',
     license : 'MIT',
     meson_version : '>= 0.63',
     default_options : [
-        'c_std=gnu11',
+        'c_std=gnu11,c11',
         'wrap_mode=nofallback'
     ]
 )

--- a/src/api/dirmonitor/dummy.c
+++ b/src/api/dirmonitor/dummy.c
@@ -2,7 +2,7 @@
 
 #include "dirmonitor.h"
 
-static struct dirmonitor_internal* init_dirmonitor() { return NULL; }
+static struct dirmonitor_internal* init_dirmonitor(void) { return NULL; }
 static void deinit_dirmonitor(struct dirmonitor_internal* monitor) { }
 static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int len) { return -1; }
 static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int size, int (*callback)(int, const char*, void*), void* data) { return -1; }

--- a/src/api/dirmonitor/dummy.c
+++ b/src/api/dirmonitor/dummy.c
@@ -8,7 +8,7 @@ static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buf
 static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int size, int (*callback)(int, const char*, void*), void* data) { return -1; }
 static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) { return -1; }
 static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) { }
-static int get_mode_dirmonitor() { return 1; }
+static int get_mode_dirmonitor(void) { return 1; }
 
 struct dirmonitor_backend dirmonitor_dummy = {
   .name = "dummy",

--- a/src/api/dirmonitor/fsevents.c
+++ b/src/api/dirmonitor/fsevents.c
@@ -14,7 +14,7 @@ struct dirmonitor_internal {
 CFRunLoopRef main_run_loop;
 
 
-static struct dirmonitor_internal* init_dirmonitor() {
+static struct dirmonitor_internal* init_dirmonitor(void) {
   static bool mainloop_registered = false;
   if (!mainloop_registered) {
     main_run_loop = CFRunLoopGetCurrent();

--- a/src/api/dirmonitor/fsevents.c
+++ b/src/api/dirmonitor/fsevents.c
@@ -217,7 +217,7 @@ static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
 }
 
 
-static int get_mode_dirmonitor() { return 1; }
+static int get_mode_dirmonitor(void) { return 1; }
 
 struct dirmonitor_backend dirmonitor_fsevents = {
   .name = "fsevents",

--- a/src/api/dirmonitor/inodewatcher.cpp
+++ b/src/api/dirmonitor/inodewatcher.cpp
@@ -11,7 +11,7 @@
 #include "dirmonitor.h"
 
 extern "C" {
-struct dirmonitor_internal* init_dirmonitor();
+struct dirmonitor_internal* init_dirmonitor(void);
 void deinit_dirmonitor(struct dirmonitor_internal*);
 int get_changes_dirmonitor(struct dirmonitor_internal*, char*, int);
 int translate_changes_dirmonitor(struct dirmonitor_internal*, char*, int, int (*)(int, const char*, void*), void*);
@@ -27,7 +27,7 @@ struct dirmonitor_internal {
 };
 
 
-struct dirmonitor_internal* init_dirmonitor() {
+struct dirmonitor_internal* init_dirmonitor(void) {
   struct dirmonitor_internal* monitor = (struct dirmonitor_internal*)SDL_calloc(sizeof(struct dirmonitor_internal), 1);
   monitor->fd = create_inode_watcher(0);
   pipe(monitor->sig);

--- a/src/api/dirmonitor/inodewatcher.cpp
+++ b/src/api/dirmonitor/inodewatcher.cpp
@@ -17,7 +17,7 @@ int get_changes_dirmonitor(struct dirmonitor_internal*, char*, int);
 int translate_changes_dirmonitor(struct dirmonitor_internal*, char*, int, int (*)(int, const char*, void*), void*);
 int add_dirmonitor(struct dirmonitor_internal*, const char*);
 void remove_dirmonitor(struct dirmonitor_internal*, int);
-int get_mode_dirmonitor();
+int get_mode_dirmonitor(void);
 }
 
 struct dirmonitor_internal {
@@ -75,7 +75,7 @@ static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
   inode_watcher_remove_watch(monitor->fd, fd);
 }
 
-static int get_mode_dirmonitor() { return 2; }
+static int get_mode_dirmonitor(void) { return 2; }
 
 struct dirmonitor_backend dirmonitor_inodewatcher = {
   .name = "inodewatcher"

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -14,7 +14,7 @@ struct dirmonitor_internal {
 };
 
 
-static struct dirmonitor_internal* init_dirmonitor() {
+static struct dirmonitor_internal* init_dirmonitor(void) {
   struct dirmonitor_internal* monitor = SDL_calloc(1, sizeof(struct dirmonitor_internal));
   monitor->fd = inotify_init();
   pipe(monitor->sig);

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -55,7 +55,7 @@ static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
 }
 
 
-static int get_mode_dirmonitor() { return 2; }
+static int get_mode_dirmonitor(void) { return 2; }
 
 struct dirmonitor_backend dirmonitor_inotify = {
   .name = "inotify",

--- a/src/api/dirmonitor/kqueue.c
+++ b/src/api/dirmonitor/kqueue.c
@@ -14,7 +14,7 @@ struct dirmonitor_internal {
 };
 
 
-static struct dirmonitor_internal* init_dirmonitor() {
+static struct dirmonitor_internal* init_dirmonitor(void) {
   struct dirmonitor_internal* monitor = SDL_calloc(1, sizeof(struct dirmonitor_internal));
   monitor->fd = kqueue();
   return monitor;

--- a/src/api/dirmonitor/kqueue.c
+++ b/src/api/dirmonitor/kqueue.c
@@ -64,7 +64,7 @@ static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
 }
 
 
-static int get_mode_dirmonitor() { return 2; }
+static int get_mode_dirmonitor(void) { return 2; }
 
 struct dirmonitor_backend dirmonitor_kqueue = {
   .name = "kqueue",

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -64,7 +64,7 @@ static  void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
 }
 
 
-static int get_mode_dirmonitor() { return 1; }
+static int get_mode_dirmonitor(void) { return 1; }
 
 struct dirmonitor_backend dirmonitor_win32 = {
   .name = "win32",

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -20,7 +20,7 @@ static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buf
 }
 
 
-static struct dirmonitor_internal* init_dirmonitor() {
+static struct dirmonitor_internal* init_dirmonitor(void) {
   return SDL_calloc(1, sizeof(struct dirmonitor_internal));
 }
 

--- a/src/tokenizer/regex.c
+++ b/src/tokenizer/regex.c
@@ -157,7 +157,7 @@ static size_t regex_offset_relative(int64_t pos, size_t len) {
     return pos;
   else if (pos == 0)
     return 1;
-  else if (pos < -len)  /* inverted comparison */
+  else if (pos < -(int64_t)len)  /* inverted comparison */
     return 1;  /* clip to 1 */
   else return len + pos + 1;
 }


### PR DESCRIPTION
## Summary
- Add `c11` as a fallback in `c_std` so MSVC (which doesn't support `gnu11`) configures cleanly.
- Fix C4146 in `src/tokenizer/regex.c`: cast `len` to `int64_t` before unary minus so the comparison is a real signed compare instead of unsigned wrap. The branch turns out to be unreachable due to an earlier early-return — tracked in #499.
- Fix C4113 across all dirmonitor backends: use `(void)` instead of K&R `()` in `init_dirmonitor` (and `get_mode_dirmonitor` for consistency) so MSVC matches them against the `dirmonitor_backend` function pointers.

Verified MSVC build is now clean of C4146/C4113.