### PR TITLE
build: silence clang-cl warnings in project sources

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,13 @@ else
 endif
 pragtical_cargs += '-DPRAGTICAL_ARCH_TUPLE="@0@"'.format(arch_tuple)
 
+# Silence MSVC/clang-cl deprecation warnings for standard CRT functions
+# (strcpy/strerror/getenv/freopen/...). The "secure" *_s variants are
+# non-portable MSVC extensions; we use the standard functions intentionally.
+if cc.get_argument_syntax() == 'msvc'
+    pragtical_cargs += '-D_CRT_SECURE_NO_WARNINGS'
+endif
+
 #===============================================================================
 # Linker Settings
 #===============================================================================

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -2062,7 +2062,7 @@ void ren_draw_poly(RenSurface *rs, RenPoint *points, unsigned short npoints, Ren
 }
 
 /******************* Rectangles **********************/
-static inline RenColor blend_pixel(RenColor dst, RenColor src) {
+static inline UNUSED RenColor blend_pixel(RenColor dst, RenColor src) {
   int ia = 0xff - src.a;
   dst.r = ((src.r * src.a) + (dst.r * ia)) >> 8;
   dst.g = ((src.g * src.a) + (dst.g * ia)) >> 8;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #define UNUSED __attribute__((__unused__))
 #else
 #define UNUSED

--- a/src/utfconv.h
+++ b/src/utfconv.h
@@ -1,7 +1,7 @@
 #ifndef MBSEC_H
 #define MBSEC_H
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #define UNUSED __attribute__((__unused__))
 #else
 #define UNUSED


### PR DESCRIPTION
## Summary
- Define `_CRT_SECURE_NO_WARNINGS` for MSVC-syntax compilers to silence CRT deprecation warnings (`strcpy`/`strerror`/`getenv`/`freopen`/...). The `*_s` variants are non-portable MSVC extensions.
- Extend the `UNUSED` macro gate in `utfconv.h` and `renderer.h` to include `__clang__`, so the attribute is applied under clang-cl (which does not define `__GNUC__`).
- Mark `blend_pixel` in `renderer.c` as `UNUSED`; currently dead code, kept for now.