### PR TITLE
Use Zig for Linux CI and improve AppImages

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -10,13 +10,13 @@ on:
 jobs:
   build_linux:
     name: Linux
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         config:
-        - { name: "GCC", cc: gcc, cxx: g++, package: false, test: true }
-        - { name: "Zig x86_64", cc: gcc, cxx: g++, zig: true, arch: x86_64, package: true, test: true }
-        - { name: "Zig aarch64", cc: gcc, cxx: g++, zig: true, arch: aarch64, package: false, test: false }
+        - { name: "GCC", distro: ubuntu-22.04, cc: gcc, cxx: g++, package: false, test: true }
+        - { name: "Zig x86_64", distro: ubuntu-22.04, cc: gcc, cxx: g++, zig: true, arch: x86_64, package: true, test: true }
+        - { name: "Zig aarch64", distro: ubuntu-22.04-arm, cc: gcc, cxx: g++, zig: true, arch: aarch64, package: false, test: false }
+    runs-on: ${{ matrix.config.distro }}
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -15,7 +15,7 @@ jobs:
         config:
         - { name: "GCC", distro: ubuntu-22.04, cc: gcc, cxx: g++, package: false, test: true }
         - { name: "Zig x86_64", distro: ubuntu-22.04, cc: gcc, cxx: g++, zig: true, arch: x86_64, package: true, test: true }
-        - { name: "Zig aarch64", distro: ubuntu-22.04-arm, cc: gcc, cxx: g++, zig: true, arch: aarch64, package: false, test: false }
+        # - { name: "Zig aarch64", distro: ubuntu-22.04-arm, cc: gcc, cxx: g++, zig: true, arch: aarch64, package: false, test: false }
     runs-on: ${{ matrix.config.distro }}
     env:
       CC: ${{ matrix.config.cc }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       matrix:
         config:
-        - { name: "GCC", cc: gcc, cxx: g++ }
-        - { name: "clang", cc: clang, cxx: clang++ }
+        - { name: "GCC", cc: gcc, cxx: g++, package: false, test: true }
+        - { name: "Zig x86_64", cc: gcc, cxx: g++, zig: true, arch: x86_64, package: true, test: true }
+        - { name: "Zig aarch64", cc: gcc, cxx: g++, zig: true, arch: aarch64, package: false, test: false }
     env:
       CC: ${{ matrix.config.cc }}
       CXX: ${{ matrix.config.cxx }}
@@ -24,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with: { fetch-depth: 0 }
       - name: Set Environment Variables
-        if: ${{ matrix.config.cc == 'gcc' }}
+        if: ${{ matrix.config.package }}
         run: |
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "INSTALL_REF=${GITHUB_REF##*/}" >> "$GITHUB_ENV"
@@ -35,24 +36,39 @@ jobs:
           python-version: 3.9
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
+      - name: Setup Zig
+        if: ${{ matrix.config.zig }}
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
       - name: Update Packages
         run: sudo apt-get update
       - name: Install Dependencies
         run: bash scripts/install-dependencies.sh --debug
       - name: Build
+        if: ${{ !matrix.config.zig }}
         run: |
           bash --version
           bash scripts/build.sh --debug --forcefallback --portable
+      - name: Build with Zig
+        if: ${{ matrix.config.zig }}
+        run: |
+          bash --version
+          bash scripts/build.sh --debug --forcefallback --portable \
+            --cross-platform linux \
+            --cross-arch ${{ matrix.config.arch }} \
+            --cross-file resources/cross/linux-zig-${{ matrix.config.arch }}.ini
       - name: Run Tests
+        if: ${{ matrix.config.test }}
         run: |
           source scripts/common.sh
           SDL_VIDEO_DRIVER=dummy ./scripts/run-local "$(get_default_build_dir)" test scripts/lua/tests
       - name: Package
-        if: ${{ matrix.config.cc == 'gcc' }}
+        if: ${{ matrix.config.package }}
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --binary
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.config.cc == 'gcc' }}
+        if: ${{ matrix.config.package }}
         with:
           name: Linux x86_64
           path: ${{ env.INSTALL_NAME }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.9
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
       - name: Setup cmake
         run: |
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
@@ -104,7 +108,10 @@ jobs:
           bash scripts/install-dependencies.sh --debug
       - name: Build Portable
         run: |
-          bash scripts/build.sh --debug --forcefallback --portable --release --lto --pgo
+          bash scripts/build.sh --debug --forcefallback --portable --release --lto --pgo \
+            --cross-platform linux \
+            --cross-arch ${{ matrix.config.arch }} \
+            --cross-file resources/cross/linux-zig-${{ matrix.config.arch }}.ini
       - name: Package Portables
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
       - name: Build AppImages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Install Dependencies
         run: |
           bash scripts/install-dependencies.sh --debug
+          sudo apt-get install -y zsync
       - name: Build Portable
         run: |
           bash scripts/build.sh --debug --forcefallback --portable --release --lto --pgo \
@@ -115,7 +116,10 @@ jobs:
       - name: Package Portables
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary --release
       - name: Build AppImages
-        run: bash scripts/appimage.sh --debug --static --addons --version ${INSTALL_REF} --nobuild --release
+        run: >
+          bash scripts/appimage.sh --debug --static --addons
+          --version ${INSTALL_REF} --nobuild --release
+          --update-channel stable
       - name: Upload Files
         uses: softprops/action-gh-release@v3
         with:
@@ -124,6 +128,7 @@ jobs:
           files: |
             pragtical-${{ env.INSTALL_REF }}-linux-${{ matrix.config.arch }}-portable.tar.gz
             Pragtical-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}.AppImage
