### PR TITLE
Fix regex negative offsets

### DIFF
--- a/scripts/lua/tests/regex.lua
+++ b/scripts/lua/tests/regex.lua
@@ -58,4 +58,54 @@ test.describe("regex", function()
     test.equal(c2s, 3)
     test.equal(c2e, 5)
   end)
+
+  test.test("handles negative offsets like string.find", function()
+    local subject = "0123456789"
+    local compiled = test.not_nil(regex.compile("(.)"))
+
+    local start_idx, end_idx, capture = regex.find(compiled, subject, -1)
+    test.equal(start_idx, 10)
+    test.equal(end_idx, 10)
+    test.equal(capture, "9")
+
+    start_idx, end_idx, capture = regex.find(compiled, subject, -10)
+    test.equal(start_idx, 1)
+    test.equal(end_idx, 1)
+    test.equal(capture, "0")
+
+    start_idx, end_idx, capture = regex.find(compiled, subject, -100)
+    test.equal(start_idx, 1)
+    test.equal(end_idx, 1)
+    test.equal(capture, "0")
+  end)
+
+  test.test("handles negative offsets for offset-returning regex APIs", function()
+    local subject = "0123456789"
+
+    local start_idx, end_idx, cap_start, cap_end =
+      regex.find_offsets("(.)", subject, -1)
+    test.equal(start_idx, 10)
+    test.equal(end_idx, 11)
+    test.equal(cap_start, 10)
+    test.equal(cap_end, 10)
+
+    local whole_start, whole_end, capture_start, capture_end =
+      regex.cmatch("(.)", subject, -1)
+    test.equal(whole_start, 10)
+    test.equal(whole_end, 11)
+    test.equal(capture_start, 10)
+    test.equal(capture_end, 11)
+  end)
+
+  test.test("handles negative offsets for match and gmatch", function()
+    local subject = "0123456789"
+
+    test.equal(regex.match("(.)", subject, -1), "9")
+
+    local items = {}
+    for item in regex.gmatch("(.)", subject, -2) do
+      items[#items + 1] = item
+    end
+    test.same(items, { "8", "9" })
+  end)
 end)

--- a/src/api/regex.c
+++ b/src/api/regex.c
@@ -127,9 +127,9 @@ static size_t regex_offset_relative(lua_Integer pos, size_t len) {
     return (size_t)pos;
   else if (pos == 0)
     return 1;
-  else if (pos < -(lua_Integer)len)  /* inverted comparison */
+  else if (pos < -(lua_Integer)len)
     return 1;  /* clip to 1 */
-  else return len + (size_t)pos + 1;
+  else return (size_t)((lua_Integer)len + pos + 1);
 }
 
 static int f_pcre_gc(lua_State* L) {
@@ -270,7 +270,7 @@ static int f_pcre_find(lua_State *L) {
     if (ovector[i] == ovector[i+1])
       lua_pushinteger(L, ovector[i]+offset+1);
     else
-      lua_pushlstring(L, subject+ovector[i], ovector[i+1] - ovector[i]);
+      lua_pushlstring(L, subject+offset+ovector[i], ovector[i+1] - ovector[i]);
 
     total_results++;
   }
@@ -502,14 +502,14 @@ static int f_pcre_match(lua_State *L) {
   }
   int results_count = rc*2;
   if (results_count == 2) {
-    lua_pushlstring(L, subject+ovector[0], ovector[1] - ovector[0]);
+    lua_pushlstring(L, subject+offset+ovector[0], ovector[1] - ovector[0]);
     total_results++;
   } else if(results_count > 0) {
     for (int i = 2; i < results_count; i+=2) {
       if (ovector[i] == ovector[i+1])
-        lua_pushinteger(L, ovector[i]+1);
+        lua_pushinteger(L, ovector[i]+offset+1);
       else
-        lua_pushlstring(L, subject+ovector[i], ovector[i+1] - ovector[i]);
+        lua_pushlstring(L, subject+offset+ovector[i], ovector[i+1] - ovector[i]);
       total_results++;
     }
   }

--- a/src/tokenizer/regex.c
+++ b/src/tokenizer/regex.c
@@ -151,15 +151,13 @@ void regex_gsub_uninit(regex_gsub* self) {
 }
 
 static size_t regex_offset_relative(int64_t pos, size_t len) {
-  if (pos < 0)
-    return 1;
-  else if (pos > 0)
+  if (pos > 0)
     return pos;
   else if (pos == 0)
     return 1;
-  else if (pos < -(int64_t)len)  /* inverted comparison */
+  else if (pos < -(int64_t)len)
     return 1;  /* clip to 1 */
-  else return len + pos + 1;
+  else return (size_t)((int64_t)len + pos + 1);
 }
 
 static bool regex_write_offset(


### PR DESCRIPTION
Restore Lua-style relative offset handling for tokenizer regex matching so negative offsets are interpreted from the end of the subject instead of always clamping to the start.

Keep the public regex API helper in sync and fix string and position captures returned from non-zero-offset matches. Add tests covering negative offsets across find, find_offsets, cmatch, match, and gmatch.

Corrects the reported issue on #499 