### PR TITLE
fix: add missing type to remaining pair patterns in language_python.lua

### DIFF
--- a/data/plugins/language_python.lua
+++ b/data/plugins/language_python.lua
@@ -150,7 +150,7 @@ local python_func = {
       type = { "normal", "string" },
       syntax = python_type
     },
-    { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, syntax = python_type },
+    { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, type = "normal", syntax = python_type },
 
   }, python_patterns),
 
@@ -233,7 +233,7 @@ syntax.add {
     },
 
     -- type declarations eg: variable_name: type1 | type2
-    { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, syntax = python_type },
+    { pattern = { ":%s*%f[%a]", "%f[^%[%]%w_| \t]" }, type = "normal", syntax = python_type },
 
   }, python_patterns),
 


### PR DESCRIPTION
Two inline pair patterns were missed in the previous fix (bea39ad5 / #498). Both patterns — one in `python_func` and one in the top-level `syntax.add` block — had `syntax = python_type` but no `type` field, triggering `[ERROR] Malformed pattern #5 <<table>> in unnamed language plugin. Not enough token types: got 0 needed 1.` in the C tokenizer when opening Python files that use type annotations (e.g. `variable: SomeType | OtherType`). Adds `type = "normal"` to both affected patterns.