### PR TITLE
Reduce unfocused wake delay when restoring focus

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -1884,8 +1884,8 @@ function core.run_step()
   if run_threads_mode == "background" then
     -- run background threads, no drawing or events processing
     run_next_step = nil
-    -- Cap sleep to 100 ms so focus / event changes are noticed quickly
-    system.sleep(math.min(time_to_wake, 0.1))
+    -- Cap sleep to ~16 ms so focus / event changes are noticed quickly
+    system.sleep(math.min(time_to_wake, 0.016))
     -- allow normal rendering when the mouse moves over the window
     if system.has_pending_events() then
       run_skip_no_focus = now + 5
@@ -1921,7 +1921,7 @@ function core.run_step()
       else
         -- No focus and nothing to do: sleep briefly to avoid spinning.
         -- SDL will call SDL_AppEvent when input arrives.
-        system.sleep(0.1)
+        system.sleep(0.016)
         -- allow normal rendering for up to 5 seconds after receiving event
         -- to let any animations render smoothly
         run_skip_no_focus = system.get_time() + 5

--- a/data/plugins/ipc.lua
+++ b/data/plugins/ipc.lua
@@ -925,6 +925,9 @@ end
 --------------------------------------------------------------------------------
 ipc:register_method("core.open_file", function(file)
   if system.get_file_info(file) then
+    if system.get_window_mode(core.window) == "minimized" then
+      system.set_window_mode(core.window, "normal")
+    end
     system.raise_window(core.window)
     core.root_view:open_doc(core.open_doc(file))
   end
@@ -932,6 +935,9 @@ end, {{name = "file", type = "string"}})
 
 ipc:register_method("core.open_directory", function(directory)
   if system.get_file_info(directory) then
+    if system.get_window_mode(core.window) == "minimized" then
+      system.set_window_mode(core.window, "normal")
+    end
     system.raise_window(core.window)
     core.add_project(directory)
   end
@@ -939,6 +945,9 @@ end, {{name = "directory", type = "string"}})
 
 ipc:register_method("core.change_directory", function(directory)
   if system.get_file_info(directory) then
+    if system.get_window_mode(core.window) == "minimized" then
+      system.set_window_mode(core.window, "normal")
+    end
     system.raise_window(core.window)
     if directory == core.root_project().path then return end
     core.confirm_close_docs(core.docs, function(dirpath)


### PR DESCRIPTION
## Summary
- reduce both unfocused sleep paths from 100 ms to 16 ms
- restore minimized windows before raising them for single-instance IPC file and directory opens
- improve restore responsiveness after focus returns while keeping the changes localized

Fixes #505

## Testing
- manually restored the app from the Windows taskbar and confirmed the delay is much better
- minimized Pragtical and opened an associated file from Explorer to confirm the running instance restores and comes to the foreground
