### PR TITLE
findfile: always resolve against open project root

### DIFF
--- a/data/plugins/findfile.lua
+++ b/data/plugins/findfile.lua
@@ -385,7 +385,7 @@ local function submit_project_file(text, selection_callback, selected_line)
     end
   end
 
-  local project = multiple_projects and core.projects[1] or core.current_project()
+  local project = core.projects[1]
   if selection_callback then
     local filename = file_in_project(project, text)
     if filename then selection_callback(filename, selected_line) end


### PR DESCRIPTION
core:find-file was calling core.current_project() with no argument in single-project mode. When an external file was the active tab, current_project() returned a synthetic Project rooted at that file's directory, causing selected project files to fail to open.

Use core.projects[1] directly so the path is always resolved against the actual open project.

Fixes: #524 