### PR TITLE
Polish codefold marker behavior

### DIFF
--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -17,7 +17,7 @@ config.plugins.codefold = common.merge({
   -- If true, newly opened documents have all fold regions initially collapsed.
   start_folded = false,
   -- If true, folded regions hide the folded end-line tail.
-  hide_tail_on_fold = true,
+  hide_tail_on_fold = false,
   -- If true, all fold markers are always visible.
   always_show_fold_markers = false,
   -- Width in pixels reserved for fold toggle indicators in the gutter.
@@ -44,7 +44,7 @@ config.plugins.codefold = common.merge({
       description = "Hide the folded end-line tail when a region is collapsed.",
       path = "hide_tail_on_fold",
       type = "toggle",
-      default = true
+      default = false
     },
     {
       label = "Always Show Fold Markers",
@@ -1132,6 +1132,11 @@ function DocView:get_gutter_width()
   return base_width + toggle_w, padding + toggle_w
 end
 
+local function fold_toggle_rect(self)
+  local toggle_w = config.plugins.codefold.toggle_width
+  return self.position.x + self:get_gutter_width() - toggle_w * 1.5, toggle_w
+end
+
 local docview_draw_line_gutter = DocView.draw_line_gutter
 function DocView:draw_line_gutter(line, x, y, width)
   local result = docview_draw_line_gutter(self, line, x, y, width)
@@ -1151,9 +1156,8 @@ function DocView:draw_line_gutter(line, x, y, width)
         toggle_color = style.accent
       end
       local lh = self:get_line_height()
-      local toggle_w = config.plugins.codefold.toggle_width
+      local toggle_x, toggle_w = fold_toggle_rect(self)
       local toggle_font = get_toggle_font(self)
-      local toggle_x = self.position.x + self:get_gutter_width() - toggle_w * 1.5
       local toggle_y = y
       common.draw_text(toggle_font, toggle_color, toggle_char, "right", toggle_x, toggle_y, toggle_w, lh)
     end
@@ -1191,9 +1195,8 @@ function DocView:on_mouse_moved(x, y, ...)
   local was_hovering = self.cf_hovering_toggle
   self.cf_hovering_toggle = nil
   if config.plugins.codefold.enabled and self:is(DocView) then
-    local tw = config.plugins.codefold.toggle_width
-    local gw = self:get_gutter_width()
-    if x >= self.position.x + gw - tw and x < self.position.x + gw then
+    local toggle_x, toggle_w = fold_toggle_rect(self)
+    if x >= toggle_x and x < toggle_x + toggle_w then
       local line = self:resolve_screen_position(x, y)
       if line and region_at_line(self, line) then
         self.cf_hovering_toggle = line

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -511,16 +511,16 @@ test.describe("codefold - region detection", function()
 end)
 
 test.describe("codefold - virtual line mapping", function()
-  test.test("hide tail on fold is enabled by default", function()
+  test.test("hide tail on fold is disabled by default", function()
     require "plugins.codefold"
 
-    test.equal(config.plugins.codefold.hide_tail_on_fold, true)
+    test.equal(config.plugins.codefold.hide_tail_on_fold, false)
 
     local found_spec = false
     for _, item in ipairs(config.plugins.codefold.config_spec) do
       if item.path == "hide_tail_on_fold" then
         found_spec = true
-        test.equal(item.default, true)
+        test.equal(item.default, false)
       end
     end
     test.ok(found_spec)
@@ -870,6 +870,41 @@ test.describe("codefold - virtual line mapping", function()
     config.plugins.codefold.always_show_fold_markers = previous_always_show
   end)
 
+  test.test("fold gutter hover uses shifted marker bounds", function()
+    require "plugins.codefold"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    local previous_always_show = config.plugins.codefold.always_show_fold_markers
+    config.plugins.codefold.enabled = true
+    config.plugins.codefold.always_show_fold_markers = true
+
+    local view = make_docview({ "a\n", "  b\n", "c\n" })
+    view.cf_regions = { { indent = 0, start = 1, stop = 2 } }
+    view.cf_folded_regions = {}
+    view.cf_fold_map = { 1, 2, 3 }
+    view.cf_unfold_map = { 1, 2, 3 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+
+    local _, y = view:get_line_screen_position(1)
+    local marker_x, marker_w
+    with_common_draw_text(function(calls)
+      view.hovering_gutter = true
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      marker_x = calls[#calls].x
+      marker_w = calls[#calls].w
+    end)
+
+    view:on_mouse_moved(marker_x + marker_w / 2, y + view:get_line_height() / 2)
+    test.equal(view.cf_hovering_toggle, 1)
+
+    view:on_mouse_moved(marker_x + marker_w + 1, y + view:get_line_height() / 2)
+    test.is_nil(view.cf_hovering_toggle)
+
+    config.plugins.codefold.enabled = previous_enabled
+    config.plugins.codefold.always_show_fold_markers = previous_always_show
+  end)
+
   test.test("ensure_line_visible unfolds regions containing the line", function()
     require "plugins.codefold"
 
@@ -1000,7 +1035,7 @@ test.describe("codefold - virtual line mapping", function()
       view.cf_regions,
       view.cf_folded_regions
     )
-    view.cf_visibility_signature = "true|1:2:1"
+    view.cf_visibility_signature = "false|1:2:1"
     view.cf_mapping_line_count = #doc.lines
     view.cf_state_loaded = true
     view.visual_lines_dirty = false

--- a/scripts/lua/tests/websocket.lua
+++ b/scripts/lua/tests/websocket.lua
@@ -201,8 +201,12 @@ local function read_server_port(proc, port_path, label)
         test.skip_now(label .. " test server cannot create local sockets")
       end
       local port = tonumber(content)
-      test.type(port, "number")
-      return port
+      if port then
+        return port
+      end
+      if not proc:running() then
+        test.fail(label .. " test server wrote invalid port: " .. content, 2)
+      end
     end
     if not proc:running() then
       break


### PR DESCRIPTION
Make the codefold hover hitbox use the same shifted gutter rectangle as the drawn fold marker. The marker had been moved left for better visual centering, but hover detection still used the old rightmost gutter area.

Also leave folded end-line tails visible by default by changing the hide_tail_on_fold default and settings metadata to false.

Add regression coverage for the shifted hover bounds and the updated default tail visibility.