### PR TITLE
Use startup scale env for restarts

### DIFF
--- a/data/plugins/scale.lua
+++ b/data/plugins/scale.lua
@@ -26,16 +26,14 @@ config.plugins.scale = common.merge({
 local scale_steps = 0.05
 local current_scale = SCALE
 local current_code_scale = SCALE
-local user_scale = tonumber(
-  os.getenv("PRAGTICAL_SCALE_RESTART") or os.getenv("PRAGTICAL_SCALE")
-)
+local user_scale = tonumber(os.getenv("PRAGTICAL_SCALE"))
 
 ---@class plugins.scale
 local scale = {}
 
 function scale.set(scale)
   if current_scale == scale then return end
-  system.setenv("PRAGTICAL_SCALE_RESTART", scale)
+  system.setenv("PRAGTICAL_SCALE", scale)
 
   scale = common.clamp(scale, 0.2, 6)
 
@@ -90,7 +88,7 @@ end
 
 function scale.set_code(scale)
   if current_code_scale == scale then return end
-  system.setenv("PRAGTICAL_SCALE_CODE_RESTART", scale)
+  system.setenv("PRAGTICAL_SCALE_CODE", scale)
 
   scale = common.clamp(scale, 0.2, 6)
 
@@ -253,14 +251,13 @@ if config.plugins.scale.use_mousewheel then
   }
 end
 
--- Apply previous scale on restart set on PRAGTICAL_SCALE_RESTART and
--- PRAGTICAL_SCALE_CODE_RESTART or custom PRAGTICAL_SCALE if set by user
+-- Apply previous scale on restart set on PRAGTICAL_SCALE and PRAGTICAL_SCALE_CODE.
 if user_scale then
   -- to prevent issues on restart we defer it
   core.add_thread(function()
     scale.set(user_scale)
     scale.set_code(
-      tonumber(os.getenv("PRAGTICAL_SCALE_CODE_RESTART")) or user_scale
+      tonumber(os.getenv("PRAGTICAL_SCALE_CODE")) or user_scale
     )
   end)
 end

--- a/scripts/run-local
+++ b/scripts/run-local
@@ -140,9 +140,9 @@ run_pragtical () {
   else
     echo "running \"pragtical ${pargs[@]:1}\" with local HOME"
     if [[ $run_windows == true ]]; then
-      USERPROFILE="$userdir" ./$bindir/pragtical "${pargs[@]:1}"
+      PRAGTICAL_SCALE=1 USERPROFILE="$userdir" ./$bindir/pragtical "${pargs[@]:1}"
     else
-      PRAGTICAL_USERDIR="$userdir" ./$bindir/pragtical "${pargs[@]:1}"
+      PRAGTICAL_SCALE=1 PRAGTICAL_USERDIR="$userdir" ./$bindir/pragtical "${pargs[@]:1}"
     fi
   fi
 }


### PR DESCRIPTION
Store scale changes in PRAGTICAL_SCALE and PRAGTICAL_SCALE_CODE instead of separate restart-only variables. These variables are read before anything is drawn during startup, which lets scale-triggered restarts come back at the target scale without an intermediate resize.

Set PRAGTICAL_SCALE=1 for scripts/run-local launches so tests and local isolated runs keep a predictable baseline regardless of the user's current session scale.