### PR TITLE
Fix inline code selection highlight

### DIFF
--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -2738,7 +2738,7 @@ end
 
 local function should_draw_command(command, phase)
   if phase == "background" then
-    return command.type == "rect"
+    return command.type == "rect" or command.type == "text"
   elseif phase == "foreground" then
     return command.type ~= "rect"
   end
@@ -2774,13 +2774,15 @@ local function draw_layout_commands(commands, start_x, start_y, clip_x, clip_y, 
         local tab_offset = 0
         for _, fragment in ipairs(command.fragments) do
           if fragment.type == "image" then
-            local draw_y = y + math.max(math.floor((command.height - fragment.height) / 2), 0)
-            renderer.draw_canvas(fragment.image, cursor_x, draw_y)
+            if phase ~= "background" then
+              local draw_y = y + math.max(math.floor((command.height - fragment.height) / 2), 0)
+              renderer.draw_canvas(fragment.image, cursor_x, draw_y)
+            end
             cursor_x = cursor_x + fragment.width
           else
             local font_height = fragment.font:get_height()
             local draw_y = y + (command.height - font_height) / 2
-            if fragment.background then
+            if fragment.background and phase ~= "foreground" then
               renderer.draw_rect(
                 cursor_x - INLINE_CODE_PADDING_X,
                 draw_y - INLINE_CODE_PADDING_Y,
@@ -2789,14 +2791,18 @@ local function draw_layout_commands(commands, start_x, start_y, clip_x, clip_y, 
                 resolve_color(fragment.background)
               )
             end
-            cursor_x = renderer.draw_text(
-              fragment.font,
-              fragment.text,
-              cursor_x,
-              draw_y,
-              resolve_color(fragment.color),
-              command.tabbed and { tab_offset = tab_offset } or nil
-            )
+            if phase ~= "background" then
+              cursor_x = renderer.draw_text(
+                fragment.font,
+                fragment.text,
+                cursor_x,
+                draw_y,
+                resolve_color(fragment.color),
+                command.tabbed and { tab_offset = tab_offset } or nil
+              )
+            else
+              cursor_x = cursor_x + fragment.width
+            end
           end
           if command.tabbed then
             tab_offset = cursor_x - x

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -378,6 +378,95 @@ Paragraph with a footnote.[^note]
     test.ok(selection_index < text_index)
   end)
 
+  test.test("shows selected text in inline code spans", function()
+    local view = MarkdownView("Paragraph with `inline code` text")
+    view.position.x = 0
+    view.position.y = 0
+    view.size.x = 400
+    view.size.y = 300
+    local layout = view:ensure_layout()
+    local code_command
+    local code_fragment
+    local code_x = 0
+
+    for _, command in ipairs(layout.commands) do
+      if command.type == "text" then
+        local fragment_x = 0
+        for _, fragment in ipairs(command.fragments) do
+          if fragment.background then
+            code_command = command
+            code_fragment = fragment
+            code_x = fragment_x
+            break
+          end
+          fragment_x = fragment_x + (fragment.width or 0)
+        end
+      end
+      if code_command then
+        break
+      end
+    end
+
+    test.not_nil(code_command)
+    test.not_nil(code_fragment)
+    local start_x = style.padding.x + code_command.x + code_x
+    local y = style.padding.y + code_command.y + code_command.height / 2
+    view:on_mouse_pressed("left", start_x, y, 1)
+    view:on_mouse_moved(start_x + code_fragment.width + 1, y, code_fragment.width + 1, 0)
+    view:on_mouse_released("left", start_x + code_fragment.width + 1, y)
+    test.equal(view:get_selected_text(), "inline code")
+
+    local events = {}
+    local original_draw_text = renderer.draw_text
+    local original_draw_rect = renderer.draw_rect
+    local original_push_clip_rect = core.push_clip_rect
+    local original_pop_clip_rect = core.pop_clip_rect
+
+    view.draw_background = function() end
+    view.draw_scrollbar = function() end
+    core.push_clip_rect = function() end
+    core.pop_clip_rect = function() end
+    renderer.draw_rect = function(_, _, _, _, color)
+      if color == style.background2 then
+        events[#events + 1] = "inline-code-background"
+      elseif color == style.selection then
+        events[#events + 1] = "selection"
+      end
+    end
+    renderer.draw_text = function(font, text, x, y, color, opts)
+      if text ~= "" then
+        events[#events + 1] = "text"
+      end
+      return x + font:get_width(text, opts)
+    end
+
+    view:draw()
+
+    renderer.draw_text = original_draw_text
+    renderer.draw_rect = original_draw_rect
+    core.push_clip_rect = original_push_clip_rect
+    core.pop_clip_rect = original_pop_clip_rect
+
+    local code_background_index
+    local selection_index
+    local text_index
+    for index, event in ipairs(events) do
+      if event == "inline-code-background" and not code_background_index then
+        code_background_index = index
+      elseif event == "selection" and not selection_index then
+        selection_index = index
+      elseif event == "text" and selection_index and not text_index then
+        text_index = index
+      end
+    end
+
+    test.not_nil(code_background_index)
+    test.not_nil(selection_index)
+    test.not_nil(text_index)
+    test.ok(code_background_index < selection_index)
+    test.ok(selection_index < text_index)
+  end)
+
   test.test("copies selected rendered text", function()
     local view = MarkdownView("# Title\n\nParagraph one")
     view.size.x = 400


### PR DESCRIPTION
Draw inline code fragment backgrounds during the MarkdownView background pass instead of the foreground pass. This keeps selected inline code visible because the selection highlight is painted after the code background and before the text.

Add a regression test that selects an inline code span and verifies the background, selection, and text draw order.