### PR TITLE
Gate project modules behind trust

### DIFF
--- a/data/core/init.lua
+++ b/data/core/init.lua
@@ -49,6 +49,30 @@ local function save_session()
 end
 
 
+local function normalize_project_path(project)
+  local path = type(project) == "table" and project.path or project
+  if type(path) ~= "string" then return nil end
+  return common.normalize_volume(system.absolute_path(path) or path)
+end
+
+
+local function load_trusted_projects()
+  local ok, trusted = pcall(dofile, USERDIR .. PATHSEP .. "trusted_projects.lua")
+  return ok and type(trusted) == "table" and trusted or {}
+end
+
+
+local function save_trusted_projects()
+  local fp = io.open(USERDIR .. PATHSEP .. "trusted_projects.lua", "w")
+  if fp then
+    fp:write("return " .. common.serialize(core.trusted_projects or {}, {pretty = true}))
+    fp:close()
+    return true
+  end
+  return false
+end
+
+
 local function update_recents_project(action, dir_path_abs)
   local dirname = common.normalize_volume(dir_path_abs)
   if not dirname then return end
@@ -110,6 +134,53 @@ function core.set_project(project)
   local project_object = core.add_project(project)
   system.chdir(project_object.path)
   return project_object
+end
+
+
+function core.is_project_trusted(project)
+  local project_path = normalize_project_path(project)
+  return project_path ~= nil and (core.trusted_projects or {})[project_path] == true
+end
+
+
+function core.trust_project(project)
+  local project_path = normalize_project_path(project)
+  if not project_path then return false end
+  core.trusted_projects = core.trusted_projects or {}
+  core.trusted_projects[project_path] = true
+  save_trusted_projects()
+  return project_path
+end
+
+
+function core.prompt_project_trust(project, options, callback)
+  local project_path = normalize_project_path(project)
+  if not project_path then return false end
+
+  options = options or {}
+  local trust_text = options.trust_text or "Trust Project"
+  local continue_text = options.continue_text or "Continue Without Trust"
+  core.nag_view:show(
+    "Trust Project",
+    string.format(
+      "The project \"%s\" contains a .pragtical_project.lua file.\n\n" ..
+      "Trust this project to allow Pragtical to load that file?",
+      common.home_encode(project_path)
+    ),
+    {
+      { text = trust_text, default_yes = true },
+      { text = continue_text, default_no = true }
+    },
+    function(item)
+      if item.text == trust_text then
+        core.trust_project(project_path)
+        if callback then callback(true, project_path) end
+      elseif item.text == continue_text then
+        if callback then callback(false, project_path) end
+      end
+    end
+  )
+  return true
 end
 
 
@@ -420,6 +491,7 @@ function core.init()
   end
   -- Ensure that we have a user directory.
   core.ensure_user_directory()
+  core.trusted_projects = load_trusted_projects()
 
   --Set the maximum fps from display refresh rate.
   config.fps = DEFAULT_FPS
@@ -567,6 +639,29 @@ function core.init()
     core.add_thread(function()
       command.perform("core:open-log")
     end)
+  end
+
+  do
+    local project_path = normalize_project_path(core.root_project())
+    local project_module = project_path
+      and project_path .. PATHSEP .. ".pragtical_project.lua"
+    local info = project_module and system.get_file_info(project_module)
+    if info and info.type ~= "dir" and not core.is_project_trusted(project_path) then
+      core.add_thread(function()
+        core.prompt_project_trust(
+          project_path,
+          {
+            trust_text = "Trust and Restart",
+            continue_text = "Continue Without Trust"
+          },
+          function(trusted)
+            if trusted then
+              command.perform("core:restart")
+            end
+          end
+        )
+      end)
+    end
   end
 
   core.configure_borderless_window()
@@ -773,9 +868,27 @@ function core.load_plugins()
     datadir = {dir = DATADIR, plugins = {}},
   }
   local files, ordered = {}, {
-    { priority = -2, load = load_lua_plugin_if_exists, version_match = true, file = USERDIR .. PATHSEP .. "init.lua", name = "User Module" },
-    { priority = -1, load = load_lua_plugin_if_exists, version_match = true, file = core.root_project().path .. PATHSEP .. ".pragtical_project.lua", name = "Project Module" }
+    { priority = -2, load = load_lua_plugin_if_exists, version_match = true, file = USERDIR .. PATHSEP .. "init.lua", name = "User Module" }
   }
+  do
+    local project_path = normalize_project_path(core.root_project())
+    local project_module = project_path
+      and project_path .. PATHSEP .. ".pragtical_project.lua"
+    local info = project_module and system.get_file_info(project_module)
+    if info and info.type ~= "dir" then
+      if core.is_project_trusted(project_path) then
+        table.insert(ordered, {
+          priority = -1,
+          load = load_lua_plugin_if_exists,
+          version_match = true,
+          file = project_module,
+          name = "Project Module"
+        })
+      else
+        core.log_quiet("Skipped untrusted project module from %s", project_path)
+      end
+    end
+  end
   for _, root_dir in ipairs {DATADIR, USERDIR} do
     local plugin_dir = root_dir .. PATHSEP .. "plugins"
     for _, filename in ipairs(system.list_dir(plugin_dir) or {}) do

--- a/data/plugins/autorestart.lua
+++ b/data/plugins/autorestart.lua
@@ -35,6 +35,23 @@ Doc.save = function(self, ...)
   local user = USERDIR .. PATHSEP .. "init.lua"
   local project = core.root_project().path .. PATHSEP .. ".pragtical_project.lua"
   if self.abs_filename == user or self.abs_filename == project then
