### PR TITLE
Improve DocView long-line rendering

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -8,6 +8,7 @@ local ime = require "core.ime"
 local View = require "core.view"
 
 local CACHE_LINE_LEN = 500
+local LONG_LINE_EXTRA_PIXELS = 2000
 
 local IME_VIEW = nil
 local IME_STATE = {line1 = 0, col1 = 0, line2 = 0, col2 = 0, w = 0, h = 0}
@@ -46,6 +47,32 @@ local DocView = View:extend()
 function DocView:__tostring() return "DocView" end
 
 DocView.context = "session"
+
+local function utf8_previous_start(text, col)
+  col = common.clamp(col, 1, #text)
+  while col > 1 and common.is_utf8_cont(text, col) do
+    col = col - 1
+  end
+  return col
+end
+
+local function utf8_next_start(text, col)
+  if col >= #text then return #text end
+  col = utf8_previous_start(text, col)
+  return utf8extra.next(text, col) or #text
+end
+
+local function utf8_char_end(text, col)
+  col = utf8_previous_start(text, col)
+  local next_col = utf8extra.next(text, col)
+  return next_col and (next_col - 1) or #text
+end
+
+local function trim_token_to_col(text, col, max_col)
+  local length = max_col - col + 1
+  if length >= #text then return text end
+  return text:sub(1, length)
+end
 
 ---Helper to move cursor vertically while preserving horizontal offset.
 ---@param dv core.docview
@@ -290,7 +317,7 @@ end
 function DocView:get_visible_cols_range(line, extra_cols)
   extra_cols = extra_cols or 100
 
-  local text = self.doc.lines[line]
+  local text = self.doc:get_utf8_line(line)
   local line_len = #text
   if line_len == 1 then return 1, 1, 1, 1 end
 
@@ -348,7 +375,7 @@ function DocView:get_col_x_offset(line, col)
   local column = 1
   local xoffset = 0
   local cache = self.doc.cache.col_x
-  local line_len = #self.doc.lines[line]
+  local line_len = #self.doc:get_utf8_line(line)
   if line_len > CACHE_LINE_LEN then
     if cache[line] and cache[line][col] then
       return cache[line][col]
@@ -382,6 +409,15 @@ function DocView:get_col_x_offset(line, col)
         return xoffset
       end
     else
+      if line_len > CACHE_LINE_LEN then
+        local chunk = text:sub(1, col - column)
+        xoffset = xoffset + font:get_width(chunk, {tab_offset = xoffset})
+        column = col
+        if cache[line] then
+          cache[line][column] = xoffset
+        end
+        return xoffset
+      end
       for char in common.utf8_chars(text) do
         if column >= col then
           return xoffset
@@ -407,23 +443,40 @@ end
 ---@param x number Horizontal pixel offset
 ---@return integer col Column number (byte offset)
 function DocView:get_x_offset_col(line, x)
-  local line_text = self.doc.lines[line]
+  if x <= 0 then return 1 end
+
+  local line_text = self.doc:get_utf8_line(line)
   local line_len = #line_text
 
   -- we leverage the caching already present on col_x, this works on all lines,
   -- but for the moment lets do it only on the cached lines and keep original
   -- code logic intact
   if line_len > CACHE_LINE_LEN then
-    local xo, pxo, last_col = 0, 0, 0
-    for col, _ in utf8extra.next, line_text do
-      pxo = xo
-      xo = self:get_col_x_offset(line, col)
-      if xo >= x or col >= line_len then
-        local w = xo - pxo
-        return (xo - x > w / 2) and last_col or col
+    local low = 1
+    local high = utf8_previous_start(line_text, line_len)
+
+    while low < high do
+      local mid = utf8_previous_start(line_text, math.floor((low + high) / 2))
+      if mid < low then mid = low end
+
+      if self:get_col_x_offset(line, mid) < x then
+        local next_col = utf8_next_start(line_text, mid)
+        if next_col <= low then break end
+        low = next_col
+      else
+        high = mid
       end
-      last_col = col
     end
+
+    if low <= 1 then return 1 end
+
+    local prev_col = utf8_previous_start(line_text, low - 1)
+    local prev_x = self:get_col_x_offset(line, prev_col)
+    local next_x = self:get_col_x_offset(line, low)
+    if x - prev_x < next_x - x then
+      return prev_col
+    end
+    return low
   end
 
   local xoffset, i = 0, 1
@@ -800,13 +853,44 @@ function DocView:draw_line_text(line, x, y)
 
   local col = 1
   local start_tx = tx
-  for tidx, type, text in self.doc.highlighter:each_token(line) do
+  local line_text = self.doc:get_utf8_line(line)
+  local line_len = #line_text
+  local visible_col1, visible_col2
+  if line_len > CACHE_LINE_LEN and #search_selections == 0 then
+    local gw = self:get_gutter_width()
+    local visible_width = math.max(0, self.size.x - gw)
+    local left_x = math.max(0, self.scroll.x - LONG_LINE_EXTRA_PIXELS)
+    local right_x = self.scroll.x + visible_width + LONG_LINE_EXTRA_PIXELS
+    visible_col1 = self:get_x_offset_col(line, left_x)
+    visible_col2 = utf8_char_end(line_text, self:get_x_offset_col(line, right_x))
+    tx = x + self:get_col_x_offset(line, visible_col1)
+    col = visible_col1
+  end
+  local token_start_col = 1
+  for tidx = 1, tokens_count, 2 do
+    local type, text = tokens[tidx], tokens[tidx + 1]
+    local token_col = token_start_col
+    token_start_col = token_start_col + #text
+    if visible_col1 then
+      local token_end = token_start_col - 1
+      if token_end < visible_col1 then goto continue end
+      if token_col < visible_col1 then
+        text = text:sub(visible_col1 - token_col + 1)
+        token_col = visible_col1
+      end
+      col = token_col
+    end
     if #search_selections == 0 then
       local color = style.syntax[type] or style.syntax["normal"]
       local font = style.syntax_fonts[type] or default_font
       if font ~= default_font then font:set_tab_size(indent_size) end
       -- do not render newline, fixes issue #1164
       if tidx == last_token then text = text:sub(1, -2) end
+      if visible_col2 then
+        if col > visible_col2 then break end
+        text = trim_token_to_col(text, col, visible_col2)
+        col = col + #text
+      end
       tx = renderer.draw_text(font, text, tx, ty, color, {tab_offset = tx - start_tx})
       if tx > self.position.x + self.size.x then break end
     else
@@ -841,6 +925,7 @@ function DocView:draw_line_text(line, x, y)
         if tx > self.position.x + self.size.x then break end
       end
     end
+    ::continue::
   end
   return self:get_line_height()
 end

--- a/data/core/tokenizer.lua
+++ b/data/core/tokenizer.lua
@@ -533,6 +533,7 @@ function tokenizer.each_token(t, scol)
   local tcount, start, col = #t, 1, nil
   if scol then
     local ccol = 1
+    start = tcount + 2
     for i=1, tcount, 2 do
       local text = t[i+1]
       local len = #text
@@ -541,7 +542,7 @@ function tokenizer.each_token(t, scol)
         col = scol - ccol + 1
         break
       end
-      ccol = ccol + len + 1
+      ccol = ccol + len
     end
   end
   local state = {t = t, tcount = tcount, col = col}

--- a/scripts/lua/benchmarks/docview_long_lines.lua
+++ b/scripts/lua/benchmarks/docview_long_lines.lua
@@ -1,0 +1,157 @@
+local Doc = require "core.doc"
+local DocView = require "core.docview"
+local style = require "core.style"
+local tokenizer = require "core.tokenizer"
+
+local function find_script_argument()
+  if not ARGS then return nil end
+  for i = 1, #ARGS do
+    local value = ARGS[i]
+    if value and value:match("scripts/lua/benchmarks/docview_long_lines%.lua$") then
+      return i
+    end
+  end
+end
+
+local function parse_inputs()
+  local script_idx = find_script_argument()
+  if not script_idx or not ARGS or not ARGS[script_idx + 1] then
+    return nil, 20, 100
+  end
+
+  local path = ARGS[script_idx + 1]
+  local iterations = tonumber(ARGS[script_idx + 2]) or 20
+  local draw_iterations = tonumber(ARGS[script_idx + 3]) or 100
+  return path, math.max(1, math.floor(iterations)), math.max(1, math.floor(draw_iterations))
+end
+
+local function print_usage()
+  print("Usage: ./scripts/run-local build run scripts/lua/benchmarks/docview_long_lines.lua /path/to/file [iterations] [draw_iterations]")
+end
+
+local function bench(label, iterations, fn)
+  collectgarbage("collect")
+  collectgarbage("collect")
+
+  local checksum
+  local start = system.get_time()
+  for _ = 1, iterations do
+    checksum = fn()
+  end
+  local elapsed = (system.get_time() - start) * 1000
+  print(string.format("%-28s %9.3f ms total  %8.3f ms/iter  checksum=%s",
+    label, elapsed, elapsed / iterations, tostring(checksum)))
+  return elapsed
+end
+
+local function original_draw_line_text(view, line, x, y)
+  local default_font = view:get_font()
+  local tx, ty = x, y + view:get_line_text_y_offset()
+  local last_token = nil
+  local tokens = view.doc.highlighter:get_line(line).tokens
+  local tokens_count = #tokens
+  if tokens_count > 0 and string.sub(tokens[tokens_count], -1) == "\n" then
+    last_token = tokens_count - 1
+  end
+  local _, indent_size = view.doc:get_indent_info()
+  local start_tx = tx
+
+  for tidx, type, text in view.doc.highlighter:each_token(line) do
+    local color = style.syntax[type] or style.syntax["normal"]
+    local font = style.syntax_fonts[type] or default_font
+    if font ~= default_font then font:set_tab_size(indent_size) end
+    if tidx == last_token then text = text:sub(1, -2) end
+    tx = renderer.draw_text(font, text, tx, ty, color, {tab_offset = tx - start_tx})
+    if tx > view.position.x + view.size.x then break end
+  end
+  return view:get_line_height()
+end
+
+local file_arg, iterations, draw_iterations = parse_inputs()
+if not file_arg then
+  print_usage()
+  os.exit(1)
+end
+
+local abs_path = system.absolute_path(file_arg)
+local info = system.get_file_info(abs_path)
+if not info or info.type ~= "file" then
+  print(string.format("File not found: %s", tostring(file_arg)))
+  print_usage()
+  os.exit(1)
+end
+
+local doc = Doc(file_arg, abs_path, false)
+local view = DocView(doc)
+view.position.x = 0
+view.position.y = 0
+view.size.x = 1200 * SCALE
+view.size.y = 800 * SCALE
+
+local longest_line = 1
+for i = 2, #doc.lines do
+  if #doc.lines[i] > #doc.lines[longest_line] then
+    longest_line = i
+  end
+end
+
+local x, y = view:get_line_screen_position(longest_line)
+local line_len = #doc.lines[longest_line]
+local draw_bytes = 0
+local real_draw_text = renderer.draw_text
+
+doc.highlighter.get_line = function(_, idx)
+  return { text = doc.lines[idx], tokens = { "normal", doc.lines[idx] } }
+end
+
+doc.highlighter.each_token = function(self, idx, scol)
+  return tokenizer.each_token(self:get_line(idx).tokens, scol)
+end
+
+renderer.draw_text = function(font, text, tx, ty, color, options)
+  draw_bytes = draw_bytes + #text
+  return tx + font:get_width(text, options)
+end
+
+local function benchmark_draw(label, draw_fn)
+  draw_bytes = 0
+  local elapsed = bench(label, draw_iterations, function()
+    draw_fn(view, longest_line, x, y)
+    return draw_bytes
+  end)
+  return elapsed, draw_bytes
+end
+
+print_usage()
+print(string.format("File: %s", abs_path))
+print(string.format("Longest line: %d (%d bytes)", longest_line, line_len))
+print(string.format("Iterations: %d", iterations))
+print(string.format("Draw iterations: %d", draw_iterations))
+print("Highlighter: plain-token override")
+print("")
+
+bench("get_visible_cols_range", iterations, function()
+  local col1, col2 = view:get_visible_cols_range(longest_line, 2000)
+  return string.format("%d:%d", col1, col2)
+end)
+
+bench("get_col_x_offset", iterations, function()
+  return math.floor(view:get_col_x_offset(longest_line, math.max(1, math.floor(line_len / 2))))
+end)
+
+local half_width = view:get_col_x_offset(longest_line, math.max(1, math.floor(line_len / 2)))
+bench("get_x_offset_col", iterations, function()
+  return view:get_x_offset_col(longest_line, half_width)
+end)
+
+local original_elapsed = benchmark_draw("draw original", original_draw_line_text)
+local optimized_elapsed = benchmark_draw("draw optimized", function(v, line, dx, dy)
+  return v:draw_line_text(line, dx, dy)
+end)
+
+renderer.draw_text = real_draw_text
+
+print("")
+print(string.format("draw speedup: %.2fx", original_elapsed / optimized_elapsed))
+
+os.exit(0)

--- a/scripts/lua/tests/docview.lua
+++ b/scripts/lua/tests/docview.lua
@@ -1,0 +1,148 @@
+local test = require "core.test"
+local Doc = require "core.doc"
+local DocView = require "core.docview"
+
+local function make_view(text)
+  local doc = Doc(nil, nil, true)
+  doc.lines = { text }
+  doc.cache.col_x = {}
+  doc.cache.ulen = {}
+  doc.highlighter:reset()
+
+  local view = DocView(doc)
+  view.position.x = 0
+  view.position.y = 0
+  view.size.x = 320
+  view.size.y = 200
+  view.indentguide_indents = {}
+  view.indentguide_indent_active = {}
+  return view
+end
+
+local function make_binary_view(raw_text, clean_text)
+  local view = make_view(raw_text)
+  view.doc.binary = true
+  view.doc.clean_lines = { clean_text }
+  view.doc.highlighter:reset()
+  return view
+end
+
+local function with_draw_text(fn)
+  local original = renderer.draw_text
+  local calls = {}
+  renderer.draw_text = function(font, text, x, y, color, options)
+    calls[#calls + 1] = {
+      text = text,
+      x = x,
+      y = y,
+      color = color,
+      options = options
+    }
+    return x + font:get_width(text, options)
+  end
+
+  local ok, err = pcall(fn, calls)
+  renderer.draw_text = original
+  if not ok then error(err, 0) end
+end
+
+local function scan_x_offset_col(view, line, x)
+  local line_text = view.doc.lines[line]
+  local line_len = #line_text
+  local xo, pxo, last_col = 0, 0, 0
+  for col in utf8extra.next, line_text do
+    pxo = xo
+    xo = view:get_col_x_offset(line, col)
+    if xo >= x or col >= line_len then
+      local w = xo - pxo
+      return (xo - x > w / 2) and last_col or col
+    end
+    last_col = col
+  end
+  return line_len
+end
+
+test.describe("docview", function()
+  test.test("draw_line_text slices long lines to the visible range", function()
+    local line = string.rep("var a = 1; ", 2000)
+    local view = make_view(line)
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function(calls)
+      view:draw_line_text(1, x, y)
+
+      local bytes = 0
+      for _, call in ipairs(calls) do
+        bytes = bytes + #call.text
+      end
+
+      test.ok(bytes > 0)
+      test.ok(bytes < #line / 2, string.format("drew too many bytes: %d of %d", bytes, #line))
+      test.equal(calls[1].options.tab_offset, calls[1].x - x)
+    end)
+  end)
+
+  test.test("draw_line_text slices from the correct syntax token", function()
+    local first = string.rep("a", 2000)
+    local second = string.rep("b", 8000)
+    local view = make_view(first .. second)
+    view.scroll.x = view:get_font():get_width(string.rep("W", 5000))
+    view.doc.highlighter.get_line = function()
+      return { tokens = { "keyword", first, "normal", second } }
+    end
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function(calls)
+      view:draw_line_text(1, x, y)
+      test.ok(#calls > 0)
+      test.equal(calls[1].text:sub(1, 1), "b")
+    end)
+  end)
+
+  test.test("draw_line_text slices binary lines using cleaned utf8 text", function()
+    local clean = string.rep("a", 2500) .. "TAIL\n"
+    local raw = string.rep("\255", 100) .. "\n"
+    local view = make_binary_view(raw, clean)
+    view.size.x = 480
+    local end_x = view:get_col_x_offset(1, #clean + 1)
+    view.scroll.x = math.max(0, end_x - view.size.x + view:get_gutter_width())
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function(calls)
+      view:draw_line_text(1, x, y)
+
+      local rendered = {}
+      for _, call in ipairs(calls) do
+        rendered[#rendered + 1] = call.text
+      end
+      test.ok(table.concat(rendered):find("TAIL", 1, true) ~= nil)
+    end)
+  end)
+
+  test.test("get_col_x_offset resumes cached long lines at token boundaries", function()
+    local first = string.rep("a", 600)
+    local second = string.rep("b", 600)
+    local view = make_view(first .. second)
+    view.doc.highlighter.get_line = function()
+      return { tokens = { "keyword", first, "normal", second } }
+    end
+
+    local font = view:get_font()
+    local first_width = font:get_width(first, { tab_offset = 0 })
+    local expected = first_width + font:get_width(second:sub(1, 299), { tab_offset = first_width })
+    view.doc.cache.col_x[1] = { [601] = first_width }
+
+    test.equal(view:get_col_x_offset(1, 900), expected)
+  end)
+
+  test.test("get_x_offset_col keeps long-line scan behavior", function()
+    local line = string.rep("abc def ", 100)
+    local view = make_view(line)
+    local width = view:get_col_x_offset(1, #line)
+
+    for i = 0, 10 do
+      local x = width * (i / 10)
+      test.equal(view:get_x_offset_col(1, x), scan_x_offset_col(view, 1, x))
+    end
+  end)
+end)

--- a/scripts/lua/tests/tokenizer.lua
+++ b/scripts/lua/tests/tokenizer.lua
@@ -277,5 +277,18 @@ test.describe("tokenizer", function()
       { "keyword", "c" },
       { "normal", " def" }
     })
+
+    items = collect_each_token({ "keyword", "abc", "normal", " def" }, 4)
+    test.same(items, {
+      { "normal", " def" }
+    })
+
+    items = collect_each_token({ "keyword", "abc", "normal", " def" }, 6)
+    test.same(items, {
+      { "normal", "ef" }
+    })
+
+    items = collect_each_token({ "keyword", "abc", "normal", " def" }, 8)
+    test.same(items, {})
   end)
 end)


### PR DESCRIPTION
Avoid drawing and measuring entire long-line tokens when only a small viewport slice is visible. DocView now computes a UTF-8-safe visible byte range from pixel offsets, draws only that token slice, and keeps tab offsets relative to the original line origin so proportional fonts remain correct.

Keep long-line coordinate math on the same cleaned UTF-8 text used by the highlighter and renderer. This avoids caret and text drift in files that contain invalid byte sequences and are displayed through Doc:get_utf8_line.

Fix tokenizer.each_token slicing from a starting column so token boundary math is contiguous instead of skipping one byte between tokens. Add focused DocView and tokenizer tests plus a benchmark for long physical lines.