### PR TITLE
Add welcome recent project menu

### DIFF
--- a/data/core/emptyview.lua
+++ b/data/core/emptyview.lua
@@ -1,6 +1,7 @@
 local core = require "core"
 local command = require "core.command"
 local common = require "core.common"
+local ContextMenu = require "core.contextmenu"
 local style = require "core.style"
 local Widget = require "widget"
 local Button = require "widget.button"
@@ -10,6 +11,9 @@ local Container = require "widget.container"
 ---@class core.emptyview : widget
 ---@field super widget
 local EmptyView = Widget:extend()
+
+---@type core.contextmenu
+EmptyView.recent_projects_menu = ContextMenu()
 
 function EmptyView:__tostring() return "EmptyView" end
 
@@ -117,21 +121,22 @@ function EmptyView:new()
   self.recent_projects = ListBox(self)
   self.recent_projects:add_column("Recent Projects")
   self.recent_projects:hide()
-  if core.recent_projects and type(core.recent_projects) == "table" then
-    for _, path in ipairs(core.recent_projects) do
-      self.recent_projects:add_row({common.home_encode(path)}, {path = path})
-    end
-  end
+  self.recent_projects_context_target = nil
+  self.prev_size = { x = self.size.x, y = self.size.y }
+  self:refresh_recent_projects()
   function self.recent_projects:on_mouse_pressed(button, x, y, clicks)
     self.super.on_mouse_pressed(self, button, x, y, clicks)
+    if button == "right" then
+      self:set_selected(self.parent:get_recent_project_row_at(x, y))
+    end
     local idx = self:get_selected()
     local data = self:get_row_data(idx)
-    if clicks == 2 then
+    if button == "right" then
+      self.parent.recent_projects_context_target = data
+    elseif button == "left" and clicks == 2 and data then
       core.open_project(data.path)
     end
   end
-
-  self.prev_size = { x = self.size.x, y = self.size.y }
 
   self:show()
   self:update()
@@ -139,6 +144,94 @@ end
 
 function EmptyView:get_h_scrollable_size()
   return 0
+end
+
+---Find the recent-project row under a screen position.
+---@param x number
+---@param y number
+---@return integer? row
+function EmptyView:get_recent_project_row_at(x, y)
+  if not self.recent_projects:mouse_on_top(x, y) then return nil end
+
+  local list = self.recent_projects
+  local header_height = style.font:get_height() + style.padding.y
+  local scroll_y = list.scroll and list.scroll.y or 0
+  local y_offset = list.position.y + list.border.width - scroll_y
+
+  for idx, row in ipairs(list.rows) do
+    local row_y = y_offset + row.y + (style.padding.y / 2)
+    if idx == 1 then
+      row_y = y_offset + header_height
+    end
+    if y >= row_y and y <= row_y + row.h then
+      return idx
+    end
+  end
+
+  return nil
+end
+
+---Refresh the displayed recent projects from the core session state.
+function EmptyView:refresh_recent_projects()
+  self.recent_projects:clear()
+  self.recent_projects_context_target = nil
+
+  if core.recent_projects and type(core.recent_projects) == "table" then
+    for _, path in ipairs(core.recent_projects) do
+      self.recent_projects:add_row({common.home_encode(path)}, {path = path})
+    end
+  end
+
+  if #self.recent_projects.rows == 0 then
+    self.recent_projects:hide()
+  end
+  self.prev_size.x = -1
+  core.redraw = true
+end
+
+---Get the recent project targeted by the context menu.
+---@return string? path
+function EmptyView:get_selected_recent_project()
+  local data = self.recent_projects_context_target
+  return data and data.path or nil
+end
+
+---Open a recent project in a separate editor instance.
+---@param path string
+function EmptyView:open_recent_project_new_instance(path)
+  system.exec(string.format("%q %q", EXEFILE, path))
+end
+
+---Add a recent project to the current editor instance.
+---@param path string
+function EmptyView:add_recent_project_current_instance(path)
+  local abs_path = system.absolute_path(path)
+  if abs_path then
+    core.add_project(abs_path)
+  else
+    core.error("Cannot add project %q", path)
+  end
+end
+
+---Remove a project from the recent projects list.
+---@param path string
+function EmptyView:remove_recent_project(path)
+  local dirname = common.normalize_volume(path)
+  if not dirname or not core.recent_projects then return end
+
+  for i = #core.recent_projects, 1, -1 do
+    if core.recent_projects[i] == dirname then
+      table.remove(core.recent_projects, i)
+    end
+  end
+
+  self:refresh_recent_projects()
+end
+
+---Remove all projects from the recent projects list.
+function EmptyView:remove_all_recent_projects()
+  core.recent_projects = {}
+  self:refresh_recent_projects()
 end
 
 function EmptyView:on_scale_change(new_scale)
@@ -193,11 +286,30 @@ function EmptyView:draw()
   if not EmptyView.super.draw(self) then return end
   local _, oy = self:get_content_offset()
   draw_text(self, self.text_x, self.text_y + oy)
+  EmptyView.recent_projects_menu:draw()
   self:draw_scrollbar()
+end
+
+function EmptyView:on_mouse_pressed(button, x, y, clicks)
+  if EmptyView.recent_projects_menu.show_context_menu then
+    return EmptyView.recent_projects_menu:on_mouse_pressed(button, x, y, clicks)
+  end
+  local processed = EmptyView.super.on_mouse_pressed(self, button, x, y, clicks)
+  local handled = false
+  if self.recent_projects:mouse_on_top(x, y) then
+    handled = EmptyView.recent_projects_menu:on_mouse_pressed(button, x, y, clicks)
+  end
+  return handled or processed
+end
+
+function EmptyView:on_mouse_moved(x, y, dx, dy)
+  if EmptyView.recent_projects_menu:on_mouse_moved(x, y) then return true end
+  return EmptyView.super.on_mouse_moved(self, x, y, dx, dy)
 end
 
 function EmptyView:update()
   if not EmptyView.super.update(self) then return end
