### PR TITLE
Expose renderer info on windows

### DIFF
--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -2155,6 +2155,16 @@ function Settings:setup_about()
     "A lightweight text editor written in Lua, adapted from lite.",
     true
   )
+  ---@type widget.label
+  local info = core.window:get_renderer_info()
+  local renderer_info_parts = { "renderer " .. info.backend }
+  if info.power then table.insert(renderer_info_parts, info.power) end
+  if info.device then table.insert(renderer_info_parts, info.device) end
+  local renderer_info = Label(
+    self.about,
+    table.concat(renderer_info_parts, ", "),
+    true
+  )
 
   ---@type widget.button
   local button = Button(self.about, "Visit Website")
@@ -2223,6 +2233,11 @@ local contributors_list = {
       style.padding.y
     )
 
+    description:set_position(
+      center - (description:get_width() / 2),
+      title:get_bottom() + (style.padding.y / 2)
+    )
+
     version:set_position(
       center - (version:get_width() / 2),
       title:get_bottom() + (style.padding.y / 2)
@@ -2233,9 +2248,14 @@ local contributors_list = {
       version:get_bottom() + (style.padding.y / 2)
     )
 
+    renderer_info:set_position(
+      center - (renderer_info:get_width() / 2),
+      description:get_bottom() + (style.padding.y / 2)
+    )
+
     button:set_position(
       center - (button:get_width() / 2),
-      description:get_bottom() + style.padding.y
+      renderer_info:get_bottom() + style.padding.y
     )
 
     contributors:set_position(

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -2157,7 +2157,7 @@ function Settings:setup_about()
   )
   ---@type widget.label
   local info = core.window:get_renderer_info()
-  local renderer_info_parts = { "renderer " .. info.backend }
+  local renderer_info_parts = { "Renderer: " .. info.backend }
   if info.power then table.insert(renderer_info_parts, info.power) end
   if info.device then table.insert(renderer_info_parts, info.device) end
   local renderer_info = Label(

--- a/docs/api/renwindow.lua
+++ b/docs/api/renwindow.lua
@@ -34,6 +34,16 @@ function renwindow.get_size(window) end
 function renwindow.get_refresh_rate(window) end
 
 ---
+---Gets renderer information for the backend currently attached to the window.
+---`backend` is always set. `power` and `device` are only set by backends where
+---the fields apply and the information is available.
+---
+---@param window renwindow
+---
+---@return { backend: "surface"|"sdlrenderer"|"sdlgpu"|string, power?: string, device?: string }
+function renwindow.get_renderer_info(window) end
+
+---
 ---Enable or disable vertical synchronization for the window swapchain.
 ---When enabled the backend presents tear-free (synced to the display refresh);
 ---when disabled it presents every rendered frame for the lowest latency, which

--- a/scripts/lua/tests/graphics.lua
+++ b/scripts/lua/tests/graphics.lua
@@ -79,7 +79,10 @@ test.describe("graphics apis", function()
   end)
 
   test.test("exports the documented renwindow, renderer and canvas functions", function()
-    for _, name in ipairs({"create", "get_size", "get_refresh_rate", "get_color", "_restore"}) do
+    for _, name in ipairs({
+      "create", "get_size", "get_refresh_rate", "get_renderer_info",
+      "set_vsync", "get_color", "_restore"
+    }) do
       test.type(renwindow[name], "function", "missing renwindow." .. name)
     end
 
@@ -311,6 +314,17 @@ test.describe("graphics apis", function()
 
     local refresh_rate = renwindow.get_refresh_rate(window)
     test.ok(refresh_rate == nil or refresh_rate > 0)
+
+    local info = window:get_renderer_info()
+    test.type(info, "table")
+    test.ok(info.backend == "surface" or info.backend == "sdlrenderer" or info.backend == "sdlgpu")
+    if info.backend == "sdlgpu" then
+      test.ok(info.power == nil or type(info.power) == "string")
+      test.ok(info.device == nil or type(info.device) == "string")
+    else
+      test.equal(info.power, nil)
+      test.equal(info.device, nil)
+    end
 
     renderer.show_debug(false)
     renderer.begin_frame(window)

--- a/src/api/renwindow.c
+++ b/src/api/renwindow.c
@@ -85,6 +85,31 @@ static int f_renwin_set_vsync(lua_State *L) {
   return 0;
 }
 
+static int f_renwin_get_renderer_info(lua_State *L) {
+  RenWindow *window_renderer = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
+  const RenBackend *backend = window_renderer->cache.backend;
+  RenRendererInfo info = {
+    .backend = backend ? backend->name : "",
+    .power = NULL,
+    .device = NULL,
+  };
+  if (backend && backend->get_renderer_info)
+    backend->get_renderer_info(window_renderer, &info);
+
+  lua_createtable(L, 0, 3);
+  lua_pushstring(L, info.backend ? info.backend : "");
+  lua_setfield(L, -2, "backend");
+  if (info.power) {
+    lua_pushstring(L, info.power);
+    lua_setfield(L, -2, "power");
+  }
+  if (info.device) {
+    lua_pushstring(L, info.device);
+    lua_setfield(L, -2, "device");
+  }
+  return 1;
+}
+
 static int f_renwin_persist(lua_State *L) {
   RenWindow *window_renderer = *(RenWindow**)luaL_checkudata(L, 1, API_TYPE_RENWINDOW);
 
@@ -178,6 +203,7 @@ static const luaL_Reg renwindow_lib[] = {
   { "get_size",         f_renwin_get_size   },
   { "get_refresh_rate", f_get_refresh_rate  },
   { "set_vsync",        f_renwin_set_vsync  },
+  { "get_renderer_info", f_renwin_get_renderer_info },
   { "get_color",        f_get_color         },
   { "_persist",         f_renwin_persist    },
   { "_restore",         f_renwin_restore    },

--- a/src/renbackend.h
+++ b/src/renbackend.h
@@ -5,9 +5,16 @@
 #include "renatlas.h"
 #include "rencache.h"
 
+typedef struct {
+  const char *backend;
+  const char *power;
+  const char *device;
+} RenRendererInfo;
+
 struct RenBackend {
   const char *name;
   bool (*available)(void); /* NULL = always available */
+  void (*get_renderer_info)(RenWindow *window, RenRendererInfo *info);
   const RenCacheDrawOps *draw_ops;
   bool (*use_full_frame_regions)(RenCache *cache);
   void (*begin_frame)(RenCache *cache, RenRect *rects, int count);

--- a/src/renbackend_sdlgpu.c
+++ b/src/renbackend_sdlgpu.c
@@ -249,6 +249,7 @@ typedef struct {
   bool validation_reported;
   bool have_native_clip_rect;
   bool sampled_canvas_this_frame;
+  bool prefer_low_power;
 } GpuWindowData;
 
 typedef struct {
@@ -300,6 +301,7 @@ static SDL_GPUDevice *gpu_device = NULL;
 static int gpu_device_ref_count = 0;
 static bool gpu_backend_disabled = false;
 static bool gpu_window_device_ready = false;
+static bool gpu_device_prefer_low_power = false;
 static SDL_GPUGraphicsPipeline *gpu_canvas_blend_pipeline = NULL;
 static SDL_GPUGraphicsPipeline *gpu_canvas_batch_pipeline = NULL;
 static SDL_GPUGraphicsPipeline *gpu_canvas_batch_replace_pipeline = NULL;
@@ -4551,6 +4553,7 @@ static void gpu_release_device(void) {
     SDL_DestroyGPUDevice(gpu_device);
     gpu_device = NULL;
     gpu_window_device_ready = false;
+    gpu_device_prefer_low_power = false;
   }
 }
 
@@ -4601,6 +4604,8 @@ static SDL_GPUDevice *gpu_get_device(void) {
     GpuPowerPreference preference = gpu_power_preference();
     bool prefer_low_power = preference != GPU_POWER_HIGH;
     gpu_device = gpu_create_device(prefer_low_power);
+    if (gpu_device)
+      gpu_device_prefer_low_power = prefer_low_power;
   }
   if (!gpu_device)
     gpu_abort("SDL_CreateGPUDeviceWithProperties failed");
@@ -4657,6 +4662,7 @@ static bool gpu_init_window(RenWindow *ren) {
 
   if (gpu_device) {
     data->device = gpu_retain_device();
+    data->prefer_low_power = gpu_device_prefer_low_power;
     if (!SDL_ClaimWindowForGPUDevice(data->device, ren->window)) {
       fprintf(stderr, "SDL_ClaimWindowForGPUDevice failed: %s\n", SDL_GetError());
       gpu_release_device();
@@ -4694,7 +4700,9 @@ static bool gpu_init_window(RenWindow *ren) {
         gpu_device = candidate;
         gpu_device_ref_count = 1;
         gpu_window_device_ready = true;
+        gpu_device_prefer_low_power = prefer_low_power;
         data->device = candidate;
+        data->prefer_low_power = prefer_low_power;
         gpu_log_device(candidate, "Using", prefer_low_power);
         break;
       }
@@ -4722,6 +4730,20 @@ static bool gpu_init_window(RenWindow *ren) {
   gpu_apply_present_mode(data, ren, true);
   gpu_create_surface(ren);
   return true;
+}
+
+static void gpu_get_renderer_info(RenWindow *ren, RenRendererInfo *info) {
+  GpuWindowData *data = ren ? ren->backend_data : NULL;
+  SDL_GPUDevice *device = data ? data->device : NULL;
+  if (!device)
+    return;
+
+  info->power = gpu_power_name(data->prefer_low_power);
+  SDL_PropertiesID props = SDL_GetGPUDeviceProperties(device);
+  if (props)
+    info->device = SDL_GetStringProperty(props, SDL_PROP_GPU_DEVICE_NAME_STRING, NULL);
+  if (!info->device)
+    info->device = SDL_GetGPUDeviceDriver(device);
 }
 
 static void gpu_set_vsync(RenWindow *ren, bool enabled) {
@@ -5988,6 +6010,7 @@ static const RenCacheDrawOps gpu_draw_ops = {
 static const RenBackend sdlgpu_backend = {
   .name = "sdlgpu",
   .available = gpu_backend_available,
+  .get_renderer_info = gpu_get_renderer_info,
   .draw_ops = &gpu_draw_ops,
   .use_full_frame_regions = gpu_use_full_frame_regions,
   .begin_frame = gpu_begin_frame,


### PR DESCRIPTION
Add renwindow:get_renderer_info() so Lua can inspect the active renderer backend for a window. The API always reports the backend name and lets backends add optional details where they apply.

Report SDLGPU selected power and device information from the active GPU window data without changing the device selection flow. Show the renderer info in the Settings About pane and update graphics API coverage.

### Preview

<img width="1434" height="375" alt="renderer-info" src="https://github.com/user-attachments/assets/09c20c0b-f81e-445c-aad7-6a91e681e43e" />
