### PR TITLE
Clear fold hover state on mouse leave

### DIFF
--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -968,6 +968,18 @@ function DocView:on_mouse_moved(x, y, ...)
 end
 
 
+---Handle mouse leaving the view area.
+---Clears hover state that would otherwise remain until the next mouse move
+---inside the DocView.
+function DocView:on_mouse_left()
+  DocView.super.on_mouse_left(self)
+  if self.hovering_gutter then
+    self.hovering_gutter = false
+    core.redraw = true
+  end
+end
+
+
 ---Adjust selection based on snap type (word, line).
 ---@param doc core.doc Document
 ---@param snap_type string Snap type: "word" or "lines"

--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -1214,6 +1214,15 @@ function DocView:on_mouse_moved(x, y, ...)
   end
 end
 
+local docview_on_mouse_left = DocView.on_mouse_left
+function DocView:on_mouse_left()
+  docview_on_mouse_left(self)
+  if self.cf_hovering_toggle then
+    self.cf_hovering_toggle = nil
+    core.redraw = true
+  end
+end
+
 ---------------------------------------------------------------------
 -- Method overrides: Doc (incremental invalidation)
 ---------------------------------------------------------------------

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -849,6 +849,15 @@ test.describe("codefold - virtual line mapping", function()
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
       test.equal(calls[#calls].color, style.dim or style.line_number)
 
+      view.cf_hovering_toggle = 1
+      view:on_mouse_left()
+      test.equal(view.hovering_gutter, false)
+      test.is_nil(view.cf_hovering_toggle)
+
+      local count = #calls
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(#calls, count + 1)
+
       view.hovering_gutter = false
       config.plugins.codefold.always_show_fold_markers = true
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
@@ -864,6 +873,11 @@ test.describe("codefold - virtual line mapping", function()
       view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
       test.equal(calls[#calls].color, style.accent)
       test.equal(view.cf_toggle_font, toggle_font)
+
+      view:on_mouse_left()
+      test.is_nil(view.cf_hovering_toggle)
+      view:draw_line_gutter(1, view.position.x, y, view:get_gutter_width())
+      test.equal(calls[#calls].color, style.caret)
     end)
 
     config.plugins.codefold.enabled = previous_enabled


### PR DESCRIPTION
Clear DocView gutter hover state when the mouse leaves the editor view so hover-only gutter UI does not remain visible after moving into another view. Also clear the codefold marker hover state so folded markers lose their hover accent when leaving the editor.

Add coverage for unfolded marker visibility and folded marker hover color after mouse leave.