### PR TITLE
Avoid hidden status item rebuilds

### DIFF
--- a/data/core/statusview.lua
+++ b/data/core/statusview.lua
@@ -1240,7 +1240,8 @@ function StatusView:update()
     self.size.y = height
   end
 
-  if self.message and system.get_time() < self.message_timeout then
+  local message_visible = self.message and system.get_time() < self.message_timeout
+  if message_visible then
     self.scroll.to.y = self.size.y
   else
     self.scroll.to.y = 0
@@ -1248,7 +1249,9 @@ function StatusView:update()
 
   StatusView.super.update(self)
 
-  self:update_active_items()
+  if not message_visible then
+    self:update_active_items()
+  end
 end
 
 

--- a/scripts/lua/tests/statusview.lua
+++ b/scripts/lua/tests/statusview.lua
@@ -1,0 +1,40 @@
+local test = require "core.test"
+local StatusView = require "core.statusview"
+local style = require "core.style"
+
+local function make_status_view()
+  local view = StatusView()
+  view.position.x = 0
+  view.position.y = 0
+  view.size.x = 320
+  view.size.y = style.font:get_height() + style.padding.y * 2
+  view.items = {}
+  view.active_items = {}
+  return view
+end
+
+test.describe("statusview", function()
+  test.it("skips hidden item rebuilds while a message is visible", function()
+    local view = make_status_view()
+    local calls = 0
+
+    view:add_item({
+      name = "test:item",
+      get_item = function()
+        calls = calls + 1
+        return { "visible" }
+      end
+    })
+
+    view:update()
+    test.equal(calls, 1)
+
+    view:show_message("i", style.text, "Saved")
+    view:update()
+    test.equal(calls, 1)
+
+    view.message_timeout = 0
+    view:update()
+    test.equal(calls, 2)
+  end)
+end)


### PR DESCRIPTION
Skip rebuilding normal status bar items while a temporary message is visible. Save notifications replace the status bar content during that time, so measuring hidden items just adds redraw work while scrolling.

Add a regression test that verifies item providers are not called until the temporary message has expired.