### PR TITLE
 Fix DiffView scrollbar markers and disable folding in diffs

### DIFF
--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -66,6 +66,15 @@ local CODEFOLD_SOURCE_FONT = nil
 
 local codefold = {}
 
+---Return whether code folding should run for a given view.
+---@param self core.view
+---@return boolean
+local function codefold_enabled_for_view(self)
+  return config.plugins.codefold.enabled
+    and self:is(DocView)
+    and not self.code_folding_disabled
+end
+
 local function maybe_yield()
   if coroutine.isyieldable() then coroutine.yield() end
 end
@@ -1049,7 +1058,7 @@ end
 
 local docview_get_hidden_lines = DocView.get_hidden_lines
 function DocView:get_hidden_lines()
-  if config.plugins.codefold.enabled and self:is(DocView)
+  if codefold_enabled_for_view(self)
     and self.cf_folded_regions and #self.cf_folded_regions > 0 then
     return self.cf_hidden_lines or build_hidden_set(self)
   end
@@ -1059,7 +1068,7 @@ end
 local docview_ensure_line_visible = DocView.ensure_line_visible
 function DocView:ensure_line_visible(line)
   line = docview_ensure_line_visible(self, line)
-  if not config.plugins.codefold.enabled or not self:is(DocView) then
+  if not codefold_enabled_for_view(self) then
     return line
   end
   if not self.cf_unfold_map or self.cf_unfold_map[line] then
@@ -1101,7 +1110,7 @@ local docview_update = DocView.update
 function DocView:update(...)
   docview_update(self, ...)
 
-  if not config.plugins.codefold.enabled or not self:is(DocView) then
+  if not codefold_enabled_for_view(self) then
     return
   end
 
@@ -1129,7 +1138,7 @@ end
 
 local docview_get_gutter_width = DocView.get_gutter_width
 function DocView:get_gutter_width()
-  if not config.plugins.codefold.enabled or not self:is(DocView) then
+  if not codefold_enabled_for_view(self) then
     return docview_get_gutter_width(self)
   end
   local base_width, padding = docview_get_gutter_width(self)
@@ -1145,7 +1154,7 @@ end
 local docview_draw_line_gutter = DocView.draw_line_gutter
 function DocView:draw_line_gutter(line, x, y, width)
   local result = docview_draw_line_gutter(self, line, x, y, width)
-  if config.plugins.codefold.enabled and self:is(DocView) then
+  if codefold_enabled_for_view(self) then
     local region_idx = region_at_line(self, line)
     if region_idx then
       local folded = is_folded(self, region_idx)
@@ -1177,7 +1186,7 @@ end
 local docview_on_mouse_pressed = DocView.on_mouse_pressed
 function DocView:on_mouse_pressed(button, x, y, clicks)
   -- Mirror the original gutter handler: trust the hover flag set in on_mouse_moved.
-  if config.plugins.codefold.enabled and self:is(DocView)
+  if codefold_enabled_for_view(self)
     and button == "left" and self.cf_hovering_toggle then
     local line = self:resolve_screen_position(x, y)
     if line then
@@ -1199,7 +1208,7 @@ function DocView:on_mouse_moved(x, y, ...)
   -- Then decide if we're hovering a fold toggle (leftmost portion of gutter).
   local was_hovering = self.cf_hovering_toggle
   self.cf_hovering_toggle = nil
-  if config.plugins.codefold.enabled and self:is(DocView) then
+  if codefold_enabled_for_view(self) then
     local toggle_x, toggle_w = fold_toggle_rect(self)
     if x >= toggle_x and x < toggle_x + toggle_w then
       local line = self:resolve_screen_position(x, y)
@@ -1232,7 +1241,7 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
   local result = doc_raw_insert(self, line, col, text, undo_stack, time)
   -- Invalidate fold state on all views of this doc
   for _, view in ipairs(core.get_views_referencing_doc(self)) do
-    if view:is(DocView) and view.cf_regions then
+    if codefold_enabled_for_view(view) and view.cf_regions then
       schedule_recalculation(view, line)
     end
   end
@@ -1243,7 +1252,7 @@ local doc_raw_remove = Doc.raw_remove
 function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   local result = doc_raw_remove(self, line1, col1, line2, col2, undo_stack, time)
   for _, view in ipairs(core.get_views_referencing_doc(self)) do
-    if view:is(DocView) and view.cf_regions then
+    if codefold_enabled_for_view(view) and view.cf_regions then
       schedule_recalculation(view, line1)
     end
   end
