### PR TITLE
Copy LuaJIT modules for local runs

### DIFF
--- a/scripts/run-local
+++ b/scripts/run-local
@@ -106,6 +106,13 @@ copy_pragtical_build () {
   if [ -d "subprojects/plugins" ]; then
     cp -a "subprojects/plugins/plugins/"language_* "$datadir/plugins"
   fi
+  if [ -d "$builddir/subprojects/luajit/src" ] && [ -d "subprojects/luajit/src/jit" ]; then
+    mkdir -p "$datadir/jit"
+    cp -a "subprojects/luajit/src/jit/." "$datadir/jit"
+    if [ -f "$builddir/subprojects/luajit/src/vmdef.lua" ]; then
+      cp -a "$builddir/subprojects/luajit/src/vmdef.lua" "$datadir/jit"
+    fi
+  fi
   if [ -d "subprojects/ppm" ]; then
     if [ -d "$builddir/subprojects/ppm" ] && ls "$builddir"/subprojects/ppm/ppm.*; then
       cp -a "subprojects/ppm/plugins/plugin_manager" "$datadir/plugins"


### PR DESCRIPTION
Mirror the LuaJIT subproject install in scripts/run-local by copying the jit helper modules into the local data directory when the subproject was built. Also copy the generated vmdef.lua file when it is available.

This lets local .run sessions resolve modules such as jit.p, matching the installed layout used by the Meson subproject.