+            Pragtical-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}.AppImage.zsync
 
   build_macos:
     name: macOS

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -82,6 +82,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.9
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
       - name: Setup cmake
         run: |
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
@@ -102,7 +106,10 @@ jobs:
           bash scripts/install-dependencies.sh --debug
       - name: Build Portable
         run: |
-          bash scripts/build.sh --debug --forcefallback --portable --lto --pgo
+          bash scripts/build.sh --debug --forcefallback --portable --lto --pgo \
+            --cross-platform linux \
+            --cross-arch ${{ matrix.config.arch }} \
+            --cross-file resources/cross/linux-zig-${{ matrix.config.arch }}.ini
       - name: Run Tests
         run: |
           source scripts/common.sh

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Install Dependencies
         run: |
           bash scripts/install-dependencies.sh --debug
+          sudo apt-get install -y zsync
       - name: Build Portable
         run: |
           bash scripts/build.sh --debug --forcefallback --portable --lto --pgo \
@@ -117,7 +118,10 @@ jobs:
       - name: Package Portables
         run: bash scripts/package.sh --version ${INSTALL_REF} --debug --addons --binary
       - name: Build AppImages
-        run: bash scripts/appimage.sh --debug --static --addons --version ${INSTALL_REF} --nobuild
+        run: >
+          bash scripts/appimage.sh --debug --static --addons
+          --version ${INSTALL_REF} --nobuild
+          --update-channel rolling
       - name: Upload Files
         uses: softprops/action-gh-release@v3
         with:
@@ -127,6 +131,7 @@ jobs:
           files: |
             pragtical-${{ env.INSTALL_REF }}-linux-${{ matrix.config.arch }}-portable.tar.gz
             Pragtical-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}.AppImage
+            Pragtical-${{ env.INSTALL_REF }}-${{ matrix.config.arch }}.AppImage.zsync
 
   build_macos:
     name: macOS

--- a/resources/cross/linux-zig-aarch64.ini
+++ b/resources/cross/linux-zig-aarch64.ini
@@ -16,3 +16,7 @@ objcopy = ['zig', 'objcopy']
 strip = 'strip'
 cmake = 'cmake'
 pkg-config = 'pkg-config'
+
+[built-in options]
+c_args = ['-isystem', '/usr/include/aarch64-linux-gnu']
+cpp_args = ['-isystem', '/usr/include/aarch64-linux-gnu']

--- a/resources/cross/linux-zig-aarch64.ini
+++ b/resources/cross/linux-zig-aarch64.ini
@@ -1,0 +1,18 @@
+# cross file for Linux aarch64 with Zig.
+# use this file by running meson setup --cross-file resources/cross/linux-zig-aarch64.ini <builddir>
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[binaries]
+c = ['zig', 'cc', '-target', 'aarch64-linux-gnu.2.17.0']
+cpp = ['zig', 'c++', '-target', 'aarch64-linux-gnu.2.17.0']
+ar = ['sh', '@GLOBAL_SOURCE_ROOT@/scripts/zig-ar.sh']
+ranlib = ['zig', 'ranlib']
+objcopy = ['zig', 'objcopy']
+strip = 'strip'
+cmake = 'cmake'
+pkg-config = 'pkg-config'

--- a/resources/cross/linux-zig-x86_64.ini
+++ b/resources/cross/linux-zig-x86_64.ini
@@ -16,3 +16,7 @@ objcopy = ['zig', 'objcopy']
 strip = 'strip'
 cmake = 'cmake'
 pkg-config = 'pkg-config'
+
+[built-in options]
+c_args = ['-isystem', '/usr/include/x86_64-linux-gnu']
+cpp_args = ['-isystem', '/usr/include/x86_64-linux-gnu']

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -79,6 +79,25 @@ download_plugin_manager() {
   fi
 }
 
