### PR TITLE
Limit Linux FFI symbol exports

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,5 +10,6 @@ option('extra_colors', type : 'boolean', value : true, description: 'Include add
 option('extra_languages', type : 'boolean', value : true, description: 'Include additional language plugins')
 option('ppm', type : 'boolean', value : true, description: 'Include the plugin manager')
 option('jit', type : 'boolean', value : true, description: 'Use luajit')
+option('export_all_symbols', type : 'boolean', value : false, description: 'Export all executable symbols for LuaJIT FFI access on Linux')
 option('repl_history', type : 'boolean', value : true, description: 'Enable history and completion support on REPL')
 option('net', type : 'boolean', value : true, description: 'Enable networking support using SDL3_net and mbedtls')

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,10 +35,29 @@ pragtical_sources = [
 
 if lua_jit_found
     pragtical_sources += 'ffiexports.c'
-    # Export all local symbols for LuaJIT FFI Access
     if host_machine.system() != 'windows' and host_machine.system() != 'darwin'
-        # reminder: on mingw the valid flag is -Wl,--export-all-symbols
-        pragtical_link_args += '-Wl,--export-dynamic'
+        if get_option('export_all_symbols')
+            # Export all local symbols for LuaJIT FFI access.
+            # reminder: on mingw the valid flag is -Wl,--export-all-symbols
+            pragtical_link_args += '-Wl,--export-dynamic'
+        else
+            ffi_export_symbols = [
+                'ren_get_target_window_ffi',
+                'rencache_set_clip_rect_ffi',
+                'rencache_draw_rect_ffi',
+                'rencache_draw_text_ffi',
+                'rencache_begin_frame_ffi',
+                'rencache_end_frame_ffi',
+                'system_get_time_ffi',
+                'system_wait_event_ffi',
+                'system_sleep_ffi',
+                'system_has_pending_events_ffi',
+            ]
+
+            foreach symbol : ffi_export_symbols
+                pragtical_link_args += '-Wl,--export-dynamic-symbol=' + symbol
+            endforeach
+        endif
     elif host_machine.system() == 'darwin'
         # macOS export dynamic symbols option slightly different
         pragtical_link_args += '-Wl,-export_dynamic'


### PR DESCRIPTION
Export only the LuaJIT FFI entrypoints by default on Linux instead of exposing the full executable symbol table.

Add an export_all_symbols Meson option for builds that need the previous broad export behavior.

Should fix #544