+  EmptyView.recent_projects_menu:update()
 
   self.background_color = style.background
 
@@ -287,5 +399,51 @@ function EmptyView:update()
     EmptyView.super.update(self)
   end
 end
+
+local function recent_project_predicate()
+  local view = core.active_view
+  if view and view:is(EmptyView) then
+    local path = view:get_selected_recent_project()
+    if path then return true, view, path end
+  end
+  return false
+end
+
+local function recent_projects_predicate()
+  local view = core.active_view
+  if view and view:is(EmptyView) and #view.recent_projects.rows > 0 then
+    return true, view
+  end
+  return false
+end
+
+command.add(recent_project_predicate, {
+  ["welcome:open-recent-project-new-instance"] = function(view, path)
+    view:open_recent_project_new_instance(path)
+  end,
+  ["welcome:add-recent-project-current-instance"] = function(view, path)
+    view:add_recent_project_current_instance(path)
+  end,
+  ["welcome:remove-recent-project"] = function(view, path)
+    view:remove_recent_project(path)
+  end
+})
+
+command.add(recent_projects_predicate, {
+  ["welcome:remove-all-recent-projects"] = function(view)
+    view:remove_all_recent_projects()
+  end
+})
+
+EmptyView.recent_projects_menu:register(recent_project_predicate, {
+  { text = "Open in New Instance", command = "welcome:open-recent-project-new-instance" },
+  { text = "Add to Current Instance", command = "welcome:add-recent-project-current-instance" },
+  ContextMenu.DIVIDER,
+  { text = "Remove", command = "welcome:remove-recent-project" }
+})
+
+EmptyView.recent_projects_menu:register(recent_projects_predicate, {
+  { text = "Remove All", command = "welcome:remove-all-recent-projects" }
+})
 
 return EmptyView

--- a/scripts/lua/tests/emptyview.lua
+++ b/scripts/lua/tests/emptyview.lua
@@ -1,0 +1,102 @@
+local test = require "core.test"
+local core = require "core"
+local command = require "core.command"
+local common = require "core.common"
+local style = require "core.style"
+local EmptyView = require "core.emptyview"
+
+test.describe("emptyview", function()
+  local old_recent_projects
+  local old_active_view
+  local old_add_project
+  local old_system_exec
+  local view
+  local project_a
+  local project_b
+
+  test.before_each(function()
+    old_recent_projects = core.recent_projects
+    old_active_view = core.active_view
+    old_add_project = core.add_project
+    old_system_exec = system.exec
+
+    project_a = common.normalize_volume(system.absolute_path(USERDIR))
+    project_b = common.normalize_volume(system.getcwd())
+    core.recent_projects = { project_a, project_b }
+    view = EmptyView()
+    core.active_view = view
+  end)
+
+  test.after_each(function()
+    if view then
+      view:destroy()
+      view = nil
+    end
+    core.recent_projects = old_recent_projects
+    core.active_view = old_active_view
+    core.add_project = old_add_project
+    system.exec = old_system_exec
+  end)
+
+  test.it("populates recent projects", function()
+    test.equal(#view.recent_projects.rows, 2)
+    test.equal(view.recent_projects:get_row_data(1).path, project_a)
+    test.equal(view.recent_projects:get_row_data(2).path, project_b)
+  end)
+
+  test.it("removes a recent project", function()
+    view:remove_recent_project(project_a)
+
+    test.same(core.recent_projects, { project_b })
+    test.equal(#view.recent_projects.rows, 1)
+    test.equal(view.recent_projects:get_row_data(1).path, project_b)
+  end)
+
+  test.it("removes all recent projects", function()
+    view:remove_all_recent_projects()
+
+    test.same(core.recent_projects, {})
+    test.equal(#view.recent_projects.rows, 0)
+    test.not_ok(view.recent_projects:is_visible())
+  end)
+
+  test.it("performs recent project context commands", function()
+    local added_path
+    local exec_command
+    core.add_project = function(path)
+      added_path = path
+    end
+    system.exec = function(cmd)
+      exec_command = cmd
+    end
+
+    view.recent_projects_context_target = { path = project_a }
+
+    command.perform("welcome:add-recent-project-current-instance")
+    test.equal(added_path, project_a)
+
+    command.perform("welcome:open-recent-project-new-instance")
+    test.match(exec_command, string.format("%q", project_a), nil, true)
+
+    command.perform("welcome:remove-recent-project")
+    test.same(core.recent_projects, { project_b })
+  end)
+
+  test.it("targets the right-clicked recent project row", function()
+    local list = view.recent_projects
+    list:show()
+    list:set_position(10, 20)
+    list:set_size(200, 200)
+
+    local x = list.position.x + list.border.width + 1
+    local y = list.position.y
+      + list.border.width
+      + style.font:get_height()
+      + style.padding.y
+      + 1
+
+    list:on_mouse_pressed("right", x, y, 1)
+
+    test.equal(view:get_selected_recent_project(), project_a)
+  end)
+end)


### PR DESCRIPTION
Add a context menu to the welcome view recent projects list so projects can be opened in a new instance, added to the current instance, removed individually, or cleared as a group.

Cover the recent project list mutations and right-click row targeting.

### Preview

<img width="1920" height="1080" alt="20260531-234914" src="https://github.com/user-attachments/assets/7dda9d14-07e9-4ea5-815e-da557ed3c491" />
