### PR TITLE
Skip net Lua files when net is disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -388,8 +388,20 @@ endif
 
 install_data('licenses/licenses.md', install_dir : pragtical_docdir)
 
-install_subdir('docs/api' , install_dir : pragtical_datadir, strip_directory: true)
-install_subdir('data/core' , install_dir : pragtical_datadir, exclude_files : 'start.lua')
+install_subdir(
+    'docs/api',
+    install_dir : pragtical_datadir,
+    strip_directory : true,
+    exclude_files : get_option('net') ? [] : ['net.lua']
+)
+
+install_subdir(
+    'data/core',
+    install_dir : pragtical_datadir,
+    exclude_files : get_option('net') ? ['start.lua'] : [
+        'start.lua', 'http.lua', 'websocket.lua'
+    ]
+)
 
 fs = import('fs')
 


### PR DESCRIPTION
Avoid installing the net API docs and Lua networking modules when Meson is configured with -Dnet=false.

Partially addresses #531 

We also need to update `lsp` and `assistant` to detect that net module is not available and disable the dependent functionality or fail gracefully (assistant)