### PR TITLE
Code folding Support

### DIFF
--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -571,6 +571,7 @@ local commands = {
           core.error("Invalid line number or unmatched string")
           return
         end
+        dv:ensure_line_visible(line)
         dv.doc:set_selection(line, 1  )
         dv:scroll_to_line(line, true)
       end,

--- a/data/core/commands/findreplace.lua
+++ b/data/core/commands/findreplace.lua
@@ -32,6 +32,7 @@ local function update_preview(sel, search_fn, text)
   local ok, line1, col1, line2, col2 = pcall(search_fn, last_view.doc,
     sel[1], sel[2], text, case_sensitive, find_regex)
   if ok and line1 and text ~= "" then
+    last_view:ensure_line_visible(line2)
     last_view.doc:set_selection(line2, col2, line1, col1)
     last_view:scroll_to_line(line2, true)
     found_expression = true
@@ -176,6 +177,7 @@ local function select_add_next(all)
       )
       if l1 == il1 and c1 == ic1 then break end
       if l2 and not is_in_any_selection(l2, c2) then
+        core.active_view:ensure_line_visible(l1)
         doc():add_selection(l2, c2, l1, c1)
         if not all then
           core.active_view:scroll_to_make_visible(l2, c2)
@@ -273,6 +275,7 @@ command.add(valid_for_finding, {
       local sl1, sc1, sl2, sc2 = dv.doc:get_selection(true)
       local line1, col1, line2, col2 = last_fn(dv.doc, sl2, sc2, last_text, case_sensitive, find_regex, false)
       if line1 then
+        dv:ensure_line_visible(line2)
         dv.doc:set_selection(line2, col2, line1, col1)
         dv:scroll_to_line(line2, true)
       else
@@ -288,6 +291,7 @@ command.add(valid_for_finding, {
       local sl1, sc1, sl2, sc2 = dv.doc:get_selection(true)
       local line1, col1, line2, col2 = last_fn(dv.doc, sl1, sc1, last_text, case_sensitive, find_regex, true)
       if line1 then
+        dv:ensure_line_visible(line2)
         dv.doc:set_selection(line2, col2, line1, col1)
         dv:scroll_to_line(line2, true)
       else

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -728,6 +728,15 @@ function DocView:get_visual_line_col_from_x(row, x)
 end
 
 
+---Ensure a document line is visible in this view.
+---Plugins that hide lines can override this to reveal the requested line.
+---@param line integer
+---@return integer line
+function DocView:ensure_line_visible(line)
+  return line
+end
+
+
 ---Convert screen coordinates to document line/column.
 ---@param x number Screen x coordinate
 ---@param y number Screen y coordinate

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -304,6 +304,9 @@ function DocView:invalidate_visual_lines(from_line)
   else
     self.visual_lines_invalid_from = math.min(self.visual_lines_invalid_from, from_line)
   end
+  if self.doc.get_change_id then
+    self.visual_lines_change_id = self.doc:get_change_id()
+  end
 end
 
 
@@ -323,14 +326,46 @@ end
 
 
 ---Rebuild the composed visual-line model.
----@param from_line? integer Reserved for future incremental rebuilds
+---@param from_line? integer First document line that may have changed
 function DocView:rebuild_visual_lines(from_line)
   local hidden = self:get_hidden_lines() or {}
-  local rows = {}
-  local line_to_first_row = {}
-  local line_row_count = {}
+  local previous = self.visual_lines
+  local rows, line_to_first_row, line_row_count
 
-  for line = 1, #self.doc.lines do
+  if previous and from_line and from_line > 1 then
+    local copy_until = from_line - 1
+    local row_limit = previous.line_to_first_row[copy_until]
+    if row_limit then
+      row_limit = row_limit + (previous.line_row_count[copy_until] or 1) - 1
+    else
+      row_limit = 0
+      for line = copy_until, 1, -1 do
+        local first = previous.line_to_first_row[line]
+        if first then
+          row_limit = first + (previous.line_row_count[line] or 1) - 1
+          break
+        end
+      end
+    end
+
+    rows = {}
+    line_to_first_row = {}
+    line_row_count = {}
+    for row = 1, row_limit do
+      rows[row] = previous.rows[row]
+    end
+    for line = 1, copy_until do
+      line_to_first_row[line] = previous.line_to_first_row[line]
+      line_row_count[line] = previous.line_row_count[line]
+    end
+  else
+    from_line = 1
+    rows = {}
+    line_to_first_row = {}
+    line_row_count = {}
+  end
+
+  for line = from_line, #self.doc.lines do
     if not hidden[line] then
       local starts = self:get_line_wraps(line)
       if not starts or #starts == 0 then
@@ -1007,10 +1042,11 @@ end
 ---Update the view state each frame.
 ---Handles cache invalidation, auto-scrolling to caret, and blink timing.
 function DocView:update()
+  local line1, col1, line2, col2 = self.doc:get_selection()
   local change_id = self.doc.get_change_id and self.doc:get_change_id()
   if self.visual_lines_change_id ~= change_id then
     self.visual_lines_change_id = change_id
-    self:invalidate_visual_lines()
+    self:invalidate_visual_lines(math.min(line1, self.last_line1 or line1))
   end
 
   -- clear cache if font or indent size changed
@@ -1028,7 +1064,6 @@ function DocView:update()
   end
 
   -- scroll to make caret visible and reset blink timer if it moved
-  local line1, col1, line2, col2 = self.doc:get_selection()
   if (line1 ~= self.last_line1 or col1 ~= self.last_col1 or
       line2 ~= self.last_line2 or col2 ~= self.last_col2) and self.size.x > 0 then
     if core.active_view == self and not ime.editing then
@@ -1187,7 +1222,7 @@ end
 
 ---Draw a complete line including highlight and selections.
 ---@param line integer Line number
-  ---@param x number Screen x coordinate
+---@param x number Screen x coordinate
 ---@param y number Screen y coordinate
 ---@return integer height Line height
 function DocView:draw_line_body(line, x, y)

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -142,6 +142,8 @@ function DocView:new(doc)
   self.cache_font_size = self.cache_font:get_size()
   local _, indent_size = self.doc:get_indent_info()
   self.cache_indent_size = indent_size
+  self.visual_lines_dirty = true
+  self.visual_lines = nil
 end
 
 
@@ -233,11 +235,12 @@ end
 ---Get the total scrollable height of the document.
 ---@return number height Total height in pixels
 function DocView:get_scrollable_size()
+  local row_count = self:visual_line_count()
   if not config.scroll_past_end then
     local _, _, _, h_scroll = self.h_scrollbar:get_track_rect()
-    return self:get_line_height() * (#self.doc.lines) + style.padding.y * 2 + h_scroll
+    return self:get_line_height() * row_count + style.padding.y * 2 + h_scroll
   end
-  return self:get_line_height() * (#self.doc.lines - 1) + self.size.y
+  return self:get_line_height() * (row_count - 1) + self.size.y
 end
 
 
@@ -283,12 +286,219 @@ function DocView:get_line_screen_position(line, col)
   local x, y = self:get_content_offset()
   local lh = self:get_line_height()
   local gw = self:get_gutter_width()
-  y = y + (line-1) * lh + style.padding.y
+  y = y + (self:visual_row_from_position(line, col) - 1) * lh + style.padding.y
   if col then
     return x + gw + self:get_col_x_offset(line, col), y
   else
     return x + gw, y
   end
+end
+
+
+---Mark the visual-line model dirty.
+---@param from_line? integer First line that changed (reserved for incremental rebuilds)
+function DocView:invalidate_visual_lines(from_line)
+  self.visual_lines_dirty = true
+  if not self.visual_lines_invalid_from or not from_line then
+    self.visual_lines_invalid_from = from_line
+  else
+    self.visual_lines_invalid_from = math.min(self.visual_lines_invalid_from, from_line)
+  end
+end
+
+
+---Return plugin-provided hidden document lines.
+---@return table<integer, boolean>? hidden_lines
+function DocView:get_hidden_lines()
+  return nil
+end
+
+
+---Return visual row start columns for a document line.
+---@param line integer
+---@return integer[]? starts
+function DocView:get_line_wraps(line)
+  return nil
+end
+
+
+---Rebuild the composed visual-line model.
+---@param from_line? integer Reserved for future incremental rebuilds
+function DocView:rebuild_visual_lines(from_line)
+  local hidden = self:get_hidden_lines() or {}
+  local rows = {}
+  local line_to_first_row = {}
+  local line_row_count = {}
+
+  for line = 1, #self.doc.lines do
+    if not hidden[line] then
+      local starts = self:get_line_wraps(line)
+      if not starts or #starts == 0 then
+        starts = { 1 }
+      elseif starts[1] ~= 1 then
+        local copy = { 1 }
+        for i = 1, #starts do
+          copy[#copy + 1] = starts[i]
+        end
+        starts = copy
+      end
+
+      line_to_first_row[line] = #rows + 1
+      line_row_count[line] = #starts
+      for i = 1, #starts do
+        rows[#rows + 1] = { line = line, col = starts[i] }
+      end
+    end
+  end
+
+  if #rows == 0 then
+    rows[1] = { line = 1, col = 1 }
+    line_to_first_row[1] = 1
+    line_row_count[1] = 1
+  end
+
+  self.visual_lines = {
+    rows = rows,
+    line_to_first_row = line_to_first_row,
+    line_row_count = line_row_count,
+    hidden_lines = hidden
+  }
+  self.visual_lines_dirty = false
+  self.visual_lines_invalid_from = nil
+
+  if self.on_visual_lines_rebuilt then
+    self:on_visual_lines_rebuilt()
+  end
+end
+
+
+function DocView:get_visual_lines()
+  if self.visual_lines_dirty or not self.visual_lines then
+    self:rebuild_visual_lines(self.visual_lines_invalid_from)
+  end
+  return self.visual_lines
+end
+
+
+---Get the total number of visual rows.
+---@return integer count
+function DocView:visual_line_count()
+  return #self:get_visual_lines().rows
+end
+
+
+---Convert a visual row to a real document position.
+---@param row integer
+---@return integer line
+---@return integer col
+function DocView:visual_position_from_row(row)
+  local rows = self:get_visual_lines().rows
+  row = common.clamp(row, 1, #rows)
+  local item = rows[row]
+  return item.line, item.col
+end
+
+
+---Convert a real document position to a visual row.
+---@param line integer
+---@param col? integer
+---@return integer row
+function DocView:visual_row_from_position(line, col)
+  local model = self:get_visual_lines()
+  if line > #self.doc.lines then
+    return #model.rows + 1
+  end
+  local first = model.line_to_first_row[line]
+  if not first then
+    while line > 1 and not model.line_to_first_row[line] do
+      line = line - 1
+    end
+    first = model.line_to_first_row[line] or 1
+  end
+
+  if not col then
+    return first
+  end
+
+  local row_count = model.line_row_count[line] or 1
+  local best = first
+  for row = first + 1, first + row_count - 1 do
+    if col >= model.rows[row].col then
+      best = row
+    else
+      break
+    end
+  end
+  return best
+end
+
+
+---Get the first visual row and row count for a real document line.
+---@param line integer
+---@return integer? first_row
+---@return integer row_count
+function DocView:visual_rows_for_line(line)
+  local model = self:get_visual_lines()
+  return model.line_to_first_row[line], model.line_row_count[line] or 0
+end
+
+
+---Return whether a document line contributes visual rows.
+---@param line integer
+---@return boolean
+function DocView:is_line_visible(line)
+  return self:get_visual_lines().line_to_first_row[line] ~= nil
+end
+
+
+---Convert a virtual line offset (from get_visible_line_range) to a real
+---document position. This is an identity function by default; plugins like
+---codefolding or linewrapping override it to map visible rows to real lines.
+---Plugins that iterate visible lines should call this to get the real line
+---and column.
+---@param offset integer Virtual line index (1-based)
+---@return integer line Real document line
+---@return integer col  Column (always 1 for the identity case)
+function DocView:position_from_offset(offset)
+  return self:visual_position_from_row(offset)
+end
+
+
+---Convert a real document position to its virtual line offset. This is an
+---identity function by default; plugins that collapse, wrap or otherwise
+---virtualize visible rows should override it with their own mapping.
+---@param line integer Real document line
+---@param col? integer Optional column
+---@return integer offset Virtual line index (1-based)
+function DocView:offset_from_position(line, col)
+  return self:visual_row_from_position(line, col)
+end
+
+
+---Iterate visible rows as virtual offset plus real document position.
+---@return fun():integer?, integer?, integer?
+function DocView:each_visible_line()
+  local offset, max_offset = self:get_visible_line_range()
+  offset = offset - 1
+  return function()
+    while offset < max_offset do
+      offset = offset + 1
+      local line, col = self:position_from_offset(offset)
+      if line then
+        return offset, line, col
+      end
+    end
+  end
+end
+
+
+---Get the visual height occupied by a real document line.
+---Wrapped lines may span more than one row.
+---@param line integer Real document line
+---@return number height
+function DocView:get_line_visual_height(line)
+  local _, count = self:visual_rows_for_line(line)
+  return math.max(1, count) * self:get_line_height()
 end
 
 
@@ -361,7 +571,7 @@ function DocView:get_visible_line_range()
   local x, y, x2, y2 = self:get_content_bounds()
   local lh = self:get_line_height()
   local minline = math.max(1, math.floor((y - style.padding.y) / lh) + 1)
-  local maxline = math.min(#self.doc.lines, math.floor((y2 - style.padding.y) / lh) + 1)
+  local maxline = math.min(self:visual_line_count(), math.floor((y2 - style.padding.y) / lh) + 1)
   return minline, maxline
 end
 
@@ -508,16 +718,28 @@ function DocView:get_x_offset_col(line, x)
 end
 
 
+---Resolve a visual row-local horizontal offset to a document column.
+---@param row integer Visual row
+---@param x number Horizontal offset from text origin
+---@return integer col
+function DocView:get_visual_line_col_from_x(row, x)
+  local line = self:visual_position_from_row(row)
+  return self:get_x_offset_col(line, x)
+end
+
+
 ---Convert screen coordinates to document line/column.
 ---@param x number Screen x coordinate
 ---@param y number Screen y coordinate
 ---@return integer line Line number
 ---@return integer col Column number
 function DocView:resolve_screen_position(x, y)
-  local ox, oy = self:get_line_screen_position(1)
-  local line = math.floor((y - oy) / self:get_line_height()) + 1
-  line = common.clamp(line, 1, #self.doc.lines)
-  local col = self:get_x_offset_col(line, x - ox)
+  local ox, oy = self:get_content_offset()
+  local gw = self:get_gutter_width()
+  local line_y = oy + style.padding.y
+  local row = math.floor((y - line_y) / self:get_line_height()) + 1
+  local line = self:visual_position_from_row(row)
+  local col = self:get_visual_line_col_from_x(row, x - ox - gw)
   return line, col
 end
 
@@ -528,7 +750,8 @@ end
 ---@param instant? boolean Jump immediately without animation
 function DocView:scroll_to_line(line, ignore_if_visible, instant)
   local min, max = self:get_visible_line_range()
-  if not (ignore_if_visible and line > min and line < max) then
+  local row = self:visual_row_from_position(line, 1)
+  if not (ignore_if_visible and row > min and row < max) then
     local x, y = self:get_line_screen_position(line)
     local ox, oy = self:get_content_offset()
     local _, _, _, scroll_h = self.h_scrollbar:get_track_rect()
@@ -775,6 +998,12 @@ end
 ---Update the view state each frame.
 ---Handles cache invalidation, auto-scrolling to caret, and blink timing.
 function DocView:update()
+  local change_id = self.doc.get_change_id and self.doc:get_change_id()
+  if self.visual_lines_change_id ~= change_id then
+    self.visual_lines_change_id = change_id
+    self:invalidate_visual_lines()
+  end
+
   -- clear cache if font or indent size changed
   local font = self:get_font()
   local _, indent_size = self.doc:get_indent_info()
@@ -1058,7 +1287,8 @@ function DocView:draw_overlay()
     -- draw caret if it overlaps this line
     local T = config.blink_period
     for _, line1, col1, line2, col2 in self.doc:get_selections() do
-      if line1 >= minline and line1 <= maxline
+      local row = self:visual_row_from_position(line1, col1)
+      if row >= minline and row <= maxline
       and system.window_has_focus(core.window) then
         if ime.editing then
           self:draw_ime_decoration(line1, col1, line2, col2)
@@ -1085,19 +1315,39 @@ function DocView:draw()
   local minline, maxline = self:get_visible_line_range()
   local lh = self:get_line_height()
 
-  local x, y = self:get_line_screen_position(minline)
+  local x, y = self:get_content_offset()
   local gw, gpad = self:get_gutter_width()
-  for i = minline, maxline do
-    y = y + (self:draw_line_gutter(i, self.position.x, y, gpad and gw - gpad or gw) or lh)
+  y = y + (minline - 1) * lh + style.padding.y
+  local drawn_gutters = {}
+  for row = minline, maxline do
+    local line = self:visual_position_from_row(row)
+    if line and not drawn_gutters[line] then
+      local first_row = self:visual_row_from_position(line, 1)
+      local line_y = y - (row - first_row) * lh
+      self:draw_line_gutter(line, self.position.x, line_y, gpad and gw - gpad or gw)
+      drawn_gutters[line] = true
+    end
+    y = y + lh
   end
 
+  local gw, gpad = self:get_gutter_width()
   local pos = self.position
-  x, y = self:get_line_screen_position(minline)
+  x, y = self:get_content_offset()
+  x = x + gw
+  y = y + (minline - 1) * lh + style.padding.y
   -- the clip below ensure we don't write on the gutter region. On the
   -- right side it is redundant with the Node's clip.
   core.push_clip_rect(pos.x + gw, pos.y, self.size.x - gw, self.size.y)
-  for i = minline, maxline do
-    y = y + (self:draw_line_body(i, x, y) or lh)
+  local drawn_lines = {}
+  for row = minline, maxline do
+    local line = self:visual_position_from_row(row)
+    if line and not drawn_lines[line] then
+      local first_row = self:visual_row_from_position(line, 1)
+      local line_y = y - (row - first_row) * lh
+      self:draw_line_body(line, x, line_y)
+      drawn_lines[line] = true
+    end
+    y = y + lh
   end
   self:draw_overlay()
   core.pop_clip_rect()

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -325,25 +325,53 @@ function DocView:get_line_wraps(line)
 end
 
 
+---Return whether this view needs a materialized visual-line model.
+---Views with wraps or other row expansions should override this.
+---@return boolean
+function DocView:has_variable_visual_lines()
+  return self.get_line_wraps ~= DocView.get_line_wraps
+end
+
+
 ---Rebuild the composed visual-line model.
 ---@param from_line? integer First document line that may have changed
 function DocView:rebuild_visual_lines(from_line)
   local hidden = self:get_hidden_lines() or {}
+  if not next(hidden) and not self:has_variable_visual_lines() then
+    self.visual_lines = {
+      identity = true,
+      line_count = math.max(1, #self.doc.lines),
+      hidden_lines = hidden
+    }
+    self.visual_lines_dirty = false
+    self.visual_lines_invalid_from = nil
+
+    if self.on_visual_lines_rebuilt then
+      self:on_visual_lines_rebuilt()
+    end
+    return
+  end
+
   local previous = self.visual_lines
   local rows, line_to_first_row, line_row_count
 
   if previous and from_line and from_line > 1 then
     local copy_until = from_line - 1
-    local row_limit = previous.line_to_first_row[copy_until]
-    if row_limit then
-      row_limit = row_limit + (previous.line_row_count[copy_until] or 1) - 1
+    local row_limit
+    if previous.identity then
+      row_limit = math.min(copy_until, previous.line_count)
     else
-      row_limit = 0
-      for line = copy_until, 1, -1 do
-        local first = previous.line_to_first_row[line]
-        if first then
-          row_limit = first + (previous.line_row_count[line] or 1) - 1
-          break
+      row_limit = previous.line_to_first_row[copy_until]
+      if row_limit then
+        row_limit = row_limit + (previous.line_row_count[copy_until] or 1) - 1
+      else
+        row_limit = 0
+        for line = copy_until, 1, -1 do
+          local first = previous.line_to_first_row[line]
+          if first then
+            row_limit = first + (previous.line_row_count[line] or 1) - 1
+            break
+          end
         end
       end
     end
@@ -352,11 +380,20 @@ function DocView:rebuild_visual_lines(from_line)
     line_to_first_row = {}
     line_row_count = {}
     for row = 1, row_limit do
-      rows[row] = previous.rows[row]
+      if previous.identity then
+        rows[row] = { line = row, col = 1 }
+      else
+        rows[row] = previous.rows[row]
+      end
     end
     for line = 1, copy_until do
-      line_to_first_row[line] = previous.line_to_first_row[line]
-      line_row_count[line] = previous.line_row_count[line]
+      if previous.identity then
+        line_to_first_row[line] = line
+        line_row_count[line] = 1
+      else
+        line_to_first_row[line] = previous.line_to_first_row[line]
+        line_row_count[line] = previous.line_row_count[line]
+      end
     end
   else
     from_line = 1
@@ -418,7 +455,8 @@ end
 ---Get the total number of visual rows.
 ---@return integer count
 function DocView:visual_line_count()
-  return #self:get_visual_lines().rows
+  local model = self:get_visual_lines()
+  return model.identity and model.line_count or #model.rows
 end
 
 
@@ -427,7 +465,12 @@ end
 ---@return integer line
 ---@return integer col
 function DocView:visual_position_from_row(row)
-  local rows = self:get_visual_lines().rows
+  local model = self:get_visual_lines()
+  if model.identity then
+    row = common.clamp(row, 1, model.line_count)
+    return row, 1
+  end
+  local rows = model.rows
   row = common.clamp(row, 1, #rows)
   local item = rows[row]
   return item.line, item.col
@@ -440,6 +483,12 @@ end
 ---@return integer row
 function DocView:visual_row_from_position(line, col)
   local model = self:get_visual_lines()
+  if model.identity then
+    if line > #self.doc.lines then
+      return model.line_count + 1
+    end
+    return common.clamp(line, 1, model.line_count)
+  end
   if line > #self.doc.lines then
     return #model.rows + 1
   end
@@ -474,6 +523,12 @@ end
 ---@return integer row_count
 function DocView:visual_rows_for_line(line)
   local model = self:get_visual_lines()
+  if model.identity then
+    if line < 1 or line > #self.doc.lines then
+      return nil, 0
+    end
+    return line, 1
+  end
   return model.line_to_first_row[line], model.line_row_count[line] or 0
 end
 
@@ -482,7 +537,11 @@ end
 ---@param line integer
 ---@return boolean
 function DocView:is_line_visible(line)
-  return self:get_visual_lines().line_to_first_row[line] ~= nil
+  local model = self:get_visual_lines()
+  if model.identity then
+    return line >= 1 and line <= #self.doc.lines
+  end
+  return model.line_to_first_row[line] ~= nil
 end
 
 

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -18,6 +18,8 @@ config.plugins.codefold = common.merge({
   start_folded = false,
   -- If true, folded regions hide the folded end-line tail.
   hide_tail_on_fold = true,
+  -- If true, all fold markers are always visible.
+  always_show_fold_markers = false,
   -- Width in pixels reserved for fold toggle indicators in the gutter.
   toggle_width = common.round(24 * SCALE),
   -- The config specification used by the settings GUI.
@@ -43,6 +45,13 @@ config.plugins.codefold = common.merge({
       path = "hide_tail_on_fold",
       type = "toggle",
       default = true
+    },
+    {
+      label = "Always Show Fold Markers",
+      description = "Always draw markers for unfolded fold regions.",
+      path = "always_show_fold_markers",
+      type = "toggle",
+      default = false
     }
   }
 }, config.plugins.codefold)
@@ -1130,6 +1139,12 @@ function DocView:draw_line_gutter(line, x, y, width)
     local region_idx = region_at_line(self, line)
     if region_idx then
       local folded = is_folded(self, region_idx)
+      if not folded
+        and not self.hovering_gutter
+        and not config.plugins.codefold.always_show_fold_markers
+      then
+        return result
+      end
       local toggle_char = folded and TOGGLE_CLOSE or TOGGLE_OPEN
       local toggle_color = folded and style.caret or (style.dim or style.line_number)
       if self.cf_hovering_toggle == line then
@@ -1279,6 +1294,18 @@ local original_previous_line = DocView.translate.previous_line
 local original_next_page = DocView.translate.next_page
 local original_previous_page = DocView.translate.previous_page
 
+---@param dv core.docview
+---@return boolean
+local function has_folded_line_maps(dv)
+  return config.plugins.codefold.enabled
+    and dv
+    and dv.cf_folded_regions
+    and #dv.cf_folded_regions > 0
+    and dv.cf_unfold_map
+    and dv.cf_fold_map
+    and #dv.cf_fold_map > 0
+end
+
 ---Skip hidden (folded) lines when moving the cursor down.
 ---@param doc core.doc
 ---@param line integer
@@ -1287,8 +1314,10 @@ local original_previous_page = DocView.translate.previous_page
 ---@return integer line
 ---@return integer col
 DocView.translate.next_line = function(doc, line, col, dv)
+  if not has_folded_line_maps(dv) then
+    return original_next_line(doc, line, col, dv)
+  end
   local function skip_hidden(l)
-    if not dv.cf_unfold_map then return l end
     while l <= #doc.lines and not dv.cf_unfold_map[l] do
       l = l + 1
     end
@@ -1308,8 +1337,10 @@ end
 
 ---Skip hidden (folded) lines when moving the cursor up.
 DocView.translate.previous_line = function(doc, line, col, dv)
+  if not has_folded_line_maps(dv) then
+    return original_previous_line(doc, line, col, dv)
+  end
   local function skip_hidden(l)
-    if not dv.cf_unfold_map then return l end
     while l >= 1 and not dv.cf_unfold_map[l] do
       l = l - 1
     end

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -207,6 +207,29 @@ local function match_fold_state(doc, regions, folds)
   local folded = {}
   local used = {}
   local unmatched_folds = {}
+  local exact = {}
+  local by_text = {}
+
+  local function fold_key(line, indent, text)
+    return tostring(line) .. "\0" .. tostring(indent) .. "\0" .. tostring(text)
+  end
+
+  local function text_key(indent, text)
+    return tostring(indent) .. "\0" .. tostring(text)
+  end
+
+  for idx, candidate in ipairs(regions) do
+    if idx % 500 == 0 then maybe_yield() end
+    local text = doc.lines[candidate.start]
+    exact[fold_key(candidate.start, candidate.indent, text)] = idx
+    local key = text_key(candidate.indent, text)
+    local list = by_text[key]
+    if not list then
+      list = {}
+      by_text[key] = list
+    end
+    list[#list + 1] = idx
+  end
 
   local function use_region(idx)
     if used[idx] then return end
@@ -214,20 +237,12 @@ local function match_fold_state(doc, regions, folds)
     folded[#folded + 1] = idx
   end
 
-  for _, fold in ipairs(folds or {}) do
+  for fold_idx, fold in ipairs(folds or {}) do
+    if fold_idx % 500 == 0 then maybe_yield() end
     if type(fold) == "table" then
       local line = fold.line
       if type(line) == "number" then
-        local region
-        for idx, candidate in ipairs(regions) do
-          if candidate.start == line
-            and candidate.indent == fold.indent
-            and doc.lines[candidate.start] == fold.text
-          then
-            region = idx
-            break
-          end
-        end
+        local region = exact[fold_key(line, fold.indent, fold.text)]
         if region then
           use_region(region)
         else
@@ -239,13 +254,15 @@ local function match_fold_state(doc, regions, folds)
     end
   end
 
-  for _, fold in ipairs(unmatched_folds) do
+  for fold_idx, fold in ipairs(unmatched_folds) do
+    if fold_idx % 500 == 0 then maybe_yield() end
     if type(fold) == "table" and type(fold.text) == "string" then
       local best, best_distance
-      for idx, candidate in ipairs(regions) do
+      local candidates = by_text[text_key(fold.indent, fold.text)] or {}
+      for idx_idx, idx in ipairs(candidates) do
+        if idx_idx % 500 == 0 then maybe_yield() end
+        local candidate = regions[idx]
         if not used[idx]
-          and candidate.indent == fold.indent
-          and doc.lines[candidate.start] == fold.text
         then
           local distance = math.abs(candidate.start - (fold.line or candidate.start))
           if not best_distance or distance < best_distance then
@@ -375,6 +392,7 @@ local function build_effective_indents(doc, indent_size)
 
   local indents = {}
   for line = 1, line_count do
+    if line % 500 == 0 then maybe_yield() end
     local indent = raw[line]
     if indent >= 0 then
       indents[line] = indent
@@ -505,25 +523,95 @@ local function block_comment_stop_line(doc, line)
   return nil
 end
 
+---@param a table
+---@param b table
+---@return boolean
+local function same_region(a, b)
+  return a.start == b.start
+    and a.stop == b.stop
+    and a.indent == b.indent
+    and a.kind == b.kind
+    and a.hide_tail == b.hide_tail
+end
+
+---@param previous_regions table[]
+---@param from_line integer
+---@return integer start_line
+---@return integer prefix_count
+local function incremental_scan_start(previous_regions, from_line)
+  local start_line = from_line
+  for _, region in ipairs(previous_regions or {}) do
+    if region.start <= from_line and region.stop >= from_line then
+      start_line = math.min(start_line, region.start)
+    end
+  end
+
+  local prefix_count = 0
+  for idx, region in ipairs(previous_regions or {}) do
+    if region.stop < start_line then
+      prefix_count = idx
+    else
+      break
+    end
+  end
+  return start_line, prefix_count
+end
+
+---Find the previous non-blank line that may become a fold head.
+---@param doc core.doc
+---@param line integer
+---@param indent_size integer
+---@return integer line
+local function previous_fold_candidate_line(doc, line, indent_size)
+  for candidate = line - 1, 1, -1 do
+    if candidate % 500 == 0 then maybe_yield() end
+    if get_effective_indent(doc, candidate, indent_size) >= 0 then
+      return candidate
+    end
+  end
+  return line
+end
+
 ---Detect all foldable regions in the document based on indentation.
 ---A fold region starts at line `s` (indent I) and continues through line `e`
 ---where line `e+1` has indent <= I (or e is the last line).
 ---@param doc core.doc
 ---@param invalidate_from? integer
----@param invalidate_to? integer
+---@param previous_regions? table[]
 ---@return table[] regions
-local function detect_fold_regions(doc, invalidate_from, invalidate_to)
+local function detect_fold_regions(doc, invalidate_from, previous_regions)
   local _, indent_size = doc:get_indent_info()
   local regions = {}
   local line_count = #doc.lines
-  local indents = build_effective_indents(doc, indent_size)
+  local indents = not invalidate_from and build_effective_indents(doc, indent_size)
+  local indent_cache = {}
+  local previous_by_start = {}
+  local invalidated_line = invalidate_from
 
   local start_line = 1
   local stop_line = line_count
-  if invalidate_from then
-    -- Find the first region that might be affected
-    start_line = math.max(1, invalidate_from)
-    stop_line = math.min(line_count, invalidate_to or line_count)
+  if invalidate_from and previous_regions then
+    start_line = previous_fold_candidate_line(
+      doc,
+      math.max(1, invalidate_from),
+      indent_size
+    )
+    local prefix_count
+    start_line, prefix_count = incremental_scan_start(previous_regions, start_line)
+    for idx = 1, prefix_count do
+      regions[#regions + 1] = previous_regions[idx]
+    end
+    for idx, region in ipairs(previous_regions) do
+      previous_by_start[region.start] = idx
+    end
+  end
+
+  local function get_indent(line)
+    if indents then return indents[line] end
+    if indent_cache[line] == nil then
+      indent_cache[line] = get_effective_indent(doc, line, indent_size)
+    end
+    return indent_cache[line]
   end
 
   local line = start_line
@@ -532,7 +620,7 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
       maybe_yield()
     end
 
-    local indent = indents[line]
+    local indent = get_indent(line)
     if indent < 0 then
       line = line + 1
       goto continue
@@ -541,13 +629,13 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
     local next_line = line + 1
     if next_line > line_count then break end
 
-    local next_indent = indents[next_line]
+    local next_indent = get_indent(next_line)
     if next_indent > indent then
       -- Line `line` starts a fold region. Find where it ends.
       local stop = next_line
       while stop < line_count do
         if stop % 500 == 0 then maybe_yield() end
-        local peek_indent = indents[stop + 1]
+        local peek_indent = get_indent(stop + 1)
         if peek_indent < 0 then
           -- blank — continue
           stop = stop + 1
@@ -568,8 +656,18 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
         stop = stop,
         kind = (comment_stop or is_comment) and "comment" or "indent"
       }
-      if comment_stop or is_comment ~= false or line_starts_with_comment_marker(doc, line) then
+      if comment_stop or is_comment == true or line_starts_with_comment_marker(doc, line) then
         region.hide_tail = false
+      end
+      local previous_idx = previous_by_start[region.start]
+      local previous = previous_idx and previous_regions[previous_idx]
+      if previous and same_region(region, previous)
+        and (not invalidated_line or region.start > invalidated_line)
+      then
+        for idx = previous_idx, #previous_regions do
+          regions[#regions + 1] = previous_regions[idx]
+        end
+        return regions
       end
       regions[#regions + 1] = region
       line = line + 1
@@ -599,6 +697,7 @@ local function set_regions(self, regions)
   self.cf_regions = regions or {}
   self.cf_region_by_start = {}
   for idx, region in ipairs(self.cf_regions) do
+    if idx % 500 == 0 then maybe_yield() end
     self.cf_region_by_start[region.start] = idx
   end
 end
@@ -608,9 +707,35 @@ end
 local function set_folded_regions(self, folded)
   self.cf_folded_regions = folded or {}
   self.cf_folded_region_set = {}
-  for _, region_idx in ipairs(self.cf_folded_regions) do
+  for idx, region_idx in ipairs(self.cf_folded_regions) do
+    if idx % 500 == 0 then maybe_yield() end
     self.cf_folded_region_set[region_idx] = true
   end
+end
+
+---@param regions table[]
+---@param folded_regions integer[]
+---@return string signature
+local function folded_visibility_signature(regions, folded_regions)
+  if not folded_regions or #folded_regions == 0 then
+    return ""
+  end
+
+  local items = {}
+  for idx, region_idx in ipairs(folded_regions) do
+    if idx % 500 == 0 then maybe_yield() end
+    local region = regions[region_idx]
+    if region then
+      items[#items + 1] = table.concat({
+        region.start,
+        region.stop,
+        region.hide_tail == false and "0" or "1",
+      }, ":")
+    end
+  end
+  table.sort(items)
+  return tostring(config.plugins.codefold.hide_tail_on_fold) .. "|"
+    .. table.concat(items, ",")
 end
 
 ---Determine which real lines are hidden based on collapsed fold regions.
@@ -618,10 +743,12 @@ end
 ---@return table<integer, boolean> hidden_set
 local function build_hidden_set(self)
   local hidden = {}
-  for _, region_idx in ipairs(self.cf_folded_regions) do
+  for idx, region_idx in ipairs(self.cf_folded_regions) do
+    if idx % 100 == 0 then maybe_yield() end
     local region = self.cf_regions[region_idx]
     if region then
       for l = region.start + 1, region.stop do
+        if l % 500 == 0 then maybe_yield() end
         hidden[l] = true
       end
       if config.plugins.codefold.hide_tail_on_fold
@@ -644,6 +771,7 @@ local function rebuild_mappings(self)
   self.cf_unfold_map = {}
 
   for real = 1, #self.doc.lines do
+    if real % 500 == 0 then maybe_yield() end
     if not hidden[real] then
       local virtual = #self.cf_fold_map + 1
       self.cf_fold_map[virtual] = real
@@ -652,6 +780,11 @@ local function rebuild_mappings(self)
       self.cf_unfold_map[real] = nil
     end
   end
+  self.cf_visibility_signature = folded_visibility_signature(
+    self.cf_regions or {},
+    self.cf_folded_regions or {}
+  )
+  self.cf_mapping_line_count = #self.doc.lines
   self:invalidate_visual_lines()
 end
 
@@ -678,6 +811,11 @@ local function apply_detected_regions(self, regions)
     self.cf_regions or {},
     self.cf_folded_regions or {}
   )
+  local previous_signature = self.cf_visibility_signature
+    or folded_visibility_signature(
+      self.cf_regions or {},
+      self.cf_folded_regions or {}
+    )
   local should_resave = false
   set_regions(self, regions)
 
@@ -701,7 +839,22 @@ local function apply_detected_regions(self, regions)
     should_resave = #previous_folds > 0
   end
 
-  rebuild_mappings(self)
+  local new_signature = folded_visibility_signature(
+    self.cf_regions or {},
+    self.cf_folded_regions or {}
+  )
+  local mappings_missing = new_signature ~= ""
+    and (
+      not self.cf_fold_map
+      or not self.cf_unfold_map
+      or not self.cf_hidden_lines
+      or self.cf_mapping_line_count ~= #self.doc.lines
+    )
+  if mappings_missing or previous_signature ~= new_signature then
+    rebuild_mappings(self)
+  else
+    self.cf_visibility_signature = new_signature
+  end
   if should_resave then
     save_fold_state(self.doc, self.cf_regions, self.cf_folded_regions)
   end
@@ -744,7 +897,10 @@ local function recalculate(self)
   replace_recalculation_thread(self)
 
   self.cf_thread_id = core.add_thread(function()
-    apply_detected_regions(self, detect_fold_regions(self.doc))
+    apply_detected_regions(
+      self,
+      detect_fold_regions(self.doc, self.cf_invalidated_from, self.cf_regions)
+    )
     self.cf_thread_id = nil
     self.cf_invalidated = false
     self.cf_invalidated_at = nil

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -7,6 +7,7 @@ local command = require "core.command"
 local keymap = require "core.keymap"
 local DocView = require "core.docview"
 local Doc = require "core.doc"
+local tokenizer = require "core.tokenizer"
 
 ---Configuration for code folding plugin.
 ---@class config.plugins.codefold
@@ -390,6 +391,120 @@ end
 -- Fold region detection
 ---------------------------------------------------------------------
 
+---@param token_type any
+---@return boolean
+local function is_comment_token(token_type)
+  if type(token_type) == "string" then
+    return token_type:find("comment", 1, true) ~= nil
+  elseif type(token_type) == "table" then
+    for _, item in ipairs(token_type) do
+      if is_comment_token(item) then return true end
+    end
+  end
+  return false
+end
+
+---@param doc core.doc
+---@param line integer
+---@return boolean? starts_with_comment
+local function line_starts_with_comment_token(doc, line)
+  local highlighter = doc.highlighter
+  if not highlighter or not highlighter.lines then
+    return nil
+  end
+  local cached = highlighter.lines[line]
+  if not cached or cached.text ~= doc:get_utf8_line(line) or cached.resume then
+    return nil
+  end
+  if line > 1 then
+    local previous = highlighter.lines[line - 1]
+    if not previous or previous.text ~= doc:get_utf8_line(line - 1)
+      or previous.resume or cached.init_state ~= previous.state then
+      return nil
+    end
+  end
+
+  for _, token_type, text in tokenizer.each_token(cached.tokens) do
+    if text:find("%S") then
+      return is_comment_token(token_type)
+    end
+  end
+  return false
+end
+
+---@param doc core.doc
+---@param line integer
+---@return core.syntax.syntax?
+local function get_line_syntax(doc, line)
+  local current_syntax = doc.syntax
+  if not current_syntax or line <= 1 then
+    return current_syntax
+  end
+
+  local highlighter = doc.highlighter
+  if not highlighter or not highlighter.lines then
+    return current_syntax
+  end
+
+  local previous = highlighter.lines[line - 1]
+  if previous and previous.text == doc:get_utf8_line(line - 1)
+    and not previous.resume and previous.state then
+    local syntaxes = tokenizer.extract_subsyntaxes(doc.syntax, previous.state)
+    for _, syntax in pairs(syntaxes) do
+      if syntax.comment or syntax.block_comment then
+        return syntax
+      end
+    end
+  end
+  return current_syntax
+end
+
+---@param doc core.doc
+---@param line integer
+---@return boolean
+local function line_starts_with_comment_marker(doc, line)
+  local text = doc:get_utf8_line(line)
+  local _, start = text:find("^%s*")
+  text = text:sub(start + 1)
+
+  local syntax = get_line_syntax(doc, line)
+  if not syntax then return false end
+  if syntax.block_comment and text:find(syntax.block_comment[1], 1, true) == 1 then
+    return true
+  end
+  if syntax.comment and text:find(syntax.comment, 1, true) == 1 then
+    return true
+  end
+  return false
+end
+
+---@param doc core.doc
+---@param line integer
+---@return integer? stop_line
+local function block_comment_stop_line(doc, line)
+  local syntax = get_line_syntax(doc, line)
+  if not syntax or not syntax.block_comment then return nil end
+
+  local start_marker, stop_marker = syntax.block_comment[1], syntax.block_comment[2]
+  local text = doc:get_utf8_line(line)
+  local _, ws_end = text:find("^%s*")
+  text = text:sub(ws_end + 1)
+
+  local start_pos = text:find(start_marker, 1, true)
+  if start_pos ~= 1 then return nil end
+  if text:find(stop_marker, start_pos + #start_marker, true) then
+    return nil
+  end
+
+  for stop = line + 1, #doc.lines do
+    if stop % 500 == 0 then maybe_yield() end
+    if doc:get_utf8_line(stop):find(stop_marker, 1, true) then
+      return stop
+    end
+  end
+  return nil
+end
+
 ---Detect all foldable regions in the document based on indentation.
 ---A fold region starts at line `s` (indent I) and continues through line `e`
 ---where line `e+1` has indent <= I (or e is the last line).
@@ -442,17 +557,34 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
           stop = stop + 1
         end
       end
-      regions[#regions + 1] = {
+      local comment_stop = block_comment_stop_line(doc, line)
+      if comment_stop then
+        stop = comment_stop
+      end
+      local is_comment = line_starts_with_comment_token(doc, line)
+      local region = {
         indent = indent,
         start = line,
-        stop = stop
+        stop = stop,
+        kind = (comment_stop or is_comment) and "comment" or "indent"
       }
+      if comment_stop or is_comment ~= false or line_starts_with_comment_marker(doc, line) then
+        region.hide_tail = false
+      end
+      regions[#regions + 1] = region
       line = line + 1
     else
       line = line + 1
     end
     ::continue::
   end
+
+  table.sort(regions, function(a, b)
+    if a.start == b.start then
+      return a.stop > b.stop
+    end
+    return a.start < b.start
+  end)
 
   return regions
 end
@@ -492,7 +624,10 @@ local function build_hidden_set(self)
       for l = region.start + 1, region.stop do
         hidden[l] = true
       end
-      if config.plugins.codefold.hide_tail_on_fold and region.stop < #self.doc.lines then
+      if config.plugins.codefold.hide_tail_on_fold
+        and region.hide_tail ~= false
+        and region.stop < #self.doc.lines
+      then
         hidden[region.stop + 1] = true
       end
     end
@@ -1064,6 +1199,7 @@ end
 
 codefold._test = {
   apply_detected_regions = apply_detected_regions,
+  detect_fold_regions = detect_fold_regions,
   doc_state_key = doc_state_key,
   hash_text = hash_text,
   load_fold_state = load_fold_state,

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -1,0 +1,884 @@
+-- mod-version:3
+local core = require "core"
+local common = require "core.common"
+local config = require "core.config"
+local style = require "core.style"
+local command = require "core.command"
+local keymap = require "core.keymap"
+local DocView = require "core.docview"
+local Doc = require "core.doc"
+
+---Configuration for code folding plugin.
+---@class config.plugins.codefold
+config.plugins.codefold = common.merge({
+  -- Whether code folding is enabled.
+  enabled = true,
+  -- If true, newly opened documents have all fold regions initially collapsed.
+  start_folded = false,
+  -- Width in pixels reserved for fold toggle indicators in the gutter.
+  toggle_width = common.round(24 * SCALE),
+  -- The config specification used by the settings GUI.
+  config_spec = {
+    name = "Code Folding",
+    {
+      label = "Enable",
+      description = "Toggle code folding capabilities.",
+      path = "enabled",
+      type = "toggle",
+      default = true
+    },
+    {
+      label = "Fold On Open",
+      description = "Collapse all foldable regions when opening a file.",
+      path = "start_folded",
+      type = "toggle",
+      default = false
+    }
+  }
+}, config.plugins.codefold)
+
+local TOGGLE_OPEN  = "\226\150\190"  -- ▾  (U+25BE)
+local TOGGLE_CLOSE = "\226\150\184"  -- ▸  (U+25B8)
+
+local codefold = {}
+
+---------------------------------------------------------------------
+-- Persistent state
+---------------------------------------------------------------------
+
+local function hash_text(text)
+  local hash = 2166136261
+  for i = 1, #text do
+    hash = (hash * 16777619 + text:byte(i)) % 4294967296
+  end
+  return string.format("%08x", hash)
+end
+
+---@param path string
+---@return string
+local function normalize_state_key(path)
+  return common.normalize_path(path):gsub("[/\\]", "/")
+end
+
+---@param doc core.doc
+---@return string? relative_path
+local function doc_state_key(doc)
+  if not doc or not doc.filename and not doc.abs_filename then
+    return nil
+  end
+  local path = doc.filename
+  if not path and doc.abs_filename then
+    path = common.relative_path(core.root_project().path, doc.abs_filename)
+  end
+  return normalize_state_key(path)
+end
+
+---@return string directory
+local function state_directory()
+  return core.root_project().path
+    .. PATHSEP .. ".pragtical"
+    .. PATHSEP .. "codefold"
+end
+
+---@param doc core.doc
+---@return string? path
+local function state_path_for_doc(doc)
+  local key = doc_state_key(doc)
+  if not key then return nil end
+  return state_directory() .. PATHSEP .. hash_text(key) .. ".lua"
+end
+
+---@param doc core.doc
+---@param regions table[]
+---@param folded_regions integer[]
+---@return table[] folds
+local function make_state_folds(doc, regions, folded_regions)
+  local folds = {}
+  for _, region_idx in ipairs(folded_regions or {}) do
+    local region = regions[region_idx]
+    if region then
+      folds[#folds + 1] = {
+        line = region.start,
+        indent = region.indent,
+        text = doc.lines[region.start]
+      }
+    end
+  end
+  return folds
+end
+
+---@param doc core.doc
+---@param regions table[]
+---@param folded_regions integer[]
+local function save_fold_state(doc, regions, folded_regions)
+  local key = doc_state_key(doc)
+  local path = state_path_for_doc(doc)
+  if not key or not path then return end
+
+  local folds = make_state_folds(doc, regions, folded_regions)
+  if #folds == 0 then
+    if system.get_file_info(path) then
+      os.remove(path)
+    end
+    return
+  end
+
+  local dir = common.dirname(path)
+  if not system.get_file_info(dir) then
+    local ok, err = common.mkdirp(dir)
+    if not ok then
+      core.error("error creating codefold state directory %s: %s", dir, err)
+      return
+    end
+  end
+
+  local fp, err = io.open(path, "wb")
+  if not fp then
+    core.error("error opening codefold state file %s: %s", path, err)
+    return
+  end
+  fp:write("return " .. common.serialize({
+    path = key,
+    folds = folds
+  }, { pretty = true }))
+  fp:close()
+end
+
+---@param doc core.doc
+---@return table[]? folds
+local function load_fold_state(doc)
+  local key = doc_state_key(doc)
+  local path = state_path_for_doc(doc)
+  if not key or not path or not system.get_file_info(path) then
+    return nil
+  end
+
+  local loader, err = loadfile(path)
+  if not loader then
+    core.error("error loading codefold state file %s: %s", path, err)
+    return nil
+  end
+
+  local ok, state = pcall(loader)
+  if not ok then
+    core.error("error reading codefold state file %s: %s", path, state)
+    return nil
+  end
+  if type(state) ~= "table" or state.path ~= key or type(state.folds) ~= "table" then
+    return nil
+  end
+  return state.folds
+end
+
+---@param doc core.doc
+---@param regions table[]
+---@param folds table[]
+---@return integer[] folded_regions
+local function match_fold_state(doc, regions, folds)
+  local folded = {}
+  local used = {}
+  local unmatched_folds = {}
+
+  local function use_region(idx)
+    if used[idx] then return end
+    used[idx] = true
+    folded[#folded + 1] = idx
+  end
+
+  for _, fold in ipairs(folds or {}) do
+    if type(fold) == "table" then
+      local line = fold.line
+      if type(line) == "number" then
+        local region
+        for idx, candidate in ipairs(regions) do
+          if candidate.start == line
+            and candidate.indent == fold.indent
+            and doc.lines[candidate.start] == fold.text
+          then
+            region = idx
+            break
+          end
+        end
+        if region then
+          use_region(region)
+        else
+          unmatched_folds[#unmatched_folds + 1] = fold
+        end
+      else
+        unmatched_folds[#unmatched_folds + 1] = fold
+      end
+    end
+  end
+
+  for _, fold in ipairs(unmatched_folds) do
+    if type(fold) == "table" and type(fold.text) == "string" then
+      local best, best_distance
+      for idx, candidate in ipairs(regions) do
+        if not used[idx]
+          and candidate.indent == fold.indent
+          and doc.lines[candidate.start] == fold.text
+        then
+          local distance = math.abs(candidate.start - (fold.line or candidate.start))
+          if not best_distance or distance < best_distance then
+            best, best_distance = idx, distance
+          elseif distance == best_distance then
+            best = nil
+          end
+        end
+      end
+      if best then
+        use_region(best)
+      end
+    end
+  end
+
+  return folded
+end
+
+---------------------------------------------------------------------
+-- Indent helpers (adapted from indentguide)
+---------------------------------------------------------------------
+
+---Computes the indent width for a line, ignoring blank/whitespace-only lines
+---by walking in `dir` (-1 up, 1 down) until a non-blank line is found.
+---@param doc core.doc
+---@param line integer
+---@param indent_size integer
+---@param dir integer?
+---@return integer indent_width (-1 if no non-blank line found)
+local function get_line_indent(doc, line, indent_size, dir)
+  if line < 1 or line > #doc.lines then
+    return -1
+  end
+  local text = doc.lines[line]
+  if not text or text == "\n" or text == "" then
+    if dir then
+      return get_line_indent(doc, line + dir, indent_size, dir)
+    end
+    return -1
+  end
+  local s, e = text:find("^%s*")
+  if e == #text then
+    -- All whitespace — skip
+    if dir then
+      return get_line_indent(doc, line + dir, indent_size, dir)
+    end
+    return -1
+  end
+  local n = 0
+  for b in text:sub(s, e):gmatch(".") do
+    n = n + (b == "\t" and indent_size or 1)
+  end
+  return n
+end
+
+---Resolve indent for a possibly-blank line by looking both directions.
+---@param doc core.doc
+---@param line integer
+---@param indent_size integer
+---@return integer
+local function get_effective_indent(doc, line, indent_size)
+  local indent = get_line_indent(doc, line, indent_size)
+  if indent >= 0 then
+    return indent
+  end
+  local above = get_line_indent(doc, line - 1, indent_size, -1)
+  local below = get_line_indent(doc, line + 1, indent_size, 1)
+  if above >= 0 and below >= 0 then
+    return math.max(above, below)
+  end
+  return above >= 0 and above or below
+end
+
+---------------------------------------------------------------------
+-- Fold region detection
+---------------------------------------------------------------------
+
+---Detect all foldable regions in the document based on indentation.
+---A fold region starts at line `s` (indent I) and continues through line `e`
+---where line `e+1` has indent <= I (or e is the last line).
+---@param doc core.doc
+---@param invalidate_from? integer
+---@param invalidate_to? integer
+---@return table[] regions
+local function detect_fold_regions(doc, invalidate_from, invalidate_to)
+  local _, indent_size = doc:get_indent_info()
+  local regions = {}
+  local line_count = #doc.lines
+
+  local start_line = 1
+  local stop_line = line_count
+  if invalidate_from then
+    -- Find the first region that might be affected
+    start_line = math.max(1, invalidate_from)
+    stop_line = math.min(line_count, invalidate_to or line_count)
+  end
+
+  local line = start_line
+  while line <= stop_line do
+    if line % 100 == 0 then
+      coroutine.yield()
+    end
+
+    local indent = get_effective_indent(doc, line, indent_size)
+    if indent < 0 then
+      line = line + 1
+      goto continue
+    end
+
+    local next_line = line + 1
+    if next_line > line_count then break end
+
+    local next_indent = get_effective_indent(doc, next_line, indent_size)
+    if next_indent > indent then
+      -- Line `line` starts a fold region. Find where it ends.
+      local stop = next_line
+      while stop < line_count do
+        local peek_indent = get_effective_indent(doc, stop + 1, indent_size)
+        if peek_indent < 0 then
+          -- blank — continue
+          stop = stop + 1
+        elseif peek_indent <= indent then
+          break
+        else
+          stop = stop + 1
+        end
+      end
+      regions[#regions + 1] = {
+        indent = indent,
+        start = line,
+        stop = stop
+      }
+      line = line + 1
+    else
+      line = line + 1
+    end
+    ::continue::
+  end
+
+  return regions
+end
+
+---------------------------------------------------------------------
+-- Virtual line mapping
+---------------------------------------------------------------------
+
+---Determine which real lines are hidden based on collapsed fold regions.
+---@param self core.docview
+---@return table<integer, boolean> hidden_set
+local function build_hidden_set(self)
+  local hidden = {}
+  for _, region_idx in ipairs(self.cf_folded_regions) do
+    local region = self.cf_regions[region_idx]
+    if region then
+      for l = region.start + 1, region.stop do
+        hidden[l] = true
+      end
+    end
+  end
+  return hidden
+end
+
+---Rebuild fold_map (virtual→real) and unfold_map (real→virtual).
+---@param self core.docview
+local function rebuild_mappings(self)
+  local hidden = build_hidden_set(self)
+  self.cf_fold_map = {}
+  self.cf_unfold_map = {}
+
+  for real = 1, #self.doc.lines do
+    if not hidden[real] then
+      local virtual = #self.cf_fold_map + 1
+      self.cf_fold_map[virtual] = real
+      self.cf_unfold_map[real] = virtual
+    else
+      self.cf_unfold_map[real] = nil
+    end
+  end
+  self:invalidate_visual_lines()
+end
+
+---Given a real line that may be hidden, find the nearest visible ancestor.
+---@param self core.docview
+---@param line integer
+---@return integer visible_real_line
+local function visible_ancestor(self, line)
+  if not self.cf_unfold_map or #self.cf_unfold_map == 0 then
+    return line
+  end
+  while line > 0 and not self.cf_unfold_map[line] do
+    line = line - 1
+  end
+  return math.max(line, 1)
+end
+
+---Apply detected regions and restore persisted or in-memory fold state.
+---@param self core.docview
+---@param regions table[]
+local function apply_detected_regions(self, regions)
+  local previous_folds = make_state_folds(
+    self.doc,
+    self.cf_regions or {},
+    self.cf_folded_regions or {}
+  )
+  local should_resave = false
+  self.cf_regions = regions
+
+  if not self.cf_state_loaded then
+    local saved_folds = load_fold_state(self.doc)
+    self.cf_state_loaded = true
+    if saved_folds then
+      self.cf_folded_regions = match_fold_state(self.doc, regions, saved_folds)
+      should_resave = true
+    elseif config.plugins.codefold.start_folded then
+      self.cf_folded_regions = {}
+      for idx = 1, #regions do
+        self.cf_folded_regions[#self.cf_folded_regions + 1] = idx
+      end
+    else
+      self.cf_folded_regions = {}
+    end
+  else
+    self.cf_folded_regions = match_fold_state(self.doc, regions, previous_folds)
+    should_resave = #previous_folds > 0
+  end
+
+  rebuild_mappings(self)
+  if should_resave then
+    save_fold_state(self.doc, self.cf_regions, self.cf_folded_regions)
+  end
+end
+
+---Recalculate everything after fold state or document change.
+---Runs in a background thread to avoid UI stalls on large documents.
+---@param self core.docview
+local function recalculate(self)
+  -- Cancel any previous in-flight recalculation.
+  if self.cf_thread_id then
+    core.threads[self.cf_thread_id] = nil
+    self.cf_thread_id = nil
+  end
+
+  self.cf_thread_id = core.add_thread(function()
+    apply_detected_regions(self, detect_fold_regions(self.doc))
+    self.cf_thread_id = nil
+    core.redraw = true
+  end)
+end
+
+---Initialize fold state for a DocView.
+---@param self core.docview
+local function init_fold_state(self)
+  self.cf_regions = {}
+  self.cf_folded_regions = {}
+  self.cf_fold_map = {}
+  self.cf_unfold_map = {}
+  self.cf_invalidated = true
+  self.cf_state_loaded = false
+end
+
+---Fold all regions.
+---@param self core.docview
+local function fold_all(self)
+  local folded = {}
+  for idx = 1, #self.cf_regions do
+    folded[#folded + 1] = idx
+  end
+  self.cf_folded_regions = folded
+  rebuild_mappings(self)
+end
+
+---Unfold all regions.
+---@param self core.docview
+local function unfold_all(self)
+  self.cf_folded_regions = {}
+  rebuild_mappings(self)
+end
+
+---Check if a fold region is collapsed.
+---@param self core.docview
+---@param region_idx integer
+---@return boolean
+local function is_folded(self, region_idx)
+  for _, idx in ipairs(self.cf_folded_regions) do
+    if idx == region_idx then
+      return true
+    end
+  end
+  return false
+end
+
+---Find the fold region that starts at a given real line.
+---@param self core.docview
+---@param line integer
+---@return integer? region_idx
+local function region_at_line(self, line)
+  for idx, region in ipairs(self.cf_regions) do
+    if region.start == line then
+      return idx
+    end
+  end
+  return nil
+end
+
+---Find the innermost fold region that contains a given real line
+---(not as the header).
+---@param self core.docview
+---@param line integer
+---@return integer? region_idx
+local function region_containing(self, line)
+  local best, best_indent = nil, -1
+  for idx, region in ipairs(self.cf_regions) do
+    if line > region.start and line <= region.stop then
+      if region.indent > best_indent then
+        best, best_indent = idx, region.indent
+      end
+    end
+  end
+  return best
+end
+
+---Toggle a fold region.
+---@param self core.docview
+---@param region_idx integer
+local function toggle_region(self, region_idx)
+  local folded = {}
+  local was_folded = false
+  for _, idx in ipairs(self.cf_folded_regions) do
+    if idx == region_idx then
+      was_folded = true
+    else
+      folded[#folded + 1] = idx
+    end
+  end
+  if not was_folded then
+    folded[#folded + 1] = region_idx
+  end
+  self.cf_folded_regions = folded
+  rebuild_mappings(self)
+  save_fold_state(self.doc, self.cf_regions, self.cf_folded_regions)
+
+  -- If the caret is now hidden, snap it to the fold header
+  local line1, col1 = self.doc:get_selection()
+  if not self.cf_unfold_map[line1] then
+    self.doc:set_selection(visible_ancestor(self, line1), col1)
+  end
+end
+
+---Normalize the caret position: if on a hidden line, move to nearest visible.
+---Safe to call when maps are not yet built (during async recalculation).
+---@param self core.docview
+local function normalize_caret(self)
+  if not self.cf_unfold_map or #self.cf_unfold_map == 0 then
+    return
+  end
+  local line1, col1, line2, col2 = self.doc:get_selection(true)
+  if not self.cf_unfold_map[line1] then
+    local ancestor = visible_ancestor(self, line1)
+    if not self.cf_unfold_map[line2] then
+      line2 = visible_ancestor(self, line2)
+    end
+    self.doc:set_selection(ancestor, col1, line2, col2)
+  end
+end
+
+
+local docview_get_hidden_lines = DocView.get_hidden_lines
+function DocView:get_hidden_lines()
+  if config.plugins.codefold.enabled and self:is(DocView)
+    and self.cf_folded_regions and #self.cf_folded_regions > 0 then
+    return build_hidden_set(self)
+  end
+  return docview_get_hidden_lines(self)
+end
+
+---------------------------------------------------------------------
+-- Method overrides: DocView
+---------------------------------------------------------------------
+
+local docview_new = DocView.new
+function DocView:new(doc, ...)
+  docview_new(self, doc, ...)
+  init_fold_state(self)
+  self.cf_first_update = true
+end
+
+local docview_update = DocView.update
+function DocView:update(...)
+  docview_update(self, ...)
+
+  if not config.plugins.codefold.enabled or not self:is(DocView) then
+    return
+  end
+
+  -- Detect fold regions on first update
+  if self.cf_first_update then
+    self.cf_first_update = nil
+    recalculate(self)
+  end
+
+  -- Recalculate if the document changed
+  if self.cf_invalidated then
+    self.cf_invalidated = nil
+    recalculate(self)
+  end
+
+  normalize_caret(self)
+end
+
+---------------------------------------------------------------------
+-- Method overrides: gutter width
+---------------------------------------------------------------------
+
+local docview_get_gutter_width = DocView.get_gutter_width
+function DocView:get_gutter_width()
+  if not config.plugins.codefold.enabled or not self:is(DocView) then
+    return docview_get_gutter_width(self)
+  end
+  local base_width, padding = docview_get_gutter_width(self)
+  local toggle_w = config.plugins.codefold.toggle_width
+  return base_width + toggle_w, padding + toggle_w
+end
+
+local docview_draw_line_gutter = DocView.draw_line_gutter
+function DocView:draw_line_gutter(line, x, y, width)
+  local result = docview_draw_line_gutter(self, line, x, y, width)
+  if config.plugins.codefold.enabled and self:is(DocView) then
+    local region_idx = region_at_line(self, line)
+    if region_idx then
+      local folded = is_folded(self, region_idx)
+      local toggle_char = folded and TOGGLE_CLOSE or TOGGLE_OPEN
+      local toggle_color = folded and style.caret or (style.dim or style.line_number)
+      if self.cf_hovering_toggle == line then
+        toggle_color = style.accent
+      end
+      local lh = self:get_line_height()
+      local toggle_w = config.plugins.codefold.toggle_width
+      local font = self:get_font()
+      local toggle_font = font:copy(common.round(font:get_size() * 1.5))
+      local toggle_x = self.position.x + self:get_gutter_width() - toggle_w * 1.5
+      local toggle_y = y
+      common.draw_text(toggle_font, toggle_color, toggle_char, "right", toggle_x, toggle_y, toggle_w, lh)
+    end
+  end
+  return result
+end
+
+---------------------------------------------------------------------
+-- Method overrides: mouse
+---------------------------------------------------------------------
+
+local docview_on_mouse_pressed = DocView.on_mouse_pressed
+function DocView:on_mouse_pressed(button, x, y, clicks)
+  -- Mirror the original gutter handler: trust the hover flag set in on_mouse_moved.
+  if config.plugins.codefold.enabled and self:is(DocView)
+    and button == "left" and self.cf_hovering_toggle then
+    local line = self:resolve_screen_position(x, y)
+    if line then
+      local region_idx = region_at_line(self, line)
+      if region_idx then
+        toggle_region(self, region_idx)
+        core.redraw = true
+        return true
+      end
+    end
+  end
+  return docview_on_mouse_pressed(self, button, x, y, clicks)
+end
+
+local docview_on_mouse_moved = DocView.on_mouse_moved
+function DocView:on_mouse_moved(x, y, ...)
+  -- Let the original handle scrollbar and gutter hover state first.
+  docview_on_mouse_moved(self, x, y, ...)
+  -- Then decide if we're hovering a fold toggle (leftmost portion of gutter).
+  local was_hovering = self.cf_hovering_toggle
+  self.cf_hovering_toggle = nil
+  if config.plugins.codefold.enabled and self:is(DocView) then
+    local tw = config.plugins.codefold.toggle_width
+    local gw = self:get_gutter_width()
+    if x >= self.position.x + gw - tw and x < self.position.x + gw then
+      local line = self:resolve_screen_position(x, y)
+      if line and region_at_line(self, line) then
+        self.cf_hovering_toggle = line
+        self.cursor = "arrow"
+      end
+    end
+  end
+  if was_hovering ~= self.cf_hovering_toggle then
+    core.redraw = true
+  end
+end
+
+---------------------------------------------------------------------
+-- Method overrides: Doc (incremental invalidation)
+---------------------------------------------------------------------
+
+local doc_raw_insert = Doc.raw_insert
+function Doc:raw_insert(line, col, text, undo_stack, time)
+  local result = doc_raw_insert(self, line, col, text, undo_stack, time)
+  -- Invalidate fold state on all views of this doc
+  for _, view in ipairs(core.get_views_referencing_doc(self)) do
+    if view:is(DocView) and view.cf_regions then
+      view.cf_invalidated = true
+    end
+  end
+  return result
+end
+
+local doc_raw_remove = Doc.raw_remove
+function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
+  local result = doc_raw_remove(self, line1, col1, line2, col2, undo_stack, time)
+  for _, view in ipairs(core.get_views_referencing_doc(self)) do
+    if view:is(DocView) and view.cf_regions then
+      view.cf_invalidated = true
+    end
+  end
+  return result
+end
+
+---------------------------------------------------------------------
+-- Commands
+---------------------------------------------------------------------
+
+command.add(nil, {
+  ["code-folding:toggle"] = function()
+    local view = core.active_view
+    if not view or not view:is(DocView) or not view.cf_regions then
+      return
+    end
+    local line = view.doc:get_selection()
+    -- First check if the line itself starts a fold region
+    local region_idx = region_at_line(view, line)
+    if not region_idx then
+      -- Find the innermost region containing this line
+      region_idx = region_containing(view, line)
+    end
+    if region_idx then
+      toggle_region(view, region_idx)
+    end
+  end,
+
+  ["code-folding:fold-all"] = function()
+    local view = core.active_view
+    if not view or not view:is(DocView) or not view.cf_regions then
+      return
+    end
+    fold_all(view)
+    save_fold_state(view.doc, view.cf_regions, view.cf_folded_regions)
+  end,
+
+  ["code-folding:unfold-all"] = function()
+    local view = core.active_view
+    if not view or not view:is(DocView) or not view.cf_regions then
+      return
+    end
+    unfold_all(view)
+    save_fold_state(view.doc, view.cf_regions, view.cf_folded_regions)
+  end,
+})
+
+---------------------------------------------------------------------
+-- Keybindings
+---------------------------------------------------------------------
+
+keymap.add {
+  ["alt+shift+left"] = "code-folding:toggle",
+  ["alt+shift+right"] = "code-folding:toggle",
+  ["alt+shift+up"] = "code-folding:fold-all",
+  ["alt+shift+down"] = "code-folding:unfold-all"
+}
+
+---------------------------------------------------------------------
+-- Translate overrides: skip hidden lines during cursor movement
+---------------------------------------------------------------------
+
+local original_next_line = DocView.translate.next_line
+local original_previous_line = DocView.translate.previous_line
+local original_next_page = DocView.translate.next_page
+local original_previous_page = DocView.translate.previous_page
+
+---Skip hidden (folded) lines when moving the cursor down.
+---@param doc core.doc
+---@param line integer
+---@param col integer
+---@param dv core.docview
+---@return integer line
+---@return integer col
+DocView.translate.next_line = function(doc, line, col, dv)
+  local function skip_hidden(l)
+    if not dv.cf_unfold_map then return l end
+    while l <= #doc.lines and not dv.cf_unfold_map[l] do
+      l = l + 1
+    end
+    if l > #doc.lines then
+      -- Walk backwards to find the last visible line
+      l = #doc.lines
+      while l >= 1 and not dv.cf_unfold_map[l] do
+        l = l - 1
+      end
+    end
+    return l
+  end
+  local nl = skip_hidden(line + 1)
+  if nl == line then return line, math.huge end
+  return nl, 1
+end
+
+---Skip hidden (folded) lines when moving the cursor up.
+DocView.translate.previous_line = function(doc, line, col, dv)
+  local function skip_hidden(l)
+    if not dv.cf_unfold_map then return l end
+    while l >= 1 and not dv.cf_unfold_map[l] do
+      l = l - 1
+    end
+    if l < 1 then
+      -- Walk forwards to find the first visible line
+      l = 1
+      while l <= #doc.lines and not dv.cf_unfold_map[l] do
+        l = l + 1
+      end
+    end
+    return l
+  end
+  local nl = skip_hidden(line - 1)
+  if nl == line then return line, 1 end
+  return nl, math.huge
+end
+
+---Page down, skipping folded regions.
+DocView.translate.next_page = function(doc, line, col, dv)
+  if not dv.cf_fold_map or #dv.cf_fold_map == 0 then
+    return original_next_page(doc, line, col, dv)
+  end
+  local virtual = dv.cf_unfold_map[line]
+  if not virtual then return dv.cf_fold_map[#dv.cf_fold_map], math.huge end
+  local min, max = dv:get_visible_line_range()
+  local new_virtual = math.min(#dv.cf_fold_map, virtual + (max - min))
+  local new_real = dv.cf_fold_map[new_virtual] or #doc.lines
+  return new_real, 1
+end
+
+---Page up, skipping folded regions.
+DocView.translate.previous_page = function(doc, line, col, dv)
+  if not dv.cf_fold_map or #dv.cf_fold_map == 0 then
+    return original_previous_page(doc, line, col, dv)
+  end
+  local virtual = dv.cf_unfold_map[line]
+  if not virtual then return 1, 1 end
+  local min, max = dv:get_visible_line_range()
+  local new_virtual = math.max(1, virtual - (max - min))
+  local new_real = dv.cf_fold_map[new_virtual] or 1
+  return new_real, 1
+end
+
+codefold._test = {
+  apply_detected_regions = apply_detected_regions,
+  doc_state_key = doc_state_key,
+  hash_text = hash_text,
+  load_fold_state = load_fold_state,
+  match_fold_state = match_fold_state,
+  save_fold_state = save_fold_state,
+  state_path_for_doc = state_path_for_doc,
+}
+
+return codefold

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -15,6 +15,8 @@ config.plugins.codefold = common.merge({
   enabled = true,
   -- If true, newly opened documents have all fold regions initially collapsed.
   start_folded = false,
+  -- If true, folded regions hide the folded end-line tail.
+  hide_tail_on_fold = true,
   -- Width in pixels reserved for fold toggle indicators in the gutter.
   toggle_width = common.round(24 * SCALE),
   -- The config specification used by the settings GUI.
@@ -33,14 +35,40 @@ config.plugins.codefold = common.merge({
       path = "start_folded",
       type = "toggle",
       default = false
+    },
+    {
+      label = "Hide Fold Tail",
+      description = "Hide the folded end-line tail when a region is collapsed.",
+      path = "hide_tail_on_fold",
+      type = "toggle",
+      default = true
     }
   }
 }, config.plugins.codefold)
 
 local TOGGLE_OPEN  = "\226\150\190"  -- ▾  (U+25BE)
 local TOGGLE_CLOSE = "\226\150\184"  -- ▸  (U+25B8)
+local RECALC_DEBOUNCE_SECONDS = 0.12
+---@type renderer.font?
+local CODEFOLD_FONT = nil
 
 local codefold = {}
+
+local function maybe_yield()
+  if coroutine.isyieldable() then coroutine.yield() end
+end
+
+---@param self core.docview
+---@return renderer.font
+local function get_toggle_font(self)
+  local font = self:get_font()
+  local size = common.round(font:get_size() * 1.5)
+  if not CODEFOLD_FONT or CODEFOLD_FONT ~= font or self.cf_toggle_font_size ~= size then
+    CODEFOLD_FONT = font:copy(size)
+    self.cf_toggle_font_size = size
+  end
+  return CODEFOLD_FONT
+end
 
 ---------------------------------------------------------------------
 -- Persistent state
@@ -272,6 +300,30 @@ local function get_line_indent(doc, line, indent_size, dir)
   return n
 end
 
+---Computes the indent width for a line without resolving blank lines.
+---@param doc core.doc
+---@param line integer
+---@param indent_size integer
+---@return integer indent_width (-1 for blank/whitespace-only lines)
+local function get_direct_line_indent(doc, line, indent_size)
+  if line < 1 or line > #doc.lines then
+    return -1
+  end
+  local text = doc.lines[line]
+  if not text or text == "\n" or text == "" then
+    return -1
+  end
+  local s, e = text:find("^%s*")
+  if e == #text then
+    return -1
+  end
+  local n = 0
+  for b in text:sub(s, e):gmatch(".") do
+    n = n + (b == "\t" and indent_size or 1)
+  end
+  return n
+end
+
 ---Resolve indent for a possibly-blank line by looking both directions.
 ---@param doc core.doc
 ---@param line integer
@@ -290,6 +342,50 @@ local function get_effective_indent(doc, line, indent_size)
   return above >= 0 and above or below
 end
 
+---@param doc core.doc
+---@param indent_size integer
+---@return integer[] indents
+local function build_effective_indents(doc, indent_size)
+  local line_count = #doc.lines
+  local raw = {}
+  local prev = {}
+  local next = {}
+  local last = -1
+
+  for line = 1, line_count do
+    if line % 500 == 0 then maybe_yield() end
+    local indent = get_direct_line_indent(doc, line, indent_size)
+    raw[line] = indent
+    if indent >= 0 then
+      last = indent
+    end
+    prev[line] = last
+  end
+
+  last = -1
+  for line = line_count, 1, -1 do
+    if line % 500 == 0 then maybe_yield() end
+    local indent = raw[line]
+    if indent >= 0 then
+      last = indent
+    end
+    next[line] = last
+  end
+
+  local indents = {}
+  for line = 1, line_count do
+    local indent = raw[line]
+    if indent >= 0 then
+      indents[line] = indent
+    elseif prev[line] >= 0 and next[line] >= 0 then
+      indents[line] = math.max(prev[line], next[line])
+    else
+      indents[line] = prev[line] >= 0 and prev[line] or next[line]
+    end
+  end
+  return indents
+end
+
 ---------------------------------------------------------------------
 -- Fold region detection
 ---------------------------------------------------------------------
@@ -305,6 +401,7 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
   local _, indent_size = doc:get_indent_info()
   local regions = {}
   local line_count = #doc.lines
+  local indents = build_effective_indents(doc, indent_size)
 
   local start_line = 1
   local stop_line = line_count
@@ -317,10 +414,10 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
   local line = start_line
   while line <= stop_line do
     if line % 100 == 0 then
-      coroutine.yield()
+      maybe_yield()
     end
 
-    local indent = get_effective_indent(doc, line, indent_size)
+    local indent = indents[line]
     if indent < 0 then
       line = line + 1
       goto continue
@@ -329,12 +426,13 @@ local function detect_fold_regions(doc, invalidate_from, invalidate_to)
     local next_line = line + 1
     if next_line > line_count then break end
 
-    local next_indent = get_effective_indent(doc, next_line, indent_size)
+    local next_indent = indents[next_line]
     if next_indent > indent then
       -- Line `line` starts a fold region. Find where it ends.
       local stop = next_line
       while stop < line_count do
-        local peek_indent = get_effective_indent(doc, stop + 1, indent_size)
+        if stop % 500 == 0 then maybe_yield() end
+        local peek_indent = indents[stop + 1]
         if peek_indent < 0 then
           -- blank — continue
           stop = stop + 1
@@ -363,6 +461,26 @@ end
 -- Virtual line mapping
 ---------------------------------------------------------------------
 
+---@param self core.docview
+---@param regions table[]
+local function set_regions(self, regions)
+  self.cf_regions = regions or {}
+  self.cf_region_by_start = {}
+  for idx, region in ipairs(self.cf_regions) do
+    self.cf_region_by_start[region.start] = idx
+  end
+end
+
+---@param self core.docview
+---@param folded integer[]
+local function set_folded_regions(self, folded)
+  self.cf_folded_regions = folded or {}
+  self.cf_folded_region_set = {}
+  for _, region_idx in ipairs(self.cf_folded_regions) do
+    self.cf_folded_region_set[region_idx] = true
+  end
+end
+
 ---Determine which real lines are hidden based on collapsed fold regions.
 ---@param self core.docview
 ---@return table<integer, boolean> hidden_set
@@ -374,6 +492,9 @@ local function build_hidden_set(self)
       for l = region.start + 1, region.stop do
         hidden[l] = true
       end
+      if config.plugins.codefold.hide_tail_on_fold and region.stop < #self.doc.lines then
+        hidden[region.stop + 1] = true
+      end
     end
   end
   return hidden
@@ -383,6 +504,7 @@ end
 ---@param self core.docview
 local function rebuild_mappings(self)
   local hidden = build_hidden_set(self)
+  self.cf_hidden_lines = hidden
   self.cf_fold_map = {}
   self.cf_unfold_map = {}
 
@@ -422,24 +544,25 @@ local function apply_detected_regions(self, regions)
     self.cf_folded_regions or {}
   )
   local should_resave = false
-  self.cf_regions = regions
+  set_regions(self, regions)
 
   if not self.cf_state_loaded then
     local saved_folds = load_fold_state(self.doc)
     self.cf_state_loaded = true
     if saved_folds then
-      self.cf_folded_regions = match_fold_state(self.doc, regions, saved_folds)
+      set_folded_regions(self, match_fold_state(self.doc, regions, saved_folds))
       should_resave = true
     elseif config.plugins.codefold.start_folded then
-      self.cf_folded_regions = {}
+      local folded = {}
       for idx = 1, #regions do
-        self.cf_folded_regions[#self.cf_folded_regions + 1] = idx
+        folded[#folded + 1] = idx
       end
+      set_folded_regions(self, folded)
     else
-      self.cf_folded_regions = {}
+      set_folded_regions(self, {})
     end
   else
-    self.cf_folded_regions = match_fold_state(self.doc, regions, previous_folds)
+    set_folded_regions(self, match_fold_state(self.doc, regions, previous_folds))
     should_resave = #previous_folds > 0
   end
 
@@ -449,19 +572,48 @@ local function apply_detected_regions(self, regions)
   end
 end
 
+---Replace a stale scheduled recalculation with a no-op coroutine.
+---@param self core.docview
+local function replace_recalculation_thread(self)
+  local thread_id = self.cf_thread_id
+  if not thread_id then return end
+
+  local thread = core.threads[thread_id]
+  if thread then
+    thread.cr = coroutine.create(function() end)
+    thread.wake = 0
+    thread.avg_time = nil
+    thread.time = nil
+    thread.calls = nil
+  end
+  self.cf_thread_id = nil
+end
+
+---@param self core.docview
+---@param from_line? integer
+local function schedule_recalculation(self, from_line)
+  replace_recalculation_thread(self)
+  self.cf_invalidated = true
+  self.cf_invalidated_at = system.get_time() + RECALC_DEBOUNCE_SECONDS
+  if from_line then
+    self.cf_invalidated_from = self.cf_invalidated_from
+      and math.min(self.cf_invalidated_from, from_line)
+      or from_line
+  end
+end
+
 ---Recalculate everything after fold state or document change.
 ---Runs in a background thread to avoid UI stalls on large documents.
 ---@param self core.docview
 local function recalculate(self)
-  -- Cancel any previous in-flight recalculation.
-  if self.cf_thread_id then
-    core.threads[self.cf_thread_id] = nil
-    self.cf_thread_id = nil
-  end
+  replace_recalculation_thread(self)
 
   self.cf_thread_id = core.add_thread(function()
     apply_detected_regions(self, detect_fold_regions(self.doc))
     self.cf_thread_id = nil
+    self.cf_invalidated = false
+    self.cf_invalidated_at = nil
+    self.cf_invalidated_from = nil
     core.redraw = true
   end)
 end
@@ -469,11 +621,13 @@ end
 ---Initialize fold state for a DocView.
 ---@param self core.docview
 local function init_fold_state(self)
-  self.cf_regions = {}
-  self.cf_folded_regions = {}
+  set_regions(self, {})
+  set_folded_regions(self, {})
+  self.cf_hidden_lines = nil
   self.cf_fold_map = {}
   self.cf_unfold_map = {}
-  self.cf_invalidated = true
+  self.cf_invalidated = false
+  self.cf_invalidated_at = nil
   self.cf_state_loaded = false
 end
 
@@ -484,14 +638,14 @@ local function fold_all(self)
   for idx = 1, #self.cf_regions do
     folded[#folded + 1] = idx
   end
-  self.cf_folded_regions = folded
+  set_folded_regions(self, folded)
   rebuild_mappings(self)
 end
 
 ---Unfold all regions.
 ---@param self core.docview
 local function unfold_all(self)
-  self.cf_folded_regions = {}
+  set_folded_regions(self, {})
   rebuild_mappings(self)
 end
 
@@ -500,10 +654,11 @@ end
 ---@param region_idx integer
 ---@return boolean
 local function is_folded(self, region_idx)
-  for _, idx in ipairs(self.cf_folded_regions) do
-    if idx == region_idx then
-      return true
-    end
+  if self.cf_folded_region_set and self.cf_folded_region_set[region_idx] then
+    return true
+  end
+  for _, idx in ipairs(self.cf_folded_regions or {}) do
+    if idx == region_idx then return true end
   end
   return false
 end
@@ -513,10 +668,11 @@ end
 ---@param line integer
 ---@return integer? region_idx
 local function region_at_line(self, line)
-  for idx, region in ipairs(self.cf_regions) do
-    if region.start == line then
-      return idx
-    end
+  if self.cf_region_by_start and self.cf_region_by_start[line] then
+    return self.cf_region_by_start[line]
+  end
+  for idx, region in ipairs(self.cf_regions or {}) do
+    if region.start == line then return idx end
   end
   return nil
 end
@@ -554,7 +710,7 @@ local function toggle_region(self, region_idx)
   if not was_folded then
     folded[#folded + 1] = region_idx
   end
-  self.cf_folded_regions = folded
+  set_folded_regions(self, folded)
   rebuild_mappings(self)
   save_fold_state(self.doc, self.cf_regions, self.cf_folded_regions)
 
@@ -569,6 +725,9 @@ end
 ---Safe to call when maps are not yet built (during async recalculation).
 ---@param self core.docview
 local function normalize_caret(self)
+  if not self.cf_folded_regions or #self.cf_folded_regions == 0 then
+    return
+  end
   if not self.cf_unfold_map or #self.cf_unfold_map == 0 then
     return
   end
@@ -587,7 +746,7 @@ local docview_get_hidden_lines = DocView.get_hidden_lines
 function DocView:get_hidden_lines()
   if config.plugins.codefold.enabled and self:is(DocView)
     and self.cf_folded_regions and #self.cf_folded_regions > 0 then
-    return build_hidden_set(self)
+    return self.cf_hidden_lines or build_hidden_set(self)
   end
   return docview_get_hidden_lines(self)
 end
@@ -614,7 +773,7 @@ function DocView:ensure_line_visible(line)
   end
 
   if changed then
-    self.cf_folded_regions = folded
+    set_folded_regions(self, folded)
     rebuild_mappings(self)
     save_fold_state(self.doc, self.cf_regions, self.cf_folded_regions)
     core.redraw = true
@@ -648,8 +807,11 @@ function DocView:update(...)
   end
 
   -- Recalculate if the document changed
-  if self.cf_invalidated then
+  if self.cf_invalidated
+    and (not self.cf_invalidated_at or system.get_time() >= self.cf_invalidated_at)
+  then
     self.cf_invalidated = nil
+    self.cf_invalidated_at = nil
     recalculate(self)
   end
 
@@ -684,8 +846,7 @@ function DocView:draw_line_gutter(line, x, y, width)
       end
       local lh = self:get_line_height()
       local toggle_w = config.plugins.codefold.toggle_width
-      local font = self:get_font()
-      local toggle_font = font:copy(common.round(font:get_size() * 1.5))
+      local toggle_font = get_toggle_font(self)
       local toggle_x = self.position.x + self:get_gutter_width() - toggle_w * 1.5
       local toggle_y = y
       common.draw_text(toggle_font, toggle_color, toggle_char, "right", toggle_x, toggle_y, toggle_w, lh)
@@ -749,7 +910,7 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
   -- Invalidate fold state on all views of this doc
   for _, view in ipairs(core.get_views_referencing_doc(self)) do
     if view:is(DocView) and view.cf_regions then
-      view.cf_invalidated = true
+      schedule_recalculation(view, line)
     end
   end
   return result
@@ -760,7 +921,7 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   local result = doc_raw_remove(self, line1, col1, line2, col2, undo_stack, time)
   for _, view in ipairs(core.get_views_referencing_doc(self)) do
     if view:is(DocView) and view.cf_regions then
-      view.cf_invalidated = true
+      schedule_recalculation(view, line1)
     end
   end
   return result

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -592,6 +592,36 @@ function DocView:get_hidden_lines()
   return docview_get_hidden_lines(self)
 end
 
+local docview_ensure_line_visible = DocView.ensure_line_visible
+function DocView:ensure_line_visible(line)
+  line = docview_ensure_line_visible(self, line)
+  if not config.plugins.codefold.enabled or not self:is(DocView) then
+    return line
+  end
+  if not self.cf_unfold_map or self.cf_unfold_map[line] then
+    return line
+  end
+
+  local folded = {}
+  local changed = false
+  for _, region_idx in ipairs(self.cf_folded_regions or {}) do
+    local region = self.cf_regions[region_idx]
+    if region and line > region.start and line <= region.stop then
+      changed = true
+    else
+      folded[#folded + 1] = region_idx
+    end
+  end
+
+  if changed then
+    self.cf_folded_regions = folded
+    rebuild_mappings(self)
+    save_fold_state(self.doc, self.cf_regions, self.cf_folded_regions)
+    core.redraw = true
+  end
+  return line
+end
+
 ---------------------------------------------------------------------
 -- Method overrides: DocView
 ---------------------------------------------------------------------

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -185,6 +185,7 @@ function LineWrapping.reconstruct_breaks(docview, default_font, width, line_offs
     docview.wrapped_line_offsets = nil
     docview.wrapped_settings = nil
   end
+  docview:invalidate_visual_lines(line_offset)
 end
 
 -- When we have an insertion or deletion, we have four sections of text.
@@ -237,6 +238,7 @@ function LineWrapping.update_breaks(docview, old_line1, old_line2, net_lines)
   while line <= #docview.wrapped_line_to_idx do
     table.remove(docview.wrapped_line_to_idx)
   end
+  docview:invalidate_visual_lines(old_line1)
 end
 
 -- Draws a guide if applicable to show where wrapping is occurring.
@@ -315,7 +317,32 @@ local function get_line_idx_col_count(docview, line, col, line_end, ndoc)
   return idx, ncol, count, scol
 end
 
-local function get_line_col_from_index_and_x(docview, idx, x)
+local get_line_col_from_index_and_x
+
+local old_get_line_wraps = DocView.get_line_wraps
+function DocView:get_line_wraps(line)
+  if not self.wrapped_settings then
+    return old_get_line_wraps(self, line)
+  end
+  local idx = self.wrapped_line_to_idx[line]
+  if not idx then return nil end
+  local next_idx = self.wrapped_line_to_idx[line + 1] or (get_total_wrapped_lines(self) + 1)
+  local starts = {}
+  for i = idx, next_idx - 1 do
+    local _, col = get_idx_line_col(self, i)
+    starts[#starts + 1] = col
+  end
+  return starts
+end
+
+function DocView:get_visual_line_col_from_x(row, x)
+  if not self.wrapped_settings then
+    return self:get_x_offset_col(self:visual_position_from_row(row), x)
+  end
+  return get_line_col_from_index_and_x(self, row, x)
+end
+
+function get_line_col_from_index_and_x(docview, idx, x)
   local doc = docview.doc
   local line, col = get_idx_line_col(docview, idx)
   if idx < 1 then return 1, 1 end
@@ -386,13 +413,6 @@ function DocView:update()
   end
 end
 
-function DocView:get_scrollable_size()
-  if not config.scroll_past_end then
-    return self:get_line_height() * get_total_wrapped_lines(self) + style.padding.y * 2
-  end
-  return self:get_line_height() * (get_total_wrapped_lines(self) - 1) + self.size.y
-end
-
 local old_get_h_scrollable_size = DocView.get_h_scrollable_size
 function DocView:get_h_scrollable_size(...)
   if self.wrapping_enabled then return 0 end
@@ -423,16 +443,6 @@ function DocView:scroll_to_make_visible(line, col, instant)
   if self.wrapping_enabled then LineWrapping.update_docview_breaks(self) end
   old_scroll_to_make_visible(self, line, col, instant)
   if self.wrapped_settings then self.scroll.to.x = 0 end
-end
-
-local old_get_visible_line_range = DocView.get_visible_line_range
-function DocView:get_visible_line_range()
-  if not self.wrapped_settings then return old_get_visible_line_range(self) end
-  local x, y, x2, y2 = self:get_content_bounds()
-  local lh = self:get_line_height()
-  local minline = get_idx_line_col(self, math.max(1, math.floor(y / lh)))
-  local maxline = get_idx_line_col(self, math.min(get_total_wrapped_lines(self), math.floor(y2 / lh) + 1))
-  return minline, maxline
 end
 
 local old_get_visible_cols_range = DocView.get_visible_cols_range
@@ -515,24 +525,6 @@ function DocView:get_col_x_offset(line, col, line_end)
     end
   end
   return xoffset
-end
-
-local old_get_line_screen_position = DocView.get_line_screen_position
-function DocView:get_line_screen_position(line, col)
-  if not self.wrapped_settings then return old_get_line_screen_position(self, line, col) end
-  local idx, ncol, count = get_line_idx_col_count(self, line, col)
-  local x, y = self:get_content_offset()
-  local lh = self:get_line_height()
-  local gw = self:get_gutter_width()
-  return x + gw + (col and self:get_col_x_offset(line, col) or 0), y + (idx-1) * lh + style.padding.y
-end
-
-local old_resolve_screen_position = DocView.resolve_screen_position
-function DocView:resolve_screen_position(x, y)
-  if not self.wrapped_settings then return old_resolve_screen_position(self, x, y) end
-  local ox, oy = self:get_line_screen_position(1)
-  local idx = common.clamp(math.floor((y - oy) / self:get_line_height()) + 1, 1, get_total_wrapped_lines(self))
-  return get_line_col_from_index_and_x(self, idx, x - ox)
 end
 
 local old_draw_line_text = DocView.draw_line_text

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -528,6 +528,27 @@ function DocView:get_col_x_offset(line, col, line_end)
 end
 
 local old_draw_line_text = DocView.draw_line_text
+local function get_search_selections(doc, line)
+  local selections = {}
+  for _, line1, col1, line2, col2 in doc:get_selections(true) do
+    if line == line1 and line <= line2
+      and doc:is_search_selection(line1, col1, line2, col2)
+    then
+      selections[#selections + 1] = { start = col1, stop = col2 }
+    end
+  end
+  return selections
+end
+
+local function is_search_selected(selections, col)
+  for _, selection in ipairs(selections) do
+    if col >= selection.start and col < selection.stop then
+      return true
+    end
+  end
+  return false
+end
+
 function DocView:draw_line_text(line, x, y)
   if not self.wrapped_settings then return old_draw_line_text(self, line, x, y) end
   local default_font = self:get_font()
@@ -536,6 +557,7 @@ function DocView:draw_line_text(line, x, y)
   local idx, _, count = get_line_idx_col_count(self, line)
   local total_offset = 1
   local _, indent_size = self.doc:get_indent_info()
+  local search_selections = get_search_selections(self.doc, line)
   default_font:set_tab_size(indent_size)
   for _, type, text in self.doc.highlighter:each_token(line) do
     local color = style.syntax[type] or style.syntax["normal"]
@@ -550,7 +572,25 @@ function DocView:draw_line_text(line, x, y)
       end
       local max_length = next_line_start_col - total_offset
       local rendered_text = text:sub(token_offset, token_offset + max_length - 1)
-      tx = renderer.draw_text(font, rendered_text, tx, ty, color, { tab_offset = tx - x })
+      if #search_selections == 0 then
+        tx = renderer.draw_text(font, rendered_text, tx, ty, color, { tab_offset = tx - x })
+      else
+        local i = 1
+        local rendered_col = total_offset
+        while i <= #rendered_text do
+          local chunk_start = i
+          local selected = is_search_selected(search_selections, rendered_col)
+          while i <= #rendered_text
+            and is_search_selected(search_selections, rendered_col) == selected
+          do
+            i = i + 1
+            rendered_col = rendered_col + 1
+          end
+          local chunk = rendered_text:sub(chunk_start, i - 1)
+          local chunk_color = selected and (style.search_selection_text or style.background) or color
+          tx = renderer.draw_text(font, chunk, tx, ty, chunk_color, { tab_offset = tx - x })
+        end
+      end
       total_offset = total_offset + #rendered_text
       if total_offset ~= next_line_start_col or max_length == 0 then break end
       token_offset = token_offset + #rendered_text
@@ -568,6 +608,10 @@ function DocView:draw_line_body(line, x, y)
   local idx0, _, count = get_line_idx_col_count(self, line)
   for lidx, line1, col1, line2, col2 in self.doc:get_selections(true) do
     if line >= line1 and line <= line2 then
+      local selection_color = style.selection
+      if self.doc:is_search_selection(line1, col1, line2, col2) then
+        selection_color = style.search_selection or style.caret
+      end
       if line1 ~= line then col1 = 1 end
       if line2 ~= line then col2 = #self.doc.lines[line] + 1 end
       if col1 ~= col2 then
@@ -582,7 +626,7 @@ function DocView:draw_line_body(line, x, y)
             start = start + get_idx_line_length(self, i, line)
             x2 = x + self:get_col_x_offset(line, start + 1, true)
           end
-          renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, style.selection)
+          renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, selection_color)
         end
       end
     end

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -335,11 +335,17 @@ function DocView:get_line_wraps(line)
   return starts
 end
 
+local old_has_variable_visual_lines = DocView.has_variable_visual_lines
+function DocView:has_variable_visual_lines()
+  return self.wrapped_settings ~= nil or old_has_variable_visual_lines(self)
+end
+
 function DocView:get_visual_line_col_from_x(row, x)
   if not self.wrapped_settings then
     return self:get_x_offset_col(self:visual_position_from_row(row), x)
   end
-  return get_line_col_from_index_and_x(self, row, x)
+  local _, col = get_line_col_from_index_and_x(self, row, x)
+  return col
 end
 
 function get_line_col_from_index_and_x(docview, idx, x)
@@ -615,18 +621,25 @@ function DocView:draw_line_body(line, x, y)
       if line1 ~= line then col1 = 1 end
       if line2 ~= line then col2 = #self.doc.lines[line] + 1 end
       if col1 ~= col2 then
-        local idx1, ncol1 = get_line_idx_col_count(self, line, col1)
-        local idx2, ncol2 = get_line_idx_col_count(self, line, col2)
-        local start = 0
+        local idx1 = get_line_idx_col_count(self, line, col1)
+        local idx2 = get_line_idx_col_count(self, line, col2, true)
         for i = idx1, idx2 do
-          local x1, x2 = x + (idx1 == i and self:get_col_x_offset(line1, col1) or 0)
-          if idx2 == i then
-            x2 = x + self:get_col_x_offset(line, col2)
-          else
-            start = start + get_idx_line_length(self, i, line)
-            x2 = x + self:get_col_x_offset(line, start + 1, true)
+          local row_line, row_col = get_idx_line_col(self, i)
+          if row_line ~= line then goto continue end
+
+          local next_line, next_col = get_idx_line_col(self, i + 1)
+          local row_end_col = next_line == line and next_col or #self.doc.lines[line] + 1
+          local start_col = math.max(col1, row_col)
+          local end_col = math.min(col2, row_end_col)
+          if start_col < end_col then
+            local x1 = x + self:get_col_x_offset(line, start_col)
+            local x2 = x + self:get_col_x_offset(line, end_col, end_col == row_end_col)
+            renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, selection_color)
+          elseif start_col == end_col and col1 == col2 then
+            local x1 = x + self:get_col_x_offset(line, start_col)
+            renderer.draw_rect(x1, y + (i - idx0) * lh, 0, lh, selection_color)
           end
-          renderer.draw_rect(x1, y + (i - idx0) * lh, x2 - x1, lh, selection_color)
+          ::continue::
         end
       end
     end

--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -1069,6 +1069,7 @@ function ResultsView:open_selected_result()
     previous_view = dv
     core.root_view.root_node:update_layout()
     local l, c1, c2 = item.line.line, item.position.col1, item.position.col2+1
+    dv:ensure_line_visible(l)
     dv.doc:set_selection(l, c2, l, c1)
     dv.doc:add_search_selection(l, c2, l, c1)
     dv:scroll_to_make_visible(l, c1, true)

--- a/data/plugins/search_ui.lua
+++ b/data/plugins/search_ui.lua
@@ -407,8 +407,10 @@ local function find(reverse, not_scroll, unselect_first, no_wrap)
         text = text:ulower()
       end
       if reverse or (current_text == text or current_text == "") then
+        doc_view:ensure_line_visible(line1)
         doc:set_selection(line1, col2, line2, col1)
       else
+        doc_view:ensure_line_visible(line1)
         doc:set_selection(line1, col1, line2, col2)
       end
       if not not_scroll then

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('pragtical',
     ['c', 'cpp'],
-    version : '3.10.1',
+    version : '3.11.0',
     license : 'MIT',
     meson_version : '>= 0.63',
     default_options : [

--- a/scripts/lua/tests/docview.lua
+++ b/scripts/lua/tests/docview.lua
@@ -1,6 +1,7 @@
 local test = require "core.test"
 local Doc = require "core.doc"
 local DocView = require "core.docview"
+local style = require "core.style"
 
 local function make_view(text)
   local doc = Doc(nil, nil, true)
@@ -46,6 +47,24 @@ local function with_draw_text(fn)
   if not ok then error(err, 0) end
 end
 
+local function with_draw_rect(fn)
+  local original = renderer.draw_rect
+  local calls = {}
+  renderer.draw_rect = function(x, y, w, h, color)
+    calls[#calls + 1] = {
+      x = x,
+      y = y,
+      w = w,
+      h = h,
+      color = color
+    }
+  end
+
+  local ok, err = pcall(fn, calls)
+  renderer.draw_rect = original
+  if not ok then error(err, 0) end
+end
+
 local function scan_x_offset_col(view, line, x)
   local line_text = view.doc.lines[line]
   local line_len = #line_text
@@ -63,6 +82,48 @@ local function scan_x_offset_col(view, line, x)
 end
 
 test.describe("docview", function()
+  test.test("ensure_line_visible returns the requested line by default", function()
+    local view = make_view("line\n")
+
+    test.equal(view:ensure_line_visible(1), 1)
+  end)
+
+  test.test("draw_line_body uses search colors for search selections", function()
+    local view = make_view("aaaa search\n")
+    local col1 = view.doc.lines[1]:find("search", 1, true)
+    local col2 = col1 + #"search"
+    view.doc:set_selection(1, col1, 1, col2)
+    view.doc:add_search_selection(1, col1, 1, col2)
+
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function(text_calls)
+      with_draw_rect(function(rect_calls)
+        view:draw_line_body(1, x, y)
+
+        local expected_rect_color = style.search_selection or style.caret
+        local found_rect = false
+        for _, call in ipairs(rect_calls) do
+          if call.color == expected_rect_color then
+            found_rect = true
+            break
+          end
+        end
+        test.ok(found_rect)
+
+        local expected_text_color = style.search_selection_text or style.background
+        local found_text = false
+        for _, call in ipairs(text_calls) do
+          if call.color == expected_text_color then
+            found_text = true
+            break
+          end
+        end
+        test.ok(found_text)
+      end)
+    end)
+  end)
+
   test.test("draw_line_text slices long lines to the visible range", function()
     local line = string.rep("var a = 1; ", 2000)
     local view = make_view(line)

--- a/scripts/lua/tests/docview.lua
+++ b/scripts/lua/tests/docview.lua
@@ -88,6 +88,30 @@ test.describe("docview", function()
     test.equal(view:ensure_line_visible(1), 1)
   end)
 
+  test.test("plain documents use identity visual lines", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "one\n",
+      "two\n",
+      "three\n"
+    }
+    doc.cache.col_x = {}
+    doc.cache.ulen = {}
+    doc.highlighter:reset()
+
+    local view = DocView(doc)
+    view:rebuild_visual_lines()
+
+    test.ok(view:get_visual_lines().identity)
+    test.equal(view:visual_line_count(), 3)
+    test.equal(view:visual_position_from_row(2), 2)
+    test.equal(view:visual_row_from_position(3, 1), 3)
+    local row, row_count = view:visual_rows_for_line(2)
+    test.equal(row, 2)
+    test.equal(row_count, 1)
+    test.ok(view:is_line_visible(3))
+  end)
+
   test.test("visual line rebuild keeps rows before invalidated line", function()
     local doc = Doc(nil, nil, true)
     doc.lines = {

--- a/scripts/lua/tests/docview.lua
+++ b/scripts/lua/tests/docview.lua
@@ -88,6 +88,36 @@ test.describe("docview", function()
     test.equal(view:ensure_line_visible(1), 1)
   end)
 
+  test.test("visual line rebuild keeps rows before invalidated line", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "one\n",
+      "two\n",
+      "three\n",
+      "four\n"
+    }
+    doc.cache.col_x = {}
+    doc.cache.ulen = {}
+    doc.highlighter:reset()
+
+    local view = DocView(doc)
+    view:rebuild_visual_lines()
+
+    local queried = {}
+    view.get_line_wraps = function(_, line)
+      queried[line] = true
+      return nil
+    end
+
+    view:invalidate_visual_lines(3)
+    view:get_visual_lines()
+
+    test.is_nil(queried[1])
+    test.is_nil(queried[2])
+    test.ok(queried[3])
+    test.ok(queried[4])
+  end)
+
   test.test("draw_line_body uses search colors for search selections", function()
     local view = make_view("aaaa search\n")
     local col1 = view.doc.lines[1]:find("search", 1, true)

--- a/scripts/lua/tests/http.lua
+++ b/scripts/lua/tests/http.lua
@@ -180,8 +180,21 @@ class Handler(BaseHTTPRequestHandler):
         self._handle_body_request()
 
 
-server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-print(server.server_address[1], flush=True)
+port_path = sys.argv[1] if len(sys.argv) > 1 else None
+try:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+except PermissionError as exc:
+    if port_path:
+        with open(port_path, "w", encoding="utf-8") as fp:
+            fp.write("SKIP:" + str(exc))
+        sys.exit(0)
+    raise
+
+if port_path:
+    with open(sys.argv[1], "w", encoding="utf-8") as fp:
+        fp.write(str(server.server_address[1]))
+else:
+    print(server.server_address[1], flush=True)
 
 try:
     server.serve_forever()
@@ -206,11 +219,40 @@ local function read_file(path)
   return content
 end
 
-local function python_command(script_path)
+local function python_command(script_path, port_path)
   if PLATFORM == "Windows" then
-    return { "python", "-u", script_path }
+    return { "python", "-u", script_path, port_path }
   end
-  return { "python3", "-u", script_path }
+  return { "python3", "-u", script_path, port_path }
+end
+
+local function read_server_port(proc, port_path, label)
+  local deadline = system.get_time() + 5
+  while system.get_time() < deadline do
+    local file = io.open(port_path, "rb")
+    if file then
+      local content = file:read("*a")
+      file:close()
+      if content:find("^SKIP:") then
+        test.skip_now(label .. " test server cannot create local sockets")
+      end
+      local port = tonumber(content)
+      test.type(port, "number")
+      return port
+    end
+    if not proc:running() then
+      break
+    end
+    system.sleep(0.01)
+  end
+
+  proc:wait(1000, 0.01)
+  local stderr = proc.stderr:read("all") or ""
+  if stderr:find("Operation not permitted", 1, true) then
+    test.skip_now(label .. " test server cannot create local sockets")
+  end
+  local suffix = stderr ~= "" and (": " .. stderr) or ""
+  test.fail(label .. " test server did not report a port" .. suffix, 2)
 end
 
 local function wait_until(predicate, timeout, message)
@@ -236,10 +278,11 @@ end
 
 local function start_http_server(context)
   local script_path = context.temp_root .. PATHSEP .. "http_test_server.py"
+  local port_path = context.temp_root .. PATHSEP .. "http_test_server.port"
   write_file(script_path, HTTP_SERVER_SCRIPT)
   context.server_script_paths[#context.server_script_paths + 1] = script_path
 
-  local proc = process.start(python_command(script_path), {
+  local proc = process.start(python_command(script_path, port_path), {
     stdout = process.REDIRECT_PIPE,
     stderr = process.REDIRECT_PIPE,
   })
@@ -247,14 +290,7 @@ local function start_http_server(context)
 
   context.server_processes[#context.server_processes + 1] = proc
 
-  local line = proc.stdout:read("line", {
-    timeout = 5,
-    scan = 0.01,
-  })
-  test.not_nil(line, "HTTP test server did not report a port")
-
-  local port = tonumber(line)
-  test.type(port, "number")
+  local port = read_server_port(proc, port_path, "HTTP")
   return "http://127.0.0.1:" .. port
 end
 

--- a/scripts/lua/tests/linewrapping.lua
+++ b/scripts/lua/tests/linewrapping.lua
@@ -251,7 +251,9 @@ test.describe("linewrapping", function()
 
   test.test("folded hidden lines do not contribute wrapped rows", function()
     local previous_codefold = config.plugins.codefold.enabled
+    local previous_hide_tail = config.plugins.codefold.hide_tail_on_fold
     config.plugins.codefold.enabled = true
+    config.plugins.codefold.hide_tail_on_fold = false
 
     local doc = Doc(nil, nil, true)
     doc.lines = {
@@ -296,5 +298,6 @@ test.describe("linewrapping", function()
     test.ok(view:get_line_visual_height(5) > view:get_line_height())
 
     config.plugins.codefold.enabled = previous_codefold
+    config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
   end)
 end)

--- a/scripts/lua/tests/linewrapping.lua
+++ b/scripts/lua/tests/linewrapping.lua
@@ -2,6 +2,9 @@ local test = require "core.test"
 local Doc = require "core.doc"
 local DocView = require "core.docview"
 local LineWrapping = require "plugins.linewrapping"
+local config = require "core.config"
+require "plugins.codefold"
+dofile("subprojects/plugins/plugins/indentguide.lua")
 
 local function make_view(text)
   local doc = Doc(nil, nil, true)
@@ -39,6 +42,24 @@ local function with_draw_text(fn)
   if not ok then error(err, 0) end
 end
 
+local function with_draw_rect(fn)
+  local original = renderer.draw_rect
+  local calls = {}
+  renderer.draw_rect = function(x, y, w, h, color)
+    calls[#calls + 1] = {
+      x = x,
+      y = y,
+      w = w,
+      h = h,
+      color = color
+    }
+  end
+
+  local ok, err = pcall(fn, calls)
+  renderer.draw_rect = original
+  if not ok then error(err, 0) end
+end
+
 test.describe("linewrapping", function()
   test.test("draw_line_text keeps final wrapped segment", function()
     local view = make_view("abcdef")
@@ -57,5 +78,180 @@ test.describe("linewrapping", function()
       end
       test.equal(table.concat(text), "abcdef")
     end)
+  end)
+
+  test.test("position helpers map wrapped rows and document lines", function()
+    local view = make_view("abcdef")
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("ab"))
+
+    local line, col = view:position_from_offset(2)
+    test.equal(line, 1)
+    test.ok(col > 1)
+
+    local first_offset = view:offset_from_position(1, 1)
+    local end_offset = view:offset_from_position(2, 1)
+    test.equal(first_offset, 1)
+    test.ok(end_offset > first_offset)
+  end)
+
+  test.test("visible line helpers expose wrapped rows", function()
+    local view = make_view("abcdef")
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("ab"))
+
+    local rows = {}
+    for offset, line, col in view:each_visible_line() do
+      rows[#rows + 1] = { offset = offset, line = line, col = col }
+    end
+
+    test.ok(#rows > 1)
+    test.equal(rows[1].offset, 1)
+    test.equal(rows[1].line, 1)
+    test.equal(rows[1].col, 1)
+    test.equal(view:get_line_visual_height(1), #rows * view:get_line_height())
+  end)
+
+  test.test("indent guides cover all wrapped visual rows", function()
+    local previous = config.plugins.indentguide.enabled
+    config.plugins.indentguide.enabled = true
+
+    local view = make_view("  abcdefghij")
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("  abc"))
+    view.indentguide_indents[1] = 2
+
+    local expected_height = (view:offset_from_position(2, 1) - view:offset_from_position(1, 1))
+      * view:get_line_height()
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function()
+      with_draw_rect(function(calls)
+        view:draw_line_text(1, x, y)
+        test.ok(#calls > 0)
+        test.equal(calls[1].h, expected_height)
+      end)
+    end)
+
+    config.plugins.indentguide.enabled = previous
+  end)
+
+  test.test("color previews use wrapped row coordinates", function()
+    dofile("subprojects/plugins/plugins/colorpreview.lua")
+    local previous = config.plugins.colorpreview.enabled
+    local previous_mode = config.plugins.colorpreview.mode
+    config.plugins.colorpreview.enabled = true
+    config.plugins.colorpreview.mode = "background"
+    config.plugins.indentguide.enabled = false
+
+    local text = "aaaa #ff0000"
+    local view = make_view(text)
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("aaaa "))
+
+    local color_col = text:find("#ff0000", 1, true)
+    local _, expected_y = view:get_line_screen_position(1, color_col)
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function()
+      with_draw_rect(function(calls)
+        view:draw_line_text(1, x, y)
+
+        local found = false
+        for _, call in ipairs(calls) do
+          if call.y == expected_y and call.h == view:get_line_height() then
+            found = true
+            break
+          end
+        end
+        test.ok(found)
+      end)
+    end)
+
+    config.plugins.colorpreview.enabled = previous
+    config.plugins.colorpreview.mode = previous_mode
+  end)
+
+  test.test("selection highlights use wrapped row coordinates", function()
+    dofile("subprojects/plugins/plugins/selectionhighlight.lua")
+    if config.plugins.colorpreview then
+      config.plugins.colorpreview.enabled = false
+    end
+    config.plugins.indentguide.enabled = false
+
+    local text = "foo aaaa foo"
+    local view = make_view(text)
+    view.doc:set_selection(1, 1, 1, 4)
+
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("foo aaaa "))
+
+    local match_col = text:find("foo", 5, true)
+    local _, expected_y = view:get_line_screen_position(1, match_col)
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function()
+      with_draw_rect(function(calls)
+        view:draw_line_body(1, x, y)
+
+        local found = false
+        for _, call in ipairs(calls) do
+          if call.y == expected_y then
+            found = true
+            break
+          end
+        end
+        test.ok(found)
+      end)
+    end)
+  end)
+
+  test.test("folded hidden lines do not contribute wrapped rows", function()
+    local previous_codefold = config.plugins.codefold.enabled
+    config.plugins.codefold.enabled = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "fold\n",
+      "hidden hidden hidden hidden\n",
+      "hidden hidden hidden hidden\n",
+      "abcdef\n",
+    }
+    doc.cache.col_x = {}
+    doc.cache.ulen = {}
+    doc.highlighter:reset()
+
+    local view = DocView(doc)
+    view.position.x = 0
+    view.position.y = 0
+    view.size.x = 320
+    view.size.y = 200
+    view.cf_regions = { { start = 2, stop = 4 } }
+    view.cf_folded_regions = { 1 }
+    view.cf_fold_map = { 1, 2, 5 }
+    view.cf_unfold_map = { 1, 2, nil, nil, 3 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("ab"))
+
+    local rows = {}
+    for offset, line, col in view:each_visible_line() do
+      rows[#rows + 1] = { line = line, col = col }
+    end
+
+    test.equal(rows[1].line, 1)
+    test.equal(rows[2].line, 2)
+    local saw_line5 = false
+    for _, row in ipairs(rows) do
+      test.ok(row.line ~= 3 and row.line ~= 4)
+      saw_line5 = saw_line5 or row.line == 5
+    end
+    test.ok(saw_line5)
+    test.ok(view:get_line_visual_height(5) > view:get_line_height())
+
+    config.plugins.codefold.enabled = previous_codefold
   end)
 end)

--- a/scripts/lua/tests/linewrapping.lua
+++ b/scripts/lua/tests/linewrapping.lua
@@ -96,6 +96,23 @@ test.describe("linewrapping", function()
     test.ok(end_offset > first_offset)
   end)
 
+  test.test("screen position resolves columns on wrapped rows", function()
+    local view = make_view("abcdef")
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("ab"))
+
+    local x, y = view:get_content_offset()
+    local gw = view:get_gutter_width()
+    local lh = view:get_line_height()
+    local line, col = view:resolve_screen_position(
+      x + gw,
+      y + style.padding.y + lh
+    )
+
+    test.equal(line, 1)
+    test.equal(col, 3)
+  end)
+
   test.test("visible line helpers expose wrapped rows", function()
     local view = make_view("abcdef")
     local font = view:get_font()
@@ -203,6 +220,37 @@ test.describe("linewrapping", function()
           end
         end
         test.ok(found)
+      end)
+    end)
+  end)
+
+  test.test("line selections span later wrapped rows", function()
+    config.plugins.indentguide.enabled = false
+
+    local view = make_view("abcdefghijkl")
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("abc"))
+
+    view.doc:set_selection(1, 4, 1, 12)
+    local start_row = view:visual_row_from_position(1, 4)
+    local end_row = view:visual_row_from_position(1, 12)
+    local expected_rows = end_row - start_row + 1
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function()
+      with_draw_rect(function(calls)
+        view:draw_line_body(1, x, y)
+
+        local selected_rows = {}
+        for _, call in ipairs(calls) do
+          if call.color == style.selection and call.w > 0 then
+            selected_rows[call.y] = true
+          end
+        end
+
+        local count = 0
+        for _ in pairs(selected_rows) do count = count + 1 end
+        test.equal(count, expected_rows)
       end)
     end)
   end)

--- a/scripts/lua/tests/linewrapping.lua
+++ b/scripts/lua/tests/linewrapping.lua
@@ -3,6 +3,7 @@ local Doc = require "core.doc"
 local DocView = require "core.docview"
 local LineWrapping = require "plugins.linewrapping"
 local config = require "core.config"
+local style = require "core.style"
 require "plugins.codefold"
 dofile("subprojects/plugins/plugins/indentguide.lua")
 
@@ -202,6 +203,48 @@ test.describe("linewrapping", function()
           end
         end
         test.ok(found)
+      end)
+    end)
+  end)
+
+  test.test("search selections keep search colors on wrapped rows", function()
+    config.plugins.indentguide.enabled = false
+
+    local text = "aaaa search\n"
+    local view = make_view(text)
+    local font = view:get_font()
+    LineWrapping.reconstruct_breaks(view, font, font:get_width("aaaa "))
+
+    local col1 = text:find("search", 1, true)
+    local col2 = col1 + #"search"
+    view.doc:set_selection(1, col1, 1, col2)
+    view.doc:add_search_selection(1, col1, 1, col2)
+
+    local x, y = view:get_line_screen_position(1)
+
+    with_draw_text(function(text_calls)
+      with_draw_rect(function(rect_calls)
+        view:draw_line_body(1, x, y)
+
+        local expected_rect_color = style.search_selection or style.caret
+        local found_rect = false
+        for _, call in ipairs(rect_calls) do
+          if call.color == expected_rect_color then
+            found_rect = true
+            break
+          end
+        end
+        test.ok(found_rect)
+
+        local expected_text_color = style.search_selection_text or style.background
+        local found_text = false
+        for _, call in ipairs(text_calls) do
+          if call.color == expected_text_color then
+            found_text = true
+            break
+          end
+        end
+        test.ok(found_text)
       end)
     end)
   end)

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -10,6 +10,24 @@ local common = require "core.common"
 local style = require "core.style"
 local syntax = require "core.syntax"
 
+local source_path = debug.getinfo(1, "S").source:gsub("^@", "")
+local source_root = common.dirname(
+  common.dirname(common.dirname(common.dirname(source_path)))
+)
+
+local function dofile_from_source(relative_path)
+  local candidates = {
+    relative_path,
+    source_root .. PATHSEP .. relative_path
+  }
+  for _, path in ipairs(candidates) do
+    if system.get_file_info(path) then
+      return dofile(path)
+    end
+  end
+  error("cannot find test helper: " .. relative_path, 2)
+end
+
 local function write_file(path, content)
   local file, err = io.open(path, "wb")
   test.not_nil(file, err)
@@ -64,7 +82,7 @@ local function make_c_doc(lines)
 end
 
 local function make_php_doc(lines)
-  dofile("subprojects/plugins/plugins/language_php.lua")
+  dofile_from_source("subprojects/plugins/plugins/language_php.lua")
   local doc = Doc(nil, nil, true)
   doc.syntax = syntax.get("test.php")
   doc.lines = lines
@@ -672,7 +690,7 @@ test.describe("codefold - virtual line mapping", function()
   test.test("indentguide caches visible folded real lines", function()
     local config = require "core.config"
     require "plugins.codefold"
-    dofile("subprojects/plugins/plugins/indentguide.lua")
+    dofile_from_source("subprojects/plugins/plugins/indentguide.lua")
 
     local previous = config.plugins.indentguide.enabled
     local previous_highlight = config.plugins.indentguide.highlight
@@ -711,7 +729,7 @@ test.describe("codefold - virtual line mapping", function()
   test.test("indentguide active range uses visible offsets", function()
     local config = require "core.config"
     require "plugins.codefold"
-    dofile("subprojects/plugins/plugins/indentguide.lua")
+    dofile_from_source("subprojects/plugins/plugins/indentguide.lua")
 
     local previous = config.plugins.indentguide.enabled
     local previous_highlight = config.plugins.indentguide.highlight
@@ -765,7 +783,7 @@ test.describe("codefold - virtual line mapping", function()
   test.test("smooth caret visibility uses visible offsets", function()
     local config = require "core.config"
     require "plugins.codefold"
-    dofile("subprojects/plugins/plugins/smoothcaret.lua")
+    dofile_from_source("subprojects/plugins/plugins/smoothcaret.lua")
 
     local previous_enabled = config.plugins.smoothcaret.enabled
     local previous_active_view = core.active_view

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -1,0 +1,788 @@
+-- Test script for codefold.lua core logic
+-- Tests fold region detection, toggle, fold-all, unfold-all, translate functions
+local test = require "core.test"
+local Doc = require "core.doc"
+local DocView = require "core.docview"
+local core = require "core"
+local config = require "core.config"
+local common = require "core.common"
+local style = require "core.style"
+
+local function write_file(path, content)
+  local file, err = io.open(path, "wb")
+  test.not_nil(file, err)
+  file:write(content or "")
+  file:close()
+end
+
+local function with_common_draw_text(fn)
+  local original = common.draw_text
+  local calls = {}
+  common.draw_text = function(font, color, text, align, x, y, w, h)
+    calls[#calls + 1] = {
+      font = font,
+      color = color,
+      text = text,
+      align = align,
+      x = x,
+      y = y,
+      w = w,
+      h = h
+    }
+    return x + font:get_width(tostring(text))
+  end
+
+  local ok, err = pcall(fn, calls)
+  common.draw_text = original
+  if not ok then error(err, 0) end
+end
+
+local function make_docview(lines)
+  local doc = Doc(nil, nil, true)
+  doc.lines = lines
+  doc:reset_syntax()
+
+  local view = DocView(doc)
+  view.position.x = 0
+  view.position.y = 0
+  view.size.x = 320
+  view.size.y = 200
+  view.indentguide_indents = {}
+  view.indentguide_indent_active = {}
+  return view
+end
+
+-- Helper: compute line indent (same logic as in codefold.lua)
+local function get_line_indent(doc, line, indent_size, dir)
+  if line < 1 or line > #doc.lines then return -1 end
+  local text = doc.lines[line]
+  if not text or text == "\n" or text == "" then
+    if dir then return get_line_indent(doc, line + dir, indent_size, dir) end
+    return -1
+  end
+  local s, e = text:find("^%s*")
+  if e == #text then
+    if dir then return get_line_indent(doc, line + dir, indent_size, dir) end
+    return -1
+  end
+  local n = 0
+  for b in text:sub(s, e):gmatch(".") do
+    n = n + (b == "\t" and indent_size or 1)
+  end
+  return n
+end
+
+local function get_effective_indent(doc, line, indent_size)
+  local indent = get_line_indent(doc, line, indent_size)
+  if indent >= 0 then return indent end
+  local above = get_line_indent(doc, line - 1, indent_size, -1)
+  local below = get_line_indent(doc, line + 1, indent_size, 1)
+  if above >= 0 and below >= 0 then return math.max(above, below) end
+  return above >= 0 and above or below
+end
+
+-- Helper: detect fold regions
+local function detect_fold_regions(doc)
+  local _, indent_size = doc:get_indent_info()
+  local regions = {}
+  local line_count = #doc.lines
+  local line = 1
+  while line <= line_count do
+    local indent = get_effective_indent(doc, line, indent_size)
+    if indent < 0 then
+      line = line + 1
+    else
+      local next_line = line + 1
+      if next_line > line_count then break end
+      local next_indent = get_effective_indent(doc, next_line, indent_size)
+      if next_indent > indent then
+        local stop = next_line
+        while stop < line_count do
+          local peek_indent = get_effective_indent(doc, stop + 1, indent_size)
+          if peek_indent < 0 then
+            stop = stop + 1
+          elseif peek_indent <= indent then
+            break
+          else
+            stop = stop + 1
+          end
+        end
+        regions[#regions + 1] = { indent = indent, start = line, stop = stop }
+      end
+      line = line + 1
+    end
+  end
+  return regions
+end
+
+-- Helper: build fold_map/unfold_map
+local function build_maps(doc_lines, regions, folded_indices)
+  local hidden = {}
+  for _, ri in ipairs(folded_indices) do
+    local region = regions[ri]
+    for l = region.start + 1, region.stop do
+      hidden[l] = true
+    end
+  end
+  local fold_map = {}
+  local unfold_map = {}
+  for real = 1, #doc_lines do
+    if not hidden[real] then
+      local virtual = #fold_map + 1
+      fold_map[virtual] = real
+      unfold_map[real] = virtual
+    else
+      unfold_map[real] = nil
+    end
+  end
+  return fold_map, unfold_map
+end
+
+test.describe("codefold - region detection", function()
+  test.test("detects flat regions", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "line1\n",    -- 1, indent 0
+      "  line2\n",   -- 2, indent 2
+      "  line3\n",   -- 3, indent 2
+      "line4\n",     -- 4, indent 0
+      "  line5\n",   -- 5, indent 2
+      "    line6\n", -- 6, indent 4
+      "  line7\n",   -- 7, indent 2
+      "line8\n",     -- 8, indent 0
+    }
+    doc:reset_syntax()
+
+    local regions = detect_fold_regions(doc)
+    test.equal(#regions, 3, "expected 3 regions")
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 3)
+    test.equal(regions[2].start, 4)
+    test.equal(regions[2].stop, 7)
+    test.equal(regions[3].start, 5)
+    test.equal(regions[3].stop, 6)
+  end)
+
+  test.test("detects nested regions", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "line1\n",
+      "  line2\n",
+      "    line3\n",
+      "      line4\n",
+      "    line5\n",
+      "  line6\n",
+      "line7\n",
+    }
+    doc:reset_syntax()
+
+    local regions = detect_fold_regions(doc)
+    test.equal(#regions, 3, "expected 3 regions")
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 6)
+    test.equal(regions[2].start, 2)
+    test.equal(regions[2].stop, 5)
+    test.equal(regions[3].start, 3)
+    test.equal(regions[3].stop, 4)
+  end)
+
+  test.test("handles empty/blank lines", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "line1\n",
+      "  line2\n",
+      "\n",
+      "  line4\n",
+      "line5\n",
+    }
+    doc:reset_syntax()
+
+    local regions = detect_fold_regions(doc)
+    test.equal(#regions, 1, "expected 1 region")
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 4)
+  end)
+
+  test.test("tab-indented lines", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "line1\n",
+      "\tline2\n",
+      "\t\tline3\n",
+      "\tline4\n",
+      "line5\n",
+    }
+    doc:reset_syntax()
+
+    local regions = detect_fold_regions(doc)
+    test.equal(#regions, 2, "expected 2 regions")
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 4)
+    test.equal(regions[2].start, 2)
+    test.equal(regions[2].stop, 3)
+  end)
+end)
+
+test.describe("codefold - virtual line mapping", function()
+  test.test("identity mapping when no folds", function()
+    local regions = {
+      { start = 2, stop = 3 },
+    }
+    local fold_map, unfold_map = build_maps(
+      { "line1\n", "line2\n", "line3\n", "line4\n" },
+      regions,
+      {} -- nothing folded
+    )
+    test.equal(#fold_map, 4)
+    test.equal(fold_map[1], 1)
+    test.equal(fold_map[2], 2)
+    test.equal(unfold_map[2], 2)
+  end)
+
+  test.test("fold one region", function()
+    local regions = {
+      { start = 2, stop = 3 },
+    }
+    local fold_map, unfold_map = build_maps(
+      { "line1\n", "line2\n", "line3\n", "line4\n" },
+      regions,
+      { 1 } -- region 1 folded
+    )
+    test.equal(#fold_map, 3)
+    test.equal(fold_map[1], 1)   -- line1
+    test.equal(fold_map[2], 2)   -- line2 (fold header)
+    test.equal(fold_map[3], 4)   -- line4
+
+    test.equal(unfold_map[1], 1)
+    test.equal(unfold_map[2], 2)
+    test.equal(unfold_map[3], nil) -- hidden
+    test.equal(unfold_map[4], 3)   -- shifted
+  end)
+
+  test.test("fold nested regions", function()
+    local regions = {
+      { start = 2, stop = 6 },  -- outer
+      { start = 3, stop = 5 },  -- inner
+    }
+    local fold_map, unfold_map = build_maps(
+      { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n", "line6\n", "line7\n" },
+      regions,
+      { 1, 2 } -- both folded
+    )
+    -- outer: hides 3-6, inner: hides 4-5
+    -- visible: 1, 2 (outer header), 7
+    test.equal(#fold_map, 3, "both folded gives 3 visible lines")
+    test.equal(fold_map[1], 1)
+    test.equal(fold_map[2], 2)   -- outer header
+    test.equal(fold_map[3], 7)
+
+    test.equal(unfold_map[3], nil) -- hidden by outer
+    test.equal(unfold_map[4], nil) -- hidden by both
+    test.equal(unfold_map[5], nil) -- hidden by both
+    test.equal(unfold_map[6], nil) -- hidden by outer
+    test.equal(unfold_map[7], 3)
+  end)
+
+  test.test("fold only inner region", function()
+    local regions = {
+      { start = 2, stop = 6 },  -- outer
+      { start = 3, stop = 5 },  -- inner
+    }
+    local fold_map, unfold_map = build_maps(
+      { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n", "line6\n", "line7\n" },
+      regions,
+      { 2 } -- only inner folded
+    )
+    test.equal(#fold_map, 5)
+    test.equal(fold_map[1], 1)
+    test.equal(fold_map[2], 2)
+    test.equal(fold_map[3], 3)  -- inner header
+    test.equal(fold_map[4], 6)  -- still in outer
+    test.equal(fold_map[5], 7)
+
+    test.equal(unfold_map[3], 3)
+    test.equal(unfold_map[4], nil) -- hidden by inner
+    test.equal(unfold_map[5], nil) -- hidden by inner
+    test.equal(unfold_map[6], 4)   -- visible (open outer)
+    test.equal(unfold_map[7], 5)
+  end)
+
+  test.test("unfold after fold", function()
+    local regions = {
+      { start = 2, stop = 4 },
+    }
+    local _, unfold_map = build_maps(
+      { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n" },
+      regions,
+      { 1 }
+    )
+    test.equal(unfold_map[3], nil) -- hidden
+
+    local fold_map2, unfold_map2 = build_maps(
+      { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n" },
+      regions,
+      {} -- unfolded
+    )
+    test.equal(#fold_map2, 5)
+    test.equal(unfold_map2[3], 3) -- visible again
+  end)
+
+  test.test("DocView position helpers use fold maps", function()
+    require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = { "a\n", "b\n", "c\n", "d\n", "e\n" }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = { { start = 2, stop = 4 } }
+    view.cf_folded_regions = { 1 }
+    view.cf_fold_map = { 1, 2, 5 }
+    view.cf_unfold_map = { 1, 2, nil, nil, 3 }
+
+    local line, col = view:position_from_offset(3)
+    test.equal(line, 5)
+    test.equal(col, 1)
+    test.equal(view:offset_from_position(5, 1), 3)
+    test.equal(view:offset_from_position(4, 1), 2)
+  end)
+
+  test.test("indentguide caches visible folded real lines", function()
+    local config = require "core.config"
+    require "plugins.codefold"
+    dofile("subprojects/plugins/plugins/indentguide.lua")
+
+    local previous = config.plugins.indentguide.enabled
+    local previous_highlight = config.plugins.indentguide.highlight
+    config.plugins.indentguide.enabled = true
+    config.plugins.indentguide.highlight = false
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = { "a\n", "  b\n", "    c\n", "  d\n", "  e\n" }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.position.x = 0
+    view.position.y = 0
+    view.size.x = 320
+    view.size.y = 200
+    view.cf_regions = { { start = 1, stop = 4 } }
+    view.cf_folded_regions = { 1 }
+    view.cf_fold_map = { 1, 5 }
+    view.cf_unfold_map = { 1, nil, nil, nil, 2 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+
+    view:update()
+
+    test.equal(view.indentguide_indents[1], 0)
+    test.equal(view.indentguide_indents[5], 2)
+    test.equal(view.indentguide_indents[2], nil)
+
+    config.plugins.indentguide.enabled = previous
+    config.plugins.indentguide.highlight = previous_highlight
+  end)
+
+  test.test("indentguide active range uses visible offsets", function()
+    local config = require "core.config"
+    require "plugins.codefold"
+    dofile("subprojects/plugins/plugins/indentguide.lua")
+
+    local previous = config.plugins.indentguide.enabled
+    local previous_highlight = config.plugins.indentguide.highlight
+    config.plugins.indentguide.enabled = true
+    config.plugins.indentguide.highlight = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {}
+    for i = 1, 66 do
+      doc.lines[i] = "line\n"
+    end
+    for i = 53, 57 do
+      doc.lines[i] = "  line\n"
+    end
+    doc.lines[58] = "    line\n"
+    doc.lines[59] = "    line\n"
+    doc.lines[60] = "  line\n"
+    doc:reset_syntax()
+    doc:set_selection(55, 1)
+
+    local view = DocView(doc)
+    view.position.x = 0
+    view.position.y = 0
+    view.size.x = 320
+    view.size.y = view:get_line_height() * 80
+    view.cf_regions = { { start = 34, stop = 47 } }
+    view.cf_folded_regions = { 1 }
+    view.cf_fold_map = {}
+    view.cf_unfold_map = {}
+    for line = 1, #doc.lines do
+      if line <= 34 or line > 47 then
+        local offset = #view.cf_fold_map + 1
+        view.cf_fold_map[offset] = line
+        view.cf_unfold_map[line] = offset
+      end
+    end
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+
+    view:update()
+
+    test.equal(#view.cf_fold_map, 53)
+    test.equal(view.indentguide_indent_active[55], 2)
+    test.equal(view.indentguide_indent_active[56], 2)
+    test.equal(view.indentguide_indent_active[57], 2)
+
+    config.plugins.indentguide.enabled = previous
+    config.plugins.indentguide.highlight = previous_highlight
+  end)
+
+  test.test("smooth caret visibility uses visible offsets", function()
+    local config = require "core.config"
+    require "plugins.codefold"
+    dofile("subprojects/plugins/plugins/smoothcaret.lua")
+
+    local previous_enabled = config.plugins.smoothcaret.enabled
+    local previous_active_view = core.active_view
+    config.plugins.smoothcaret.enabled = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {}
+    for i = 1, 66 do
+      doc.lines[i] = "line\n"
+    end
+    doc:reset_syntax()
+    doc:set_selection(55, 1)
+
+    local view = DocView(doc)
+    view.position.x = 0
+    view.position.y = 0
+    view.size.x = 320
+    view.size.y = view:get_line_height() * 80
+    view.cf_fold_map = {}
+    view.cf_unfold_map = {}
+    for line = 1, #doc.lines do
+      if line <= 34 or line > 47 then
+        local offset = #view.cf_fold_map + 1
+        view.cf_fold_map[offset] = line
+        view.cf_unfold_map[line] = offset
+      end
+    end
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+    core.active_view = view
+
+    view:update()
+
+    test.equal(#view.cf_fold_map, 53)
+    test.equal(#view.visible_carets, 1)
+
+    config.plugins.smoothcaret.enabled = previous_enabled
+    core.active_view = previous_active_view
+  end)
+
+  test.test("fold gutter marker color reflects folded and hover state", function()
+    require "plugins.codefold"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    config.plugins.codefold.enabled = true
+
+    local view = make_docview({ "a\n", "  b\n", "c\n" })
+    view.cf_regions = { { indent = 0, start = 1, stop = 2 } }
+    view.cf_folded_regions = {}
+    view.cf_fold_map = { 1, 2, 3 }
+    view.cf_unfold_map = { 1, 2, 3 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+
+    local _, y = view:get_line_screen_position(1)
+    with_common_draw_text(function(calls)
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(calls[#calls].color, style.dim or style.line_number)
+
+      view.cf_folded_regions = { 1 }
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(calls[#calls].color, style.caret)
+
+      view.cf_hovering_toggle = 1
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(calls[#calls].color, style.accent)
+    end)
+
+    config.plugins.codefold.enabled = previous_enabled
+  end)
+
+end)
+
+test.describe("codefold - persistent state", function()
+  local original_project_path
+
+  test.before_each(function(context)
+    original_project_path = core.root_project().path
+    context.project_root = original_project_path
+      .. PATHSEP .. "codefold-tests-"
+      .. system.get_process_id() .. "-"
+      .. math.floor(system.get_time() * 1000000)
+    local ok, err = common.mkdirp(context.project_root .. PATHSEP .. "src")
+    test.ok(ok, err)
+    core.root_project().path = context.project_root
+  end)
+
+  test.after_each(function(context)
+    core.root_project().path = original_project_path
+    if context.project_root and system.get_file_info(context.project_root) then
+      local ok, err = common.rm(context.project_root, true)
+      test.ok(ok, err)
+    end
+  end)
+
+  local function make_named_doc(filename, lines)
+    local abs_filename = core.project_absolute_path(filename)
+    write_file(abs_filename, table.concat(lines))
+    local doc = Doc(filename, abs_filename, false)
+    doc.lines = lines
+    doc:reset_syntax()
+    return doc
+  end
+
+  test.test("saving folded regions creates project-local state", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_named_doc("src/main.lua", {
+      "local function main()\n",
+      "  print('hello')\n",
+      "end\n"
+    })
+    local regions = { { indent = 0, start = 1, stop = 2 } }
+
+    codefold._test.save_fold_state(doc, regions, { 1 })
+
+    local path = codefold._test.state_path_for_doc(doc)
+    test.not_nil(system.get_file_info(path))
+    local state = dofile(path)
+    test.equal(state.path, "src/main.lua")
+    test.equal(#state.folds, 1)
+    test.equal(state.folds[1].line, 1)
+    test.equal(state.folds[1].text, "local function main()\n")
+  end)
+
+  test.test("saving no folded regions removes project state", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_named_doc("src/main.lua", {
+      "local function main()\n",
+      "  print('hello')\n",
+      "end\n"
+    })
+    local regions = { { indent = 0, start = 1, stop = 2 } }
+
+    codefold._test.save_fold_state(doc, regions, { 1 })
+    local path = codefold._test.state_path_for_doc(doc)
+    test.not_nil(system.get_file_info(path))
+
+    codefold._test.save_fold_state(doc, regions, {})
+    test.is_nil(system.get_file_info(path))
+  end)
+
+  test.test("loads saved folds for the same document", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_named_doc("src/main.lua", {
+      "local function main()\n",
+      "  print('hello')\n",
+      "end\n"
+    })
+    local regions = { { indent = 0, start = 1, stop = 2 } }
+
+    codefold._test.save_fold_state(doc, regions, { 1 })
+    local loaded = codefold._test.load_fold_state(doc)
+    local folded = codefold._test.match_fold_state(doc, regions, loaded)
+
+    test.equal(#folded, 1)
+    test.equal(folded[1], 1)
+  end)
+
+  test.test("ignores stale folds that no longer match", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_named_doc("src/main.lua", {
+      "local function main()\n",
+      "  print('hello')\n",
+      "end\n"
+    })
+    local regions = { { indent = 0, start = 1, stop = 2 } }
+
+    codefold._test.save_fold_state(doc, regions, { 1 })
+    doc.lines = {
+      "local function renamed()\n",
+      "  print('hello')\n",
+      "end\n"
+    }
+    local loaded = codefold._test.load_fold_state(doc)
+    local folded = codefold._test.match_fold_state(doc, regions, loaded)
+
+    test.equal(#folded, 0)
+  end)
+
+  test.test("does not duplicate exact matches through fallback matching", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_named_doc("src/main.lua", {
+      "if ok then\n",
+      "  one()\n",
+      "end\n",
+      "if ok then\n",
+      "  two()\n",
+      "end\n"
+    })
+    local regions = {
+      { indent = 0, start = 1, stop = 2 },
+      { indent = 0, start = 4, stop = 5 }
+    }
+    local folds = {
+      { line = 1, indent = 0, text = "if ok then\n" }
+    }
+
+    local folded = codefold._test.match_fold_state(doc, regions, folds)
+
+    test.equal(#folded, 1)
+    test.equal(folded[1], 1)
+  end)
+
+  test.test("folds all detected regions on open when no saved state exists", function()
+    local codefold = require "plugins.codefold"
+    local previous_start_folded = config.plugins.codefold.start_folded
+    config.plugins.codefold.start_folded = true
+
+    local doc = make_named_doc("src/main.lua", {
+      "local function one()\n",
+      "  print('one')\n",
+      "end\n",
+      "local function two()\n",
+      "  print('two')\n",
+      "end\n"
+    })
+    local view = DocView(doc)
+    local regions = {
+      { indent = 0, start = 1, stop = 2 },
+      { indent = 0, start = 4, stop = 5 }
+    }
+
+    codefold._test.apply_detected_regions(view, regions)
+
+    test.equal(#view.cf_folded_regions, 2)
+    test.equal(view.cf_folded_regions[1], 1)
+    test.equal(view.cf_folded_regions[2], 2)
+    test.is_nil(system.get_file_info(codefold._test.state_path_for_doc(doc)))
+
+    config.plugins.codefold.start_folded = previous_start_folded
+  end)
+
+  test.test("saved state takes precedence over fold-on-open", function()
+    local codefold = require "plugins.codefold"
+    local previous_start_folded = config.plugins.codefold.start_folded
+    config.plugins.codefold.start_folded = true
+
+    local doc = make_named_doc("src/main.lua", {
+      "local function one()\n",
+      "  print('one')\n",
+      "end\n",
+      "local function two()\n",
+      "  print('two')\n",
+      "end\n"
+    })
+    local regions = {
+      { indent = 0, start = 1, stop = 2 },
+      { indent = 0, start = 4, stop = 5 }
+    }
+    codefold._test.save_fold_state(doc, regions, { 2 })
+
+    local view = DocView(doc)
+    codefold._test.apply_detected_regions(view, regions)
+
+    test.equal(#view.cf_folded_regions, 1)
+    test.equal(view.cf_folded_regions[1], 2)
+
+    config.plugins.codefold.start_folded = previous_start_folded
+  end)
+end)
+
+test.describe("codefold - translate functions", function()
+  local function make_mock_dv(doc_lines, regions, folded_indices)
+    local fold_map, unfold_map = build_maps(doc_lines, regions, folded_indices)
+    return {
+      cf_unfold_map = unfold_map,
+      cf_fold_map = fold_map,
+      cf_regions = regions,
+      cf_folded_regions = folded_indices,
+    }
+  end
+
+  -- Load the plugin to get access to translate overrides
+  local codefold = require "plugins.codefold"
+
+  test.test("next_line skips hidden lines", function()
+    local dv = make_mock_dv(
+      { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n" },
+      { { start = 2, stop = 4 } },
+      { 1 } -- fold region 1
+    )
+
+    -- Starting at line 2 (visible, fold header)
+    -- next visible line should be 5
+    local doc = { lines = { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n" } }
+    local translate = require "core.docview".translate
+    local nl, nc = translate.next_line(doc, 2, 1, dv)
+    test.equal(nl, 5)
+    test.equal(nc, 1)
+  end)
+
+  test.test("previous_line skips hidden lines", function()
+    local dv = make_mock_dv(
+      { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n" },
+      { { start = 2, stop = 4 } },
+      { 1 }
+    )
+
+    local doc = { lines = { "line1\n", "line2\n", "line3\n", "line4\n", "line5\n" } }
+    local translate = require "core.docview".translate
+    local nl, nc = translate.previous_line(doc, 5, 1, dv)
+    test.equal(nl, 2)
+  end)
+
+  test.test("next_line at last visible line", function()
+    local dv = make_mock_dv(
+      { "line1\n", "line2\n", "line3\n" },
+      { { start = 2, stop = 3 } },
+      { 1 }
+    )
+
+    local doc = { lines = { "line1\n", "line2\n", "line3\n" } }
+    local translate = require "core.docview".translate
+    local nl, nc = translate.next_line(doc, 2, 1, dv)
+    -- line 1 is before, line 2 is header, 3 is hidden. End of doc.
+    test.equal(nl, 2, "stays at line 2 since no more visible lines")
+  end)
+
+  test.test("next_page / previous_page", function()
+    local lines = {}
+    for i = 1, 10 do
+      lines[i] = "line" .. i .. "\n"
+    end
+    local dv = make_mock_dv(
+      lines,
+      { { start = 5, stop = 8 } },
+      { 1 } -- fold region 5-8
+    )
+    -- visible: 1,2,3,4,5(header),9,10
+
+    -- Mock get_visible_line_range
+    dv.get_visible_line_range = function()
+      return 1, math.min(7, #lines) -- 7 visible lines
+    end
+    dv.size = { y = 200 }
+
+    local translate = require "core.docview".translate
+    local nl = translate.next_page(nil, 2, 1, dv)
+    -- virtual line 2 + (7-1) = 8, but max virtual is 7
+    test.equal(nl, 10, "page down from line 2 lands on last line")
+
+    nl = translate.previous_page(nil, 10, 1, dv)
+    test.equal(nl, 1, "page up from last line lands on first")
+  end)
+end)

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -4,6 +4,7 @@ local test = require "core.test"
 local Doc = require "core.doc"
 local DocView = require "core.docview"
 local core = require "core"
+local command = require "core.command"
 local config = require "core.config"
 local common = require "core.common"
 local style = require "core.style"
@@ -510,6 +511,147 @@ test.describe("codefold - virtual line mapping", function()
     end)
 
     config.plugins.codefold.enabled = previous_enabled
+  end)
+
+  test.test("ensure_line_visible unfolds regions containing the line", function()
+    require "plugins.codefold"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    config.plugins.codefold.enabled = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "  b\n",
+      "    c\n",
+      "  d\n",
+      "e\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = {
+      { indent = 0, start = 1, stop = 4 },
+      { indent = 2, start = 2, stop = 3 }
+    }
+    view.cf_folded_regions = { 1, 2 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+    view.cf_state_loaded = true
+    view.cf_fold_map, view.cf_unfold_map = build_maps(
+      doc.lines,
+      view.cf_regions,
+      view.cf_folded_regions
+    )
+
+    test.is_nil(view.cf_unfold_map[3])
+
+    view:ensure_line_visible(3)
+
+    test.equal(#view.cf_folded_regions, 0)
+    test.ok(view:is_line_visible(3))
+    test.equal(view.cf_unfold_map[3], 3)
+
+    config.plugins.codefold.enabled = previous_enabled
+  end)
+
+  test.test("select all occurrences reveals folded matches and keeps search highlight", function()
+    require "plugins.codefold"
+    require "core.commands.findreplace"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    local previous_active_view = core.active_view
+    config.plugins.codefold.enabled = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "target\n",
+      "if ok then\n",
+      "  target\n",
+      "end\n"
+    }
+    doc:reset_syntax()
+    doc:set_selection(1, 1, 1, 7)
+
+    local view = DocView(doc)
+    view.cf_regions = {
+      { indent = 0, start = 2, stop = 3 }
+    }
+    view.cf_folded_regions = { 1 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+    view.cf_state_loaded = true
+    view.cf_fold_map, view.cf_unfold_map = build_maps(
+      doc.lines,
+      view.cf_regions,
+      view.cf_folded_regions
+    )
+    core.active_view = view
+
+    test.is_nil(view.cf_unfold_map[3])
+
+    command.perform("find-replace:select-add-all")
+
+    test.equal(#view.cf_folded_regions, 0)
+    test.ok(view:is_line_visible(3))
+    test.ok(#doc.selections > 4)
+    test.ok(doc:is_search_selection(3, 3, 3, 9))
+
+    config.plugins.codefold.enabled = previous_enabled
+    core.active_view = previous_active_view
+  end)
+
+  test.test("go to line fuzzy match reveals folded target line", function()
+    require "plugins.codefold"
+    require "core.commands.doc"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    local previous_active_view = core.active_view
+    config.plugins.codefold.enabled = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "start\n",
+      "if ok then\n",
+      "  target match\n",
+      "end\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = {
+      { indent = 0, start = 2, stop = 3 }
+    }
+    view.cf_folded_regions = { 1 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+    view.cf_state_loaded = true
+    view.cf_fold_map, view.cf_unfold_map = build_maps(
+      doc.lines,
+      view.cf_regions,
+      view.cf_folded_regions
+    )
+    core.active_view = view
+
+    test.is_nil(view.cf_unfold_map[3])
+
+    command.perform("doc:go-to-line")
+    core.command_view:set_text("target")
+    core.command_view:update_suggestions()
+    for idx, item in ipairs(core.command_view.suggestions) do
+      if item.line == 3 then
+        core.command_view.suggestion_idx = idx
+        break
+      end
+    end
+    core.command_view:submit()
+
+    test.equal(#view.cf_folded_regions, 0)
+    test.ok(view:is_line_visible(3))
+    test.equal(doc:get_selection(), 3)
+
+    config.plugins.codefold.enabled = previous_enabled
+    core.active_view = previous_active_view
   end)
 
 end)

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -225,6 +225,54 @@ test.describe("codefold - region detection", function()
 end)
 
 test.describe("codefold - virtual line mapping", function()
+  test.test("hide tail on fold is enabled by default", function()
+    require "plugins.codefold"
+
+    test.equal(config.plugins.codefold.hide_tail_on_fold, true)
+
+    local found_spec = false
+    for _, item in ipairs(config.plugins.codefold.config_spec) do
+      if item.path == "hide_tail_on_fold" then
+        found_spec = true
+        test.equal(item.default, true)
+      end
+    end
+    test.ok(found_spec)
+  end)
+
+  test.test("folded regions hide their ending boundary line", function()
+    local codefold = require "plugins.codefold"
+
+    local previous_hide_tail = config.plugins.codefold.hide_tail_on_fold
+    local previous_start_folded = config.plugins.codefold.start_folded
+    config.plugins.codefold.hide_tail_on_fold = true
+    config.plugins.codefold.start_folded = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "function main()\n",
+      "  print('test')\n",
+      "end\n",
+      "print('done')\n",
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    codefold._test.apply_detected_regions(view, {
+      { indent = 0, start = 1, stop = 2 },
+    })
+
+    test.ok(view.cf_hidden_lines[2])
+    test.ok(view.cf_hidden_lines[3])
+    test.is_nil(view.cf_hidden_lines[4])
+    test.equal(#view.cf_fold_map, 2)
+    test.equal(view.cf_fold_map[1], 1)
+    test.equal(view.cf_fold_map[2], 4)
+
+    config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
+    config.plugins.codefold.start_folded = previous_start_folded
+  end)
+
   test.test("identity mapping when no folds", function()
     local regions = {
       { start = 2, stop = 3 },
@@ -331,6 +379,9 @@ test.describe("codefold - virtual line mapping", function()
   test.test("DocView position helpers use fold maps", function()
     require "plugins.codefold"
 
+    local previous_hide_tail = config.plugins.codefold.hide_tail_on_fold
+    config.plugins.codefold.hide_tail_on_fold = false
+
     local doc = Doc(nil, nil, true)
     doc.lines = { "a\n", "b\n", "c\n", "d\n", "e\n" }
     doc:reset_syntax()
@@ -346,6 +397,8 @@ test.describe("codefold - virtual line mapping", function()
     test.equal(col, 1)
     test.equal(view:offset_from_position(5, 1), 3)
     test.equal(view:offset_from_position(4, 1), 2)
+
+    config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
   end)
 
   test.test("indentguide caches visible folded real lines", function()
@@ -355,8 +408,10 @@ test.describe("codefold - virtual line mapping", function()
 
     local previous = config.plugins.indentguide.enabled
     local previous_highlight = config.plugins.indentguide.highlight
+    local previous_hide_tail = config.plugins.codefold.hide_tail_on_fold
     config.plugins.indentguide.enabled = true
     config.plugins.indentguide.highlight = false
+    config.plugins.codefold.hide_tail_on_fold = false
 
     local doc = Doc(nil, nil, true)
     doc.lines = { "a\n", "  b\n", "    c\n", "  d\n", "  e\n" }
@@ -382,6 +437,7 @@ test.describe("codefold - virtual line mapping", function()
 
     config.plugins.indentguide.enabled = previous
     config.plugins.indentguide.highlight = previous_highlight
+    config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
   end)
 
   test.test("indentguide active range uses visible offsets", function()
@@ -504,10 +560,12 @@ test.describe("codefold - virtual line mapping", function()
       view.cf_folded_regions = { 1 }
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
       test.equal(calls[#calls].color, style.caret)
+      local toggle_font = view.cf_toggle_font
 
       view.cf_hovering_toggle = 1
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
       test.equal(calls[#calls].color, style.accent)
+      test.equal(view.cf_toggle_font, toggle_font)
     end)
 
     config.plugins.codefold.enabled = previous_enabled
@@ -553,6 +611,91 @@ test.describe("codefold - virtual line mapping", function()
     test.equal(view.cf_unfold_map[3], 3)
 
     config.plugins.codefold.enabled = previous_enabled
+  end)
+
+  test.test("detected regions build lookup caches and hidden lines", function()
+    local codefold = require "plugins.codefold"
+
+    local previous_start_folded = config.plugins.codefold.start_folded
+    config.plugins.codefold.start_folded = true
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "  b\n",
+      "c\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    local regions = {
+      { indent = 0, start = 1, stop = 2 }
+    }
+
+    codefold._test.apply_detected_regions(view, regions)
+
+    test.equal(view.cf_region_by_start[1], 1)
+    test.ok(view.cf_folded_region_set[1])
+    test.ok(view.cf_hidden_lines[2])
+    test.is_nil(view.cf_unfold_map[2])
+
+    config.plugins.codefold.start_folded = previous_start_folded
+  end)
+
+  test.test("document edits debounce fold recalculation", function()
+    require "plugins.codefold"
+
+    local previous_get_views = core.get_views_referencing_doc
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "  b\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = { { indent = 0, start = 1, stop = 2 } }
+    view.cf_invalidated = false
+    view.cf_invalidated_at = nil
+    view.cf_thread_id = "codefold-test-thread"
+
+    local old_thread_ran = false
+    local old_cr = coroutine.create(function()
+      old_thread_ran = true
+    end)
+    core.threads[view.cf_thread_id] = {
+      cr = old_cr,
+      wake = 999,
+      avg_time = 10,
+      time = 10,
+      calls = 1
+    }
+
+    core.get_views_referencing_doc = function(target)
+      return target == doc and { view } or {}
+    end
+
+    local before = system.get_time()
+    doc:insert(1, 1, "x")
+
+    test.ok(view.cf_invalidated)
+    test.ok(view.cf_invalidated_at and view.cf_invalidated_at >= before)
+    test.is_nil(view.cf_thread_id)
+    test.ok(core.threads["codefold-test-thread"])
+    test.not_equal(core.threads["codefold-test-thread"].cr, old_cr)
+    test.equal(core.threads["codefold-test-thread"].wake, 0)
+    test.is_nil(core.threads["codefold-test-thread"].avg_time)
+    test.is_nil(core.threads["codefold-test-thread"].time)
+    test.is_nil(core.threads["codefold-test-thread"].calls)
+
+    local ok = coroutine.resume(core.threads["codefold-test-thread"].cr)
+    test.ok(ok)
+    test.equal(coroutine.status(core.threads["codefold-test-thread"].cr), "dead")
+    test.equal(old_thread_ran, false)
+
+    core.threads["codefold-test-thread"] = nil
+    core.get_views_referencing_doc = previous_get_views
   end)
 
   test.test("select all occurrences reveals folded matches and keeps search highlight", function()

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -806,11 +806,13 @@ test.describe("codefold - virtual line mapping", function()
     core.active_view = previous_active_view
   end)
 
-  test.test("fold gutter marker color reflects folded and hover state", function()
+  test.test("fold gutter marker visibility and color reflect state", function()
     require "plugins.codefold"
 
     local previous_enabled = config.plugins.codefold.enabled
+    local previous_always_show = config.plugins.codefold.always_show_fold_markers
     config.plugins.codefold.enabled = true
+    config.plugins.codefold.always_show_fold_markers = false
 
     local view = make_docview({ "a\n", "  b\n", "c\n" })
     view.cf_regions = { { indent = 0, start = 1, stop = 2 } }
@@ -823,8 +825,18 @@ test.describe("codefold - virtual line mapping", function()
     local _, y = view:get_line_screen_position(1)
     with_common_draw_text(function(calls)
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(#calls, 1)
+
+      view.hovering_gutter = true
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
       test.equal(calls[#calls].color, style.dim or style.line_number)
 
+      view.hovering_gutter = false
+      config.plugins.codefold.always_show_fold_markers = true
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(calls[#calls].color, style.dim or style.line_number)
+
+      config.plugins.codefold.always_show_fold_markers = false
       view.cf_folded_regions = { 1 }
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
       test.equal(calls[#calls].color, style.caret)
@@ -837,6 +849,7 @@ test.describe("codefold - virtual line mapping", function()
     end)
 
     config.plugins.codefold.enabled = previous_enabled
+    config.plugins.codefold.always_show_fold_markers = previous_always_show
   end)
 
   test.test("ensure_line_visible unfolds regions containing the line", function()
@@ -1383,6 +1396,38 @@ test.describe("codefold - translate functions", function()
 
   -- Load the plugin to get access to translate overrides
   local codefold = require "plugins.codefold"
+
+  test.test("next_line falls back when no regions are folded", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = { "line1\n", "line2\n", "line3\n" }
+    doc:reset_syntax()
+
+    local dv = DocView(doc)
+    dv.cf_fold_map = {}
+    dv.cf_unfold_map = {}
+    dv.cf_folded_regions = {}
+    dv.last_x_offset = { line = 1, col = 1, offset = 0 }
+
+    local translate = require "core.docview".translate
+    local nl = translate.next_line(doc, 1, 1, dv)
+    test.equal(nl, 2)
+  end)
+
+  test.test("previous_line falls back when no regions are folded", function()
+    local doc = Doc(nil, nil, true)
+    doc.lines = { "line1\n", "line2\n", "line3\n" }
+    doc:reset_syntax()
+
+    local dv = DocView(doc)
+    dv.cf_fold_map = {}
+    dv.cf_unfold_map = {}
+    dv.cf_folded_regions = {}
+    dv.last_x_offset = { line = 2, col = 1, offset = 0 }
+
+    local translate = require "core.docview".translate
+    local nl = translate.previous_line(doc, 2, 1, dv)
+    test.equal(nl, 1)
+  end)
 
   test.test("next_line skips hidden lines", function()
     local dv = make_mock_dv(

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -408,6 +408,88 @@ test.describe("codefold - region detection", function()
     test.equal(regions[1].stop, 3)
     test.equal(regions[1].hide_tail, false)
   end)
+
+  test.test("incremental detection stops at unchanged next fold point", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "changed text\n",
+      "  changed child\n",
+      "stable fold\n",
+      "  stable child\n",
+      "later fold\n",
+      "  later child\n",
+    }
+    doc:reset_syntax()
+
+    local previous_regions = {
+      { indent = 0, start = 1, stop = 2, kind = "indent" },
+      { indent = 0, start = 3, stop = 4, kind = "indent" },
+      { indent = 0, start = 5, stop = 6, kind = "indent" },
+    }
+
+    local original_get_utf8_line = doc.get_utf8_line
+    doc.get_utf8_line = function(self, line)
+      test.ok(line < 5, "incremental detection scanned past stable fold point")
+      return original_get_utf8_line(self, line)
+    end
+
+    local regions = codefold._test.detect_fold_regions(doc, 1, previous_regions)
+
+    test.equal(#regions, 3)
+    test.equal(regions[2], previous_regions[2])
+    test.equal(regions[3], previous_regions[3])
+
+    doc.get_utf8_line = original_get_utf8_line
+  end)
+
+  test.test("incremental detection keeps scanning inside changed fold", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "outer\n",
+      "  new fold\n",
+      "    new child\n",
+      "  sibling\n",
+      "stable fold\n",
+      "  stable child\n",
+    }
+    doc:reset_syntax()
+
+    local previous_regions = {
+      { indent = 0, start = 1, stop = 4, kind = "indent" },
+      { indent = 0, start = 5, stop = 6, kind = "indent" },
+    }
+
+    local regions = codefold._test.detect_fold_regions(doc, 2, previous_regions)
+
+    test.equal(#regions, 3)
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 4)
+    test.equal(regions[2].start, 2)
+    test.equal(regions[2].stop, 3)
+    test.equal(regions[3], previous_regions[2])
+  end)
+
+  test.test("incremental detection catches fold created by next line", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "{\n",
+      "  something\n",
+      "}\n",
+    }
+    doc:reset_syntax()
+
+    local regions = codefold._test.detect_fold_regions(doc, 2, {})
+
+    test.equal(#regions, 1)
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 2)
+  end)
 end)
 
 test.describe("codefold - virtual line mapping", function()
@@ -826,6 +908,121 @@ test.describe("codefold - virtual line mapping", function()
     test.is_nil(view.cf_unfold_map[2])
 
     config.plugins.codefold.start_folded = previous_start_folded
+  end)
+
+  test.test("detected regions without folded spans skip map rebuild", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "  b\n",
+      "c\n",
+      "  d\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = {}
+    view.cf_folded_regions = {}
+    view.cf_state_loaded = true
+    view.cf_fold_map = {}
+    view.cf_unfold_map = {}
+    view.cf_visibility_signature = ""
+    view.visual_lines_dirty = false
+
+    codefold._test.apply_detected_regions(view, {
+      { indent = 0, start = 1, stop = 2 },
+      { indent = 0, start = 3, stop = 4 }
+    })
+
+    test.equal(view.cf_region_by_start[1], 1)
+    test.equal(view.cf_region_by_start[3], 2)
+    test.equal(view.visual_lines_dirty, false)
+    test.equal(#view.cf_fold_map, 0)
+  end)
+
+  test.test("unchanged folded spans skip map rebuild", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "  b\n",
+      "c\n",
+      "  d\n",
+      "e\n",
+      "  f\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = {
+      { indent = 0, start = 1, stop = 2 },
+      { indent = 0, start = 3, stop = 4 }
+    }
+    view.cf_folded_regions = { 1 }
+    view.cf_folded_region_set = { [1] = true }
+    view.cf_hidden_lines = { [2] = true }
+    view.cf_fold_map, view.cf_unfold_map = build_maps(
+      doc.lines,
+      view.cf_regions,
+      view.cf_folded_regions
+    )
+    view.cf_visibility_signature = "true|1:2:1"
+    view.cf_mapping_line_count = #doc.lines
+    view.cf_state_loaded = true
+    view.visual_lines_dirty = false
+
+    codefold._test.apply_detected_regions(view, {
+      { indent = 0, start = 1, stop = 2 },
+      { indent = 0, start = 3, stop = 4 },
+      { indent = 0, start = 5, stop = 6 }
+    })
+
+    test.equal(view.cf_region_by_start[5], 3)
+    test.ok(view.cf_folded_region_set[1])
+    test.equal(view.visual_lines_dirty, false)
+    test.is_nil(view.cf_unfold_map[2])
+  end)
+
+  test.test("changed folded spans rebuild maps", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = Doc(nil, nil, true)
+    doc.lines = {
+      "a\n",
+      "  b\n",
+      "  c\n",
+      "d\n"
+    }
+    doc:reset_syntax()
+
+    local view = DocView(doc)
+    view.cf_regions = {
+      { indent = 0, start = 1, stop = 2 }
+    }
+    view.cf_folded_regions = { 1 }
+    view.cf_folded_region_set = { [1] = true }
+    view.cf_hidden_lines = { [2] = true }
+    view.cf_fold_map, view.cf_unfold_map = build_maps(
+      doc.lines,
+      view.cf_regions,
+      view.cf_folded_regions
+    )
+    view.cf_visibility_signature = "true|1:2:1"
+    view.cf_mapping_line_count = #doc.lines
+    view.cf_state_loaded = true
+    view.visual_lines_dirty = false
+
+    codefold._test.apply_detected_regions(view, {
+      { indent = 0, start = 1, stop = 3 }
+    })
+
+    test.equal(view.visual_lines_dirty, true)
+    test.ok(view.cf_hidden_lines[2])
+    test.ok(view.cf_hidden_lines[3])
+    test.is_nil(view.cf_unfold_map[3])
   end)
 
   test.test("document edits debounce fold recalculation", function()

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -8,6 +8,7 @@ local command = require "core.command"
 local config = require "core.config"
 local common = require "core.common"
 local style = require "core.style"
+local syntax = require "core.syntax"
 
 local function write_file(path, content)
   local file, err = io.open(path, "wb")
@@ -51,6 +52,24 @@ local function make_docview(lines)
   view.indentguide_indents = {}
   view.indentguide_indent_active = {}
   return view
+end
+
+local function make_c_doc(lines)
+  require "plugins.language_c"
+  local doc = Doc(nil, nil, true)
+  doc.syntax = syntax.get("test.c")
+  doc.lines = lines
+  doc.highlighter:reset()
+  return doc
+end
+
+local function make_php_doc(lines)
+  dofile("subprojects/plugins/plugins/language_php.lua")
+  local doc = Doc(nil, nil, true)
+  doc.syntax = syntax.get("test.php")
+  doc.lines = lines
+  doc.highlighter:reset()
+  return doc
 end
 
 -- Helper: compute line indent (same logic as in codefold.lua)
@@ -221,6 +240,173 @@ test.describe("codefold - region detection", function()
     test.equal(regions[1].stop, 4)
     test.equal(regions[2].start, 2)
     test.equal(regions[2].stop, 3)
+  end)
+
+  test.test("detects multiline block comment regions from tokens", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_c_doc({
+      "/**\n",
+      " * Function that does something\n",
+      " */\n",
+      "function somefunction(){\n",
+      "}\n",
+    })
+    doc.highlighter:get_line(1)
+
+    local regions = codefold._test.detect_fold_regions(doc)
+
+    test.equal(regions[1].kind, "comment")
+    test.equal(regions[1].start, 1)
+    test.equal(regions[1].stop, 3)
+    test.equal(regions[1].hide_tail, false)
+  end)
+
+  test.test("block comment folds do not hide following code as tail", function()
+    local codefold = require "plugins.codefold"
+
+    local previous_start_folded = config.plugins.codefold.start_folded
+    local previous_hide_tail = config.plugins.codefold.hide_tail_on_fold
+    config.plugins.codefold.start_folded = true
+    config.plugins.codefold.hide_tail_on_fold = true
+
+    local doc = make_c_doc({
+      "/**\n",
+      " * Function that does something\n",
+      " */\n",
+      "function somefunction(){\n",
+      "}\n",
+    })
+    local view = DocView(doc)
+    local regions = codefold._test.detect_fold_regions(doc)
+    codefold._test.apply_detected_regions(view, regions)
+
+    test.ok(view.cf_hidden_lines[2])
+    test.ok(view.cf_hidden_lines[3])
+    test.is_nil(view.cf_hidden_lines[4])
+    test.equal(view.cf_fold_map[1], 1)
+    test.equal(view.cf_fold_map[2], 4)
+
+    config.plugins.codefold.start_folded = previous_start_folded
+    config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
+  end)
+
+  test.test("block comment delimiters inside strings do not create folds", function()
+    local codefold = require "plugins.codefold"
+    local doc = make_c_doc({
+      "const char *s = \"/* not a comment\";\n",
+      "const char *e = \"*/ not a comment\";\n",
+    })
+    doc.highlighter:get_line(1)
+
+    local regions = codefold._test.detect_fold_regions(doc)
+
+    for _, region in ipairs(regions) do
+      test.not_equal(region.kind, "comment")
+    end
+  end)
+
+  test.test("untokenized fold heads do not hide tail lines", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = make_c_doc({
+      "/**\n",
+      " * Function that does something\n",
+      " */\n",
+      "function somefunction(){\n",
+      "}\n",
+    })
+
+    local regions = codefold._test.detect_fold_regions(doc)
+
+    test.equal(regions[1].kind, "comment")
+    test.equal(regions[1].hide_tail, false)
+  end)
+
+  test.test("comment marker fold heads do not hide tail after stale tokens", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = make_c_doc({
+      "/**\n",
+      " * Function that does something\n",
+      " */\n",
+      "static function addFieldsets(\n",
+      "}\n",
+    })
+    doc.highlighter.lines[1] = {
+      init_state = nil,
+      text = doc.lines[1],
+      tokens = { "normal", doc.lines[1] },
+      state = nil
+    }
+
+    local regions = codefold._test.detect_fold_regions(doc)
+
+    test.equal(regions[1].kind, "comment")
+    test.equal(regions[1].hide_tail, false)
+  end)
+
+  test.test("php subsyntax comment markers do not hide following function", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = make_php_doc({
+      "<?php\n",
+      "/**\n",
+      " * Add a new fieldset with fields to an array of fieldsets.\n",
+      " */\n",
+      "static function addFieldsets(\n",
+      "    array $fieldsets,\n",
+      ")\n",
+      "{\n",
+      "}\n",
+    })
+    doc.highlighter:get_line(1)
+
+    local regions = codefold._test.detect_fold_regions(doc)
+
+    test.equal(regions[1].start, 2)
+    test.equal(regions[1].stop, 4)
+    test.equal(regions[1].kind, "comment")
+    test.equal(regions[1].hide_tail, false)
+
+    local previous_start_folded = config.plugins.codefold.start_folded
+    local previous_hide_tail = config.plugins.codefold.hide_tail_on_fold
+    config.plugins.codefold.start_folded = true
+    config.plugins.codefold.hide_tail_on_fold = true
+
+    local view = DocView(doc)
+    codefold._test.apply_detected_regions(view, regions)
+
+    test.ok(view.cf_hidden_lines[3])
+    test.ok(view.cf_hidden_lines[4])
+    test.is_nil(view.cf_hidden_lines[5])
+    test.equal(view.cf_fold_map[2], 2)
+    test.equal(view.cf_fold_map[3], 5)
+
+    config.plugins.codefold.start_folded = previous_start_folded
+    config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
+  end)
+
+  test.test("missing highlighter cache falls back to document syntax", function()
+    local codefold = require "plugins.codefold"
+
+    local doc = make_c_doc({
+      "/**\n",
+      " * Function that does something\n",
+      " */\n",
+      "function somefunction(){\n",
+      "}\n",
+    })
+    doc.highlighter = {
+      each_token = function()
+        return function() end
+      end
+    }
+
+    local regions = codefold._test.detect_fold_regions(doc)
+
+    test.equal(regions[1].kind, "comment")
+    test.equal(regions[1].stop, 3)
+    test.equal(regions[1].hide_tail, false)
   end)
 end)
 

--- a/scripts/lua/tests/websocket.lua
+++ b/scripts/lua/tests/websocket.lua
@@ -148,8 +148,21 @@ def serve_badaccept(server):
         upgrade(conn, bad_accept=True)
 
 
-server = socket.create_server(("127.0.0.1", 0), reuse_port=False)
-print(server.getsockname()[1], flush=True)
+port_path = sys.argv[2] if len(sys.argv) > 2 else None
+try:
+    server = socket.create_server(("127.0.0.1", 0), reuse_port=False)
+except PermissionError as exc:
+    if port_path:
+        with open(port_path, "w", encoding="utf-8") as fp:
+            fp.write("SKIP:" + str(exc))
+        sys.exit(0)
+    raise
+
+if port_path:
+    with open(port_path, "w", encoding="utf-8") as fp:
+        fp.write(str(server.getsockname()[1]))
+else:
+    print(server.getsockname()[1], flush=True)
 
 mode = sys.argv[1]
 with server:
@@ -170,11 +183,40 @@ local function write_file(path, content)
   file:close()
 end
 
-local function python_command(script_path, mode)
+local function python_command(script_path, mode, port_path)
   if PLATFORM == "Windows" then
-    return { "python", "-u", script_path, mode }
+    return { "python", "-u", script_path, mode, port_path }
   end
-  return { "python3", "-u", script_path, mode }
+  return { "python3", "-u", script_path, mode, port_path }
+end
+
+local function read_server_port(proc, port_path, label)
+  local deadline = system.get_time() + 5
+  while system.get_time() < deadline do
+    local file = io.open(port_path, "rb")
+    if file then
+      local content = file:read("*a")
+      file:close()
+      if content:find("^SKIP:") then
+        test.skip_now(label .. " test server cannot create local sockets")
+      end
+      local port = tonumber(content)
+      test.type(port, "number")
+      return port
+    end
+    if not proc:running() then
+      break
+    end
+    system.sleep(0.01)
+  end
+
+  proc:wait(1000, 0.01)
+  local stderr = proc.stderr:read("all") or ""
+  if stderr:find("Operation not permitted", 1, true) then
+    test.skip_now(label .. " test server cannot create local sockets")
+  end
+  local suffix = stderr ~= "" and (": " .. stderr) or ""
+  test.fail(label .. " test server did not report a port" .. suffix, 2)
 end
 
 local function wait_until(predicate, timeout, message)
@@ -191,10 +233,11 @@ end
 
 local function start_websocket_server(context, mode)
   local script_path = context.temp_root .. PATHSEP .. "websocket_test_server.py"
+  local port_path = context.temp_root .. PATHSEP .. "websocket_test_server.port"
   write_file(script_path, WEBSOCKET_SERVER_SCRIPT)
   context.server_script_paths[#context.server_script_paths + 1] = script_path
 
-  local proc = process.start(python_command(script_path, mode), {
+  local proc = process.start(python_command(script_path, mode, port_path), {
     stdout = process.REDIRECT_PIPE,
     stderr = process.REDIRECT_PIPE,
   })
@@ -202,14 +245,7 @@ local function start_websocket_server(context, mode)
 
   context.server_processes[#context.server_processes + 1] = proc
 
-  local line = proc.stdout:read("line", {
-    timeout = 5,
-    scan = 0.01,
-  })
-  test.not_nil(line, "WebSocket test server did not report a port")
-
-  local port = tonumber(line)
-  test.type(port, "number")
+  local port = read_server_port(proc, port_path, "WebSocket")
   return "ws://127.0.0.1:" .. port
 end
 

--- a/subprojects/plugins.wrap
+++ b/subprojects/plugins.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/pragtical/plugins.git
-revision = a88f8dfdbc9bf1d7e87adaa6fce9f4d188b32f78
+revision = 7fa0e839438d05ac1d6cd20d3370da6424689eb1
 depth = 1
 patch_directory = plugins


### PR DESCRIPTION
This PR adds code folding support built on a shared DocView visual-line model, allowing folding, wrapping, and
related plugins to use consistent screen-position and navigation behavior.

  - Adds a DocView visual-line model for hidden lines and wrapped rows.
  - Adds the codefold plugin with gutter markers, fold/unfold commands, fold-aware navigation, and persisted collapsed
    state.
  - Integrates codefold with linewrapping, indent guides, search, selection, and go-to-line behavior.
  - Improves folding performance for large documents through incremental detection and reduced visibility-map
    rebuilds.
  - Adds tokenizer-aware handling for comment/docblock folds.
  - Adds tests covering folding, wrapping integration, search/selection unfolding, persistence, and performance-
    sensitive update paths.

### Config

```lua
config.plugins.codefold = {
  -- Whether code folding is enabled.
  enabled = true,
  -- If true, newly opened documents have all fold regions initially collapsed.
  start_folded = false,
  -- If true, folded regions hide the folded end-line tail.
  hide_tail_on_fold = true,
  -- If true, all fold markers are always visible.
  always_show_fold_markers = false,
  -- Width in pixels reserved for fold toggle indicators in the gutter.
  toggle_width = common.round(24 * SCALE)
}
```

### Commands

```lua
keymap.add {
  ["alt+shift+left"] = "code-folding:toggle",
  ["alt+shift+right"] = "code-folding:toggle",
  ["alt+shift+up"] = "code-folding:fold-all",
  ["alt+shift+down"] = "code-folding:unfold-all"
}
```

### Previews

https://github.com/user-attachments/assets/1d1dc701-63c5-415d-8ab4-77bbe6e42853

https://github.com/user-attachments/assets/ab145ec2-94d8-4d41-a724-808b09d42608