### PR TITLE
Skip stale visual rows while drawing

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -1432,7 +1432,7 @@ function DocView:draw()
   local drawn_gutters = {}
   for row = minline, maxline do
     local line = self:visual_position_from_row(row)
-    if line and not drawn_gutters[line] then
+    if line and self.doc.lines[line] and not drawn_gutters[line] then
       local first_row = self:visual_row_from_position(line, 1)
       local line_y = y - (row - first_row) * lh
       self:draw_line_gutter(line, self.position.x, line_y, gpad and gw - gpad or gw)
@@ -1452,7 +1452,7 @@ function DocView:draw()
   local drawn_lines = {}
   for row = minline, maxline do
     local line = self:visual_position_from_row(row)
-    if line and not drawn_lines[line] then
+    if line and self.doc.lines[line] and not drawn_lines[line] then
       local first_row = self:visual_row_from_position(line, 1)
       local line_y = y - (row - first_row) * lh
       self:draw_line_body(line, x, line_y)

--- a/scripts/lua/tests/docview.lua
+++ b/scripts/lua/tests/docview.lua
@@ -1,4 +1,5 @@
 local test = require "core.test"
+local core = require "core"
 local Doc = require "core.doc"
 local DocView = require "core.docview"
 local style = require "core.style"
@@ -223,6 +224,42 @@ test.describe("docview", function()
         test.ok(found_text)
       end)
     end)
+  end)
+
+  test.test("draw skips stale visual rows without backing document lines", function()
+    local view = make_view("one\n")
+    view.size.y = view:get_line_height() * 2
+    view.visual_line_count = function() return 2 end
+    view.visual_position_from_row = function(_, row)
+      return row
+    end
+
+    local invalid_gutter = false
+    local invalid_body = false
+    view.draw_line_gutter = function(_, line)
+      if line == 2 then invalid_gutter = true end
+    end
+    view.draw_line_body = function(_, line)
+      if line == 2 then invalid_body = true end
+      return view:get_line_height()
+    end
+
+    local push_clip_rect = core.push_clip_rect
+    local pop_clip_rect = core.pop_clip_rect
+    core.push_clip_rect = function() end
+    core.pop_clip_rect = function() end
+
+    local ok, err = pcall(function()
+      with_draw_rect(function()
+        view:draw()
+      end)
+    end)
+    core.push_clip_rect = push_clip_rect
+    core.pop_clip_rect = pop_clip_rect
+    if not ok then error(err, 0) end
+
+    test.equal(invalid_gutter, false)
+    test.equal(invalid_body, false)
   end)
 
   test.test("draw_line_text slices long lines to the visible range", function()


### PR DESCRIPTION
Avoid dispatching gutter or body draw calls for visual rows whose resolved document line no longer has backing text. Virtual line state can briefly be stale after edits or plugin updates, and passing those line numbers into draw hooks caused plugins such as whitespace or parenthesis highlighters to index nil document lines.

Add a DocView regression test that simulates a stale visual row and asserts that invalid rows are ignored during drawing.