### PR TITLE
Return partial process writes

### DIFF
--- a/docs/api/process.lua
+++ b/docs/api/process.lua
@@ -170,9 +170,13 @@ function process:read_stderr(len) end
 ---
 ---Write to stdin.
 ---
+---This may write only part of the provided data. A return value of 0 means the
+---process is not ready to accept more bytes yet; retry later. On error this
+---returns nil and an error message.
+---
 ---@param data string
 ---
----@return integer | nil bytes The amount of bytes written or nil if error.
+---@return integer | nil bytes The amount of bytes written, or nil if error.
 ---@return string? errmsg
 ---@return process.errortype | integer? errcode
 function process:write(data) end

--- a/scripts/lua/tests/process.lua
+++ b/scripts/lua/tests/process.lua
@@ -66,6 +66,27 @@ test.describe("process", function()
     test.type(process.strerror(1), "string")
   end)
 
+  test.test("stdin writes can return partial byte counts", function()
+    test.skip_if(PLATFORM == "Windows", "POSIX pipe capacity behavior is required")
+
+    local proc = process.start(shell_command("sleep 0.3; cat >/dev/null"), {
+      stdin = process.REDIRECT_PIPE,
+      stdout = process.REDIRECT_DISCARD,
+      stderr = process.REDIRECT_DISCARD
+    })
+
+    test.not_nil(proc)
+    local data = ("x"):rep(1024 * 1024)
+    local written, errmsg = proc:write(data)
+
+    test.type(written, "number")
+    test.is_nil(errmsg)
+    test.ok(written > 0)
+    test.ok(written < #data)
+
+    proc:kill()
+  end)
+
   test.test("does not mutate environment options", function()
     local command = PLATFORM == "Windows"
       and "echo %PRAGTICAL_PROCESS_TEST_ENV%"

--- a/src/api/process.c
+++ b/src/api/process.c
@@ -1284,6 +1284,11 @@ static int f_write(lua_State *L) {
   if (written > 0)
     SDL_FlushIO(input);
 
+  if (written > 0 && written < size) {
+    lua_pushinteger(L, (lua_Integer) written);
+    return 1;
+  }
+
   if (written < size) {
     SDL_IOStatus status = SDL_GetIOStatus(input);
     if (status == SDL_IO_STATUS_NOT_READY) {


### PR DESCRIPTION
Allow process:write to return the number of bytes accepted when a non-blocking stdin pipe writes only part of the requested buffer. This lets callers continue writing the remaining bytes instead of losing the amount that was already accepted before a not-ready state.

Document the partial-write behavior and add a POSIX coverage case that fills a pipe enough to verify a short successful write is surfaced to Lua.