+    if self.abs_filename == project and not core.is_project_trusted(core.root_project()) then
+      core.add_thread(function()
+        core.prompt_project_trust(
+          core.root_project(),
+          {
+            trust_text = "Trust and Restart",
+            continue_text = "Ignore"
+          },
+          function(trusted)
+            if trusted then
+              command.perform("core:restart")
+            end
+          end
+        )
+      end)
+      return res
+    end
     if config.plugins.autorestart.reload_type == "restart" then
       command.perform("core:restart")
     elseif config.plugins.autorestart.reload_type == "reload" then

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -2514,9 +2514,14 @@ function core.run()
   -- reloading these user modules, got an idea time ago and forgot it :(
   if settings.config.reload_user_modules then
     local modules = {
-      USERDIR .. PATHSEP .. "init.lua",
-      core.root_project().path .. PATHSEP .. ".pragtical_project.lua"
+      USERDIR .. PATHSEP .. "init.lua"
     }
+    if core.is_project_trusted(core.root_project()) then
+      table.insert(
+        modules,
+        core.root_project().path .. PATHSEP .. ".pragtical_project.lua"
+      )
+    end
     for _, module in ipairs(modules) do
       core.reload_absolute_module(module)
     end

--- a/scripts/lua/tests/project_trust.lua
+++ b/scripts/lua/tests/project_trust.lua
@@ -1,0 +1,127 @@
+local common = require "core.common"
+local core = require "core"
+local test = require "core.test"
+
+local function join_path(...)
+  return table.concat({...}, PATHSEP)
+end
+
+local function write_file(path, content)
+  local file, err = io.open(path, "wb")
+  test.not_nil(file, err)
+  file:write(content or "")
+  file:close()
+end
+
+local function read_file(path)
+  local file = io.open(path, "rb")
+  if not file then return nil end
+  local content = file:read("*a")
+  file:close()
+  return content
+end
+
+test.describe("project trust", function()
+  local trusted_projects_file = join_path(USERDIR, "trusted_projects.lua")
+
+  test.before_each(function(context)
+    context.old_trusted_projects = core.trusted_projects
+    context.old_nag_view = core.nag_view
+    context.old_trusted_projects_file = read_file(trusted_projects_file)
+    context.temp_root = join_path(
+      USERDIR,
+      "project-trust-tests-" .. system.get_process_id()
+        .. "-" .. math.floor(system.get_time() * 1000000)
+    )
+    context.project_path = join_path(context.temp_root, "project")
+    local ok, err = common.mkdirp(context.project_path)
+    test.ok(ok, err)
+    write_file(
+      join_path(context.project_path, ".pragtical_project.lua"),
+      "-- mod-version:3\nreturn true\n"
+    )
+    core.trusted_projects = {}
+    os.remove(trusted_projects_file)
+  end)
+
+  test.after_each(function(context)
+    core.trusted_projects = context.old_trusted_projects
+    core.nag_view = context.old_nag_view
+    if context.old_trusted_projects_file then
+      write_file(trusted_projects_file, context.old_trusted_projects_file)
+    else
+      os.remove(trusted_projects_file)
+    end
+    if context.temp_root and system.get_file_info(context.temp_root) then
+      local ok, err = common.rm(context.temp_root, true)
+      test.ok(ok, err)
+    end
+  end)
+
+  test.test("persists trusted project paths", function(context)
+    test.equal(core.is_project_trusted(context.project_path), false)
+
+    local trusted_path = core.trust_project(context.project_path)
+    test.equal(core.is_project_trusted(context.project_path), true)
+
+    local stored = dofile(trusted_projects_file)
+    test.equal(stored[trusted_path], true)
+  end)
+
+  test.test("trust prompt records trusted choices", function(context)
+    local callback_trusted
+    local callback_path
+    local prompt
+    core.nag_view = {
+      show = function(_, title, message, options, callback)
+        prompt = {
+          title = title,
+          message = message,
+          options = options,
+          callback = callback
+        }
+      end
+    }
+
+    test.ok(core.prompt_project_trust(
+      context.project_path,
+      { trust_text = "Trust and Open", continue_text = "Open Without Trust" },
+      function(trusted, path)
+        callback_trusted = trusted
+        callback_path = path
+      end
+    ))
+    test.equal(prompt.title, "Trust Project")
+    test.not_nil(prompt.message:find(".pragtical_project.lua", 1, true))
+    test.equal(#prompt.options, 2)
+
+    prompt.callback(prompt.options[1])
+
+    test.equal(callback_trusted, true)
+    test.equal(core.is_project_trusted(context.project_path), true)
+    local stored = dofile(trusted_projects_file)
+    test.equal(stored[callback_path], true)
+  end)
+
+  test.test("trust prompt continues without recording trust", function(context)
+    local callback_trusted
+    local prompt
+    core.nag_view = {
+      show = function(_, _, _, options, callback)
+        prompt = { options = options, callback = callback }
+      end
+    }
+
+    core.prompt_project_trust(
+      context.project_path,
+      { trust_text = "Trust and Open", continue_text = "Open Without Trust" },
+      function(trusted)
+        callback_trusted = trusted
+      end
+    )
+    prompt.callback(prompt.options[2])
+
+    test.equal(callback_trusted, false)
+    test.equal(core.is_project_trusted(context.project_path), false)
+  end)
+end)


### PR DESCRIPTION
Persist trusted project paths in the user directory and skip loading .pragtical_project.lua until the project is trusted. Guard autorestart and settings reload paths so they cannot reload an untrusted project module directly.

### Preview

<img width="1920" height="1080" alt="project-trust" src="https://github.com/user-attachments/assets/f2974efc-7674-4aa4-8ede-6bc6b0dc4bba" />