@@ -1257,7 +1266,7 @@ end
 command.add(nil, {
   ["code-folding:toggle"] = function()
     local view = core.active_view
-    if not view or not view:is(DocView) or not view.cf_regions then
+    if not view or not codefold_enabled_for_view(view) or not view.cf_regions then
       return
     end
     local line = view.doc:get_selection()
@@ -1274,7 +1283,7 @@ command.add(nil, {
 
   ["code-folding:fold-all"] = function()
     local view = core.active_view
-    if not view or not view:is(DocView) or not view.cf_regions then
+    if not view or not codefold_enabled_for_view(view) or not view.cf_regions then
       return
     end
     fold_all(view)
@@ -1283,7 +1292,7 @@ command.add(nil, {
 
   ["code-folding:unfold-all"] = function()
     local view = core.active_view
-    if not view or not view:is(DocView) or not view.cf_regions then
+    if not view or not codefold_enabled_for_view(view) or not view.cf_regions then
       return
     end
     unfold_all(view)

--- a/data/plugins/diffview.lua
+++ b/data/plugins/diffview.lua
@@ -129,6 +129,8 @@ function DiffView:new(a, b, compare_type, names)
 
   self.doc_view_a.diff_view_parent = self
   self.doc_view_b.diff_view_parent = self
+  self.doc_view_a.code_folding_disabled = true
+  self.doc_view_b.code_folding_disabled = true
 
   self.a_gaps = {}
   self.b_gaps = {}

--- a/data/plugins/diffview.lua
+++ b/data/plugins/diffview.lua
@@ -977,23 +977,74 @@ local function redraw_thumb(view_scrollbar)
   renderer.draw_rect(x, y, w, h, color)
 end
 
+---Get the scrollbar marker rectangle for a visual row range.
+---@param track_y number
+---@param track_h number
+---@param start_row number
+---@param end_row number
+---@param scrollable_size number
+---@param line_height number
+---@param content_padding number
+---@return number y
+---@return number h
+local function get_scrollbar_marker_rect(
+  track_y, track_h, start_row, end_row, scrollable_size, line_height,
+  content_padding
+)
+  local scrollable = math.max(1, scrollable_size)
+  local start_y = content_padding + start_row * line_height
+  local end_y = content_padding + end_row * line_height
+  local ratio_start = common.clamp(start_y / scrollable, 0, 1)
+  local ratio_end = common.clamp(end_y / scrollable, ratio_start, 1)
+  local y = track_y + ratio_start * track_h
+  local h = math.max(2 * SCALE, (ratio_end - ratio_start) * track_h)
+  return y, h
+end
+
+---Get the marker lane that matches the scrollbar selector width.
+---@param scrollbar core.scrollbar
+---@return number x
+---@return number y
+---@return number w
+---@return number h
+local function get_scrollbar_marker_lane(scrollbar)
+  local track_x, track_y, track_w, track_h = scrollbar:get_track_rect()
+  local thumb_x, _, thumb_w = scrollbar:get_thumb_rect()
+  if thumb_w > 0 then
+    track_x, track_w = thumb_x, thumb_w
+  end
+  return track_x, track_y, track_w, track_h
+end
+
 function DiffView:draw_scrollbar()
   DiffView.super.draw_scrollbar(self)
 
+  local parent_scrollable = self:get_scrollable_size()
+  local parent_lh = self.doc_view_a:get_line_height()
+  local parent_x, parent_y, parent_w, parent_h = get_scrollbar_marker_lane(
+    self.v_scrollbar
+  )
+
   for _, side in ipairs {
-    {view = self.doc_view_a, changes = self.a_changes},
-    {view = self.doc_view_b, changes = self.b_changes},
+    {
+      view = self.doc_view_a,
+      changes = self.a_changes,
+      gaps = self.a_gaps
+    },
+    {
+      view = self.doc_view_b,
+      changes = self.b_changes,
+      gaps = self.b_gaps
+    },
   } do
     local view = side.view
     local changes = side.changes
+    local gaps = side.gaps
     local scrollbar = view.v_scrollbar
-
+    local scrollable = view:get_scrollable_size()
     local lh = view:get_line_height()
-    local full_h = view:get_scrollable_size()
-    local visible_h = view.size.y
-    local x, y, w, h = scrollbar:get_track_rect()
 
-    local scroll_range = math.max(1, full_h - visible_h)
+    local x, y, w, h = get_scrollbar_marker_lane(scrollbar)
 
     -- Step 1: group consecutive lines of same change tag
     local change_lines = {}
@@ -1023,17 +1074,23 @@ function DiffView:draw_scrollbar()
         or tag == "modify" and style.diff_modify
 
       if color then
-        local scroll_y_start = (start_line - 1) * lh
-        local scroll_y_end = (end_line) * lh
-        local ratio_start = scroll_y_start / scroll_range
-        local ratio_end = scroll_y_end / scroll_range
-        local marker_y = y + ratio_start * h
-        local marker_h = math.max(2, (ratio_end - ratio_start) * h) * SCALE
+        local start_gap = gaps[start_line] and gaps[start_line][2] or 0
+        local end_gap = gaps[end_line] and gaps[end_line][2] or start_gap
+        local start_row = start_line - 1 + start_gap
+        local end_row = end_line + end_gap
+        local marker_y, marker_h = get_scrollbar_marker_rect(
+          y, h, start_row, end_row, scrollable, lh, style.padding.y
+        )
 
         renderer.draw_rect(x, marker_y, w, marker_h, color)
 
-        local sx, _, sw = self.v_scrollbar:get_track_rect()
-        renderer.draw_rect(sx, marker_y, sw, marker_h, color)
+        local parent_marker_y, parent_marker_h = get_scrollbar_marker_rect(
+          parent_y, parent_h, start_row, end_row, parent_scrollable, parent_lh,
+          style.padding.y
+        )
+        renderer.draw_rect(
+          parent_x, parent_marker_y, parent_w, parent_marker_h, color
+        )
       end
 
       i = i + 1


### PR DESCRIPTION
This PR fixes DiffView’s scrollbar diff markers so they align with the actual diff content and scrollbar selector.

  Changes include:

  - Position diff markers using each pane’s scrollable coordinate space instead of scrollbar scroll range.
  - Account for diff gap rows, content padding, and scroll_past_end when drawing markers.
  - Draw markers in the same lane as the scrollbar thumb so expanded scrollbars align correctly.
  - Disable code folding for DiffView’s internal DocViews, since DiffView owns custom gap/layout behavior.
  - Centralize codefold eligibility checks so disabled views skip fold gutter width, marker drawing, mouse 
     handling, commands, hidden-line queries, and edit invalidation.