+prune_appdir_development_files() {
+  local static_build=$1
+
+  if [[ $static_build == true ]]; then
+    pushd Pragtical.AppDir > /dev/null
+    find . -type d -name 'include' -prune -exec rm -rf {} \;
+    find . -type d -name 'lib' -prune -exec rm -rf {} \;
+    find . -type d -empty -delete
+    popd > /dev/null
+  else
+    find Pragtical.AppDir/usr -type d -name 'include' -prune -exec rm -rf {} \;
+    if [[ -d Pragtical.AppDir/usr/lib ]]; then
+      find Pragtical.AppDir/usr/lib -type f \( -name '*.a' -o -name '*.la' \) -delete
+      find Pragtical.AppDir/usr/lib -type d -name 'pkgconfig' -prune -exec rm -rf {} \;
+    fi
+    find Pragtical.AppDir -type d -empty -delete
+  fi
+}
+
 main() {
   local arch="$(uname -m)"
   local native_arch=$arch
@@ -252,6 +271,8 @@ main() {
       rm -rf "Pragtical.AppDir/usr/data"
     fi
   fi
+
+  prune_appdir_development_files "$static_build"
 
   if [[ -z "$cross" ]]; then
     polyfill_glibc Pragtical.AppDir/usr/bin/pragtical

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -26,6 +26,7 @@ show_help(){
   echo "-L --lto                 Enables Link-Time Optimization (LTO)."
   echo "-r --release             Compile in release mode."
   echo "--cross-arch ARCH        The architecture to package for."
+  echo "--update-channel CHANNEL Embed update metadata. One of: stable, rolling."
   echo
 }
 
@@ -113,6 +114,8 @@ main() {
   local lto
   local cross
   local cross_arch
+  local update_channel
+  local update_information=()
 
   initial_arg_count=$#
 
@@ -166,6 +169,11 @@ main() {
         shift
         shift
         ;;
+      --update-channel)
+        update_channel="$2"
+        shift
+        shift
+        ;;
       *)
         # unknown option
         ;;
@@ -197,6 +205,32 @@ main() {
     ppm_file="ppm.${arch}-linux"
     # reload build_dir because platform and arch might change
     build_dir="$(get_default_build_dir "linux" "$arch")"
+  fi
+
+  case "$update_channel" in
+    "")
+      ;;
+    stable)
+      update_information=(
+        --updateinformation
+        "gh-releases-zsync|pragtical|pragtical|latest|Pragtical-*-${arch}.AppImage.zsync"
+      )
+      ;;
+    rolling)
+      update_information=(
+        --updateinformation
+        "gh-releases-zsync|pragtical|pragtical|latest-pre|Pragtical-*-${arch}.AppImage.zsync"
+      )
+      ;;
+    *)
+      echo "Unsupported update channel '${update_channel}'. Expected 'stable' or 'rolling'."
+      exit 1
+      ;;
+  esac
+
+  if [[ -n "$update_channel" ]] && ! command -v zsyncmake > /dev/null; then
+    echo "zsyncmake is required to generate update metadata."
+    exit 1
   fi
 
   # Setup appimage tools
@@ -321,6 +355,7 @@ main() {
   echo "Generating AppImage..."
 
   $appimagebin --appimage-extract-and-run --runtime-file "runtime-${arch}" \
+    "${update_information[@]}" \
     Pragtical.AppDir \
     "Pragtical${version}-${arch}.AppImage"
 }

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -37,7 +37,7 @@ main() {
   fi
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6 libharfbuzz-dev llvm-14
+    sudo apt-get install -qq libfuse2 ninja-build wayland-protocols libsdl2-dev libfreetype6 libharfbuzz-dev libtiff-dev llvm-14
     pip3 install meson
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install bash ninja sdl2 harfbuzz coreutils # coreutils for grealpath


### PR DESCRIPTION
This PR updates Linux CI and packaging so release artifacts are built through the Zig cross files and AppImages are
smaller and update-ready.

Changes:

- Build Linux release and rolling artifacts with Zig cross files for x86_64 and aarch64.
- Add PR CI validation for Zig x86_64 and aarch64 Linux builds.
- Move PR portable artifact packaging to the Zig x86_64 build.
- Prune headers, static libraries, and development-only files from AppImages.
- Add AppImage zsync update metadata for stable and rolling channels.
- Upload generated .AppImage.zsync files alongside release and rolling AppImages.

Validation:

- Local Zig x86_64 build completed successfully.
- Headless Lua tests passed locally.
- Generated local AppImage size dropped to about 8.7M after pruning.
- Local zsync AppImage generation produced a .AppImage.zsync file and embedded the expected update information.