### PR TITLE
Render MarkdownView frontmatter legibly

### DIFF
--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -205,6 +205,27 @@ local function is_rule(line)
   return true
 end
 
+local function is_frontmatter_delimiter(line)
+  return trim(line) == "---"
+end
+
+local function parse_frontmatter(lines)
+  if not is_frontmatter_delimiter(lines[1] or "") then
+    return nil
+  end
+
+  local frontmatter_lines = {}
+  for i = 2, #lines do
+    if is_frontmatter_delimiter(lines[i]) then
+      return {
+        type = "frontmatter",
+        lines = frontmatter_lines
+      }, i + 1
+    end
+    frontmatter_lines[#frontmatter_lines + 1] = lines[i]
+  end
+end
+
 local function get_heading(line)
   local marks, text = line:match("^%s*(#+)%s+(.-)%s*$")
   if marks and #marks <= 6 then
@@ -1270,15 +1291,23 @@ extract_single_image = function(segments)
   end
 end
 
-local function parse_blocks_from_lines(lines, state)
+local function parse_blocks_from_lines(lines, state, allow_frontmatter)
   local blocks = {}
   local i = 1
+
+  if allow_frontmatter then
+    local frontmatter, next_index = parse_frontmatter(lines)
+    if frontmatter then
+      blocks[#blocks + 1] = frontmatter
+      i = next_index
+    end
+  end
 
   local function parse_nested_lines(nested_lines)
     if #nested_lines == 0 then
       return {}
     end
-    return parse_blocks_from_lines(nested_lines, state)
+    return parse_blocks_from_lines(nested_lines, state, false)
   end
 
   while i <= #lines do
@@ -1657,7 +1686,7 @@ local function parse_document(text)
     references = {},
     footnote_definitions = {}
   }
-  local blocks = parse_blocks_from_lines(split_lines(text), state)
+  local blocks = parse_blocks_from_lines(split_lines(text), state, true)
   local footnotes = {
     definitions = state.footnote_definitions,
     numbers = {},
@@ -2573,6 +2602,10 @@ render_blocks = function(self, commands, y, blocks, width, x_offset, fonts, acce
       local used_width
       y, used_width = add_code_block(commands, y, block.lines, fonts.code, block.info, available_width, x_offset)
       content_width = math.max(content_width, x_offset + used_width)
+    elseif block.type == "frontmatter" then
+      local used_width
+      y, used_width = add_code_block(commands, y, block.lines, fonts.code, "yaml", available_width, x_offset)
+      content_width = math.max(content_width, x_offset + used_width)
     elseif block.type == "table" then
       local used_width
       y, used_width = add_table_block(self, commands, y, block, fonts.body, accent_color, available_width, x_offset)
@@ -3224,7 +3257,7 @@ function MarkdownView:append_text(text)
     references = self.references,
     footnote_definitions = self.footnotes.definitions
   }
-  local blocks = parse_blocks_from_lines(split_lines(text), state)
+  local blocks = parse_blocks_from_lines(split_lines(text), state, existing_text == "")
   prepare_blocks(blocks, self.references, self.footnotes)
   append_blocks(self.blocks, blocks)
 

--- a/data/core/markdownview.lua
+++ b/data/core/markdownview.lua
@@ -205,20 +205,29 @@ local function is_rule(line)
   return true
 end
 
-local function is_frontmatter_delimiter(line)
-  return trim(line) == "---"
+local FRONTMATTER_DELIMITERS = {
+  ["---"] = "yaml",
+  ["+++"] = "toml",
+  [";;;"] = "json"
+}
+
+local function get_frontmatter_info(line)
+  return FRONTMATTER_DELIMITERS[trim(line)]
 end
 
 local function parse_frontmatter(lines)
-  if not is_frontmatter_delimiter(lines[1] or "") then
+  local delimiter = trim(lines[1] or "")
+  local info = get_frontmatter_info(delimiter)
+  if not info then
     return nil
   end
 
   local frontmatter_lines = {}
   for i = 2, #lines do
-    if is_frontmatter_delimiter(lines[i]) then
+    if trim(lines[i]) == delimiter then
       return {
         type = "frontmatter",
+        info = info,
         lines = frontmatter_lines
       }, i + 1
     end
@@ -2604,7 +2613,7 @@ render_blocks = function(self, commands, y, blocks, width, x_offset, fonts, acce
       content_width = math.max(content_width, x_offset + used_width)
     elseif block.type == "frontmatter" then
       local used_width
-      y, used_width = add_code_block(commands, y, block.lines, fonts.code, "yaml", available_width, x_offset)
+      y, used_width = add_code_block(commands, y, block.lines, fonts.code, block.info, available_width, x_offset)
       content_width = math.max(content_width, x_offset + used_width)
     elseif block.type == "table" then
       local used_width

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -159,6 +159,58 @@ print("hello")
     test.equal(blocks[1].items[2].text, "Done task")
   end)
 
+  test.test("parses document frontmatter as a block", function()
+    local blocks = MarkdownView.parse_blocks([[
+---
+slug: pragtical-v3101-release
+title: Pragtical v3.10.1 Release
+authors: jgmdev
+---
+
+# Release Notes
+]])
+
+    test.equal(#blocks, 2)
+    test.equal(blocks[1].type, "frontmatter")
+    test.same(blocks[1].lines, {
+      "slug: pragtical-v3101-release",
+      "title: Pragtical v3.10.1 Release",
+      "authors: jgmdev"
+    })
+    test.equal(blocks[2].type, "heading")
+    test.equal(blocks[2].text, "Release Notes")
+  end)
+
+  test.test("renders frontmatter lines without collapsing them", function()
+    local view = MarkdownView([[
+---
+slug: pragtical-v3101-release
+title: Pragtical v3.10.1 Release
+authors: jgmdev
+---
+
+# Release Notes
+]])
+    view.size.x = 640
+    view.size.y = 360
+
+    local text_lines = {}
+    for _, command in ipairs(view:ensure_layout().commands) do
+      if command.type == "text" then
+        local fragments = {}
+        for _, fragment in ipairs(command.fragments or {}) do
+          fragments[#fragments + 1] = fragment.text or ""
+        end
+        text_lines[#text_lines + 1] = table.concat(fragments)
+      end
+    end
+
+    test.equal(text_lines[1], "slug: pragtical-v3101-release")
+    test.equal(text_lines[2], "title: Pragtical v3.10.1 Release")
+    test.equal(text_lines[3], "authors: jgmdev")
+    test.equal(text_lines[4], "Release Notes")
+  end)
+
   test.test("appends markdown incrementally at block boundaries", function()
     local view = MarkdownView("# One\n\nFirst paragraph.\n\n")
     local before_blocks = view.blocks

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -172,6 +172,7 @@ authors: jgmdev
 
     test.equal(#blocks, 2)
     test.equal(blocks[1].type, "frontmatter")
+    test.equal(blocks[1].info, "yaml")
     test.same(blocks[1].lines, {
       "slug: pragtical-v3101-release",
       "title: Pragtical v3.10.1 Release",
@@ -181,13 +182,78 @@ authors: jgmdev
     test.equal(blocks[2].text, "Release Notes")
   end)
 
+  test.test("parses toml frontmatter as a block", function()
+    local blocks = MarkdownView.parse_blocks([[
++++
+title = "My Article Title"
+date = 2024-01-15
+author = "John Doe"
+tags = ["markdown", "tutorial", "web"]
++++
+
+# Article
+]])
+
+    test.equal(#blocks, 2)
+    test.equal(blocks[1].type, "frontmatter")
+    test.equal(blocks[1].info, "toml")
+    test.same(blocks[1].lines, {
+      'title = "My Article Title"',
+      "date = 2024-01-15",
+      'author = "John Doe"',
+      'tags = ["markdown", "tutorial", "web"]'
+    })
+    test.equal(blocks[2].type, "heading")
+  end)
+
+  test.test("parses json frontmatter as a block", function()
+    local blocks = MarkdownView.parse_blocks([[
+;;;
+{
+  "title": "My Article Title",
+  "date": "2024-01-15",
+  "author": "John Doe",
+  "tags": ["markdown", "tutorial", "web"]
+}
+;;;
+
+# Article
+]])
+
+    test.equal(#blocks, 2)
+    test.equal(blocks[1].type, "frontmatter")
+    test.equal(blocks[1].info, "json")
+    test.same(blocks[1].lines, {
+      "{",
+      '  "title": "My Article Title",',
+      '  "date": "2024-01-15",',
+      '  "author": "John Doe",',
+      '  "tags": ["markdown", "tutorial", "web"]',
+      "}"
+    })
+    test.equal(blocks[2].type, "heading")
+  end)
+
+  test.test("does not parse mismatched frontmatter delimiters", function()
+    local blocks = MarkdownView.parse_blocks([[
++++
+title = "My Article Title"
+---
+
+# Article
+]])
+
+    test.not_equal(blocks[1].type, "frontmatter")
+  end)
+
   test.test("renders frontmatter lines without collapsing them", function()
     local view = MarkdownView([[
----
-slug: pragtical-v3101-release
-title: Pragtical v3.10.1 Release
-authors: jgmdev
----
++++
+title = "My Article Title"
+date = 2024-01-15
+author = "John Doe"
+tags = ["markdown", "tutorial", "web"]
++++
 
 # Release Notes
 ]])
@@ -205,10 +271,11 @@ authors: jgmdev
       end
     end
 
-    test.equal(text_lines[1], "slug: pragtical-v3101-release")
-    test.equal(text_lines[2], "title: Pragtical v3.10.1 Release")
-    test.equal(text_lines[3], "authors: jgmdev")
-    test.equal(text_lines[4], "Release Notes")
+    test.equal(text_lines[1], 'title = "My Article Title"')
+    test.equal(text_lines[2], "date = 2024-01-15")
+    test.equal(text_lines[3], 'author = "John Doe"')
+    test.equal(text_lines[4], 'tags = ["markdown", "tutorial", "web"]')
+    test.equal(text_lines[5], "Release Notes")
   end)
 
   test.test("appends markdown incrementally at block boundaries", function()


### PR DESCRIPTION
Recognize YAML frontmatter only at the start of a MarkdownView document and parse it as a dedicated block instead of treating the delimiters as horizontal rules around one collapsed paragraph.

Render the frontmatter through the existing YAML-highlighted code block path so each metadata line remains readable while regular horizontal rules elsewhere keep their existing behavior.

Add regression tests for frontmatter parsing and rendered line output.

### Before

<img width="840" height="282" alt="20260525-122444" src="https://github.com/user-attachments/assets/e6adf3e1-646d-4af9-94f4-1221c4461016" />

### After

<img width="751" height="332" alt="20260525-122418" src="https://github.com/user-attachments/assets/0eab1e4f-49fd-481e-917d-ef3e173fdd31" />

Fixes #494