### PR TITLE
Fix directory monitor reliability

### DIFF
--- a/data/core/dirwatch.lua
+++ b/data/core/dirwatch.lua
@@ -20,6 +20,12 @@ local Object = require "core.object"
 ---@field single_watch_count number Number of files that are being watched.
 local DirWatch = Object:extend()
 
+local function is_same_or_child(path, parent)
+  if path == parent then return true end
+  local prefix = parent:sub(-1) == PATHSEP and parent or parent .. PATHSEP
+  return path:find(prefix, 1, true) == 1
+end
+
 
 ---Constructor.
 function DirWatch:new()
@@ -68,10 +74,10 @@ function DirWatch:watch(path, watch)
   if not self.watched[path] and not self.scanned[path] then
     if self.monitor:mode() == "single" then
       if info.type ~= "dir" then return self:scan(path) end
-      if not self.single_watch_top or path:find(self.single_watch_top, 1, true) ~= 1 then
+      if not self.single_watch_top or not is_same_or_child(path, self.single_watch_top) then
         -- Get the highest level of directory that is common to this directory, and the original.
         local target = path
-        while self.single_watch_top and self.single_watch_top:find(target, 1, true) ~= 1 do
+        while self.single_watch_top and not is_same_or_child(self.single_watch_top, target) do
           target = common.dirname(target)
         end
         if target ~= self.single_watch_top then
@@ -103,13 +109,15 @@ end
 function DirWatch:unwatch(path)
   if self.watched[path] then
     if self.monitor:mode() == "multiple" then
-      self.monitor:unwatch(self.watched[path])
-      self.reverse_watched[path] = nil
+      local watch_id = self.watched[path]
+      self.monitor:unwatch(watch_id)
+      self.reverse_watched[watch_id] = nil
     else
       self.single_watch_count = self.single_watch_count - 1
       if self.single_watch_count == 0 then
+        local watch_top = self.single_watch_top
         self.single_watch_top = nil
-        self.monitor:unwatch(path)
+        self.monitor:unwatch(watch_top)
       end
     end
     self.watched[path] = nil

--- a/data/plugins/autoreload.lua
+++ b/data/plugins/autoreload.lua
@@ -36,6 +36,21 @@ local function update_time(doc)
   end
 end
 
+local function doc_changed(doc)
+  if not doc.abs_filename or not times[doc] then return false end
+  local info = system.get_file_info(doc.abs_filename)
+  return
+    info
+    and
+    info.type == "file"
+    and
+    (
+      times[doc].modified ~= info.modified
+      or
+      times[doc].size ~= info.size
+    )
+end
+
 local function reload_doc(doc)
   doc:reload()
   update_time(doc)
@@ -72,6 +87,20 @@ local function autoreload_doc(doc)
   end
 end
 
+local function process_changed_doc(doc)
+  if
+    core.active_view
+    and
+    core.active_view.doc
+    and
+    core.active_view.doc == doc
+  then
+    autoreload_doc(doc)
+  elseif not doc.deferred_reload then
+    changed[doc] = true
+  end
+end
+
 local core_set_active_view = core.set_active_view
 function core.set_active_view(view)
   core_set_active_view(view)
@@ -90,32 +119,18 @@ core.add_thread(function()
   while true do
     watch:check(function(file)
       for _, doc in ipairs(core.docs) do
-        if doc.abs_filename == file then
-          local info = system.get_file_info(doc.abs_filename or "")
-          if
-            info and info.type == "file" and times[doc]
-            and
-            (
-              times[doc].modified ~= info.modified
-              or
-              times[doc].size ~= info.size
-            )
-          then
-            if
-              core.active_view
-              and
-              core.active_view.doc
-              and
-              core.active_view.doc == doc
-            then
-              autoreload_doc(doc)
-            elseif not doc.deferred_reload then
-              changed[doc] = true
-            end
-          end
+        if doc.abs_filename == file and doc_changed(doc) then
+          process_changed_doc(doc)
         end
       end
     end)
+    for _, doc in ipairs(core.docs) do
+      if doc_changed(doc) then
+        watch:unwatch(doc.abs_filename)
+        watch:watch(doc.abs_filename)
+        process_changed_doc(doc)
+      end
+    end
     coroutine.yield(1)
   end
 end)

--- a/scripts/lua/tests/dirmonitor.lua
+++ b/scripts/lua/tests/dirmonitor.lua
@@ -2,13 +2,53 @@ local common = require "core.common"
 local test = require "core.test"
 
 local temp_root
+local temp_index = 0
+
+local function write_file(path, content)
+  local file, err = io.open(path, "wb")
+  test.not_nil(file, err)
+  file:write(content)
+  file:close()
+end
+
+local function wait(wait_time)
+  if coroutine.isyieldable() then
+    coroutine.yield(wait_time)
+  else
+    system.sleep(wait_time)
+  end
+end
+
+local function wait_for_changes(monitor, callback, timeout)
+  local deadline = system.get_time() + (timeout or 2)
+  local changed = false
+  while system.get_time() < deadline do
+    local ok, err = monitor:check(function(value)
+      changed = true
+      if callback then callback(value) end
+    end, function(check_err)
+      error(check_err)
+    end)
+    test.ok(ok == nil or type(ok) == "boolean", err)
+    if changed then return true end
+    wait(0.01)
+  end
+  return false
+end
+
+local function wait_for_watch()
+  local deadline = system.get_time() + 0.1
+  repeat wait(0.01) until system.get_time() >= deadline
+end
 
 test.describe("dirmonitor", function()
   test.before_each(function(context)
+    temp_index = temp_index + 1
     temp_root = USERDIR
       .. PATHSEP .. "dirmonitor-tests-"
       .. system.get_process_id() .. "-"
-      .. math.floor(system.get_time() * 1000000)
+      .. math.floor(system.get_time() * 1000000) .. "-"
+      .. temp_index
     local ok, err = common.mkdirp(temp_root)
     test.ok(ok, err)
     context.temp_root = temp_root
@@ -54,6 +94,74 @@ test.describe("dirmonitor", function()
       monitor:unwatch(context.temp_root)
     else
       monitor:unwatch(watch_id)
+    end
+  end)
+
+  test.test("detects watched file replacement", function(context)
+    local path = context.temp_root .. PATHSEP .. "watched.txt"
+    local temp_path = context.temp_root .. PATHSEP .. "watched.tmp"
+    write_file(path, "before\n")
+
+    local monitor = dirmonitor.new()
+    local watch_path = monitor:mode() == "single" and context.temp_root or path
+    local watch_id = monitor:watch(watch_path)
+    test.type(watch_id, "number")
+    test.ok(watch_id >= 0)
+    wait_for_watch()
+
+    write_file(temp_path, "after\n")
+    if PLATFORM == "Windows" then os.remove(path) end
+    local ok, err = os.rename(temp_path, path)
+    test.ok(ok, err)
+
+    test.ok(wait_for_changes(monitor, nil, 2), "expected file replacement change")
+
+    if monitor:mode() == "single" then
+      monitor:unwatch(watch_path)
+    else
+      monitor:unwatch(watch_id)
+    end
+  end)
+
+  test.test("reports changes from separate watched directories", function(context)
+    local one = context.temp_root .. PATHSEP .. "one"
+    local two = context.temp_root .. PATHSEP .. "two"
+    test.ok(common.mkdirp(one))
+    test.ok(common.mkdirp(two))
+
+    local monitor = dirmonitor.new()
+    local watch_one = monitor:watch(monitor:mode() == "single" and context.temp_root or one)
+    local watch_two = monitor:mode() == "single" and watch_one or monitor:watch(two)
+    test.type(watch_one, "number")
+    test.type(watch_two, "number")
+    test.ok(watch_one >= 0)
+    test.ok(watch_two >= 0)
+    wait_for_watch()
+
+    if monitor:mode() == "multiple" then
+      write_file(one .. PATHSEP .. "first-file-with-a-long-name.txt", "one\n")
+      write_file(two .. PATHSEP .. "second-file-with-a-long-name.txt", "two\n")
+    else
+      write_file(context.temp_root .. PATHSEP .. "first-file-with-a-long-name.txt", "one\n")
+      write_file(context.temp_root .. PATHSEP .. "second-file-with-a-long-name.txt", "two\n")
+    end
+
+    local seen = {}
+    local deadline = system.get_time() + 2
+    while system.get_time() < deadline and not (seen[watch_one] and seen[watch_two]) do
+      wait_for_changes(monitor, function(value)
+        seen[value] = true
+      end, 0.1)
+    end
+
+    if monitor:mode() == "multiple" then
+      test.ok(seen[watch_one], "expected first directory change")
+      test.ok(seen[watch_two], "expected second directory change")
+      monitor:unwatch(watch_one)
+      monitor:unwatch(watch_two)
+    else
+      test.ok(next(seen) ~= nil, "expected directory change")
+      monitor:unwatch(context.temp_root)
     end
   end)
 end)

--- a/scripts/lua/tests/dirwatch.lua
+++ b/scripts/lua/tests/dirwatch.lua
@@ -1,0 +1,50 @@
+local common = require "core.common"
+local DirWatch = require "core.dirwatch"
+local test = require "core.test"
+
+local temp_root
+
+local function write_file(path, content)
+  local file, err = io.open(path, "wb")
+  test.not_nil(file, err)
+  file:write(content)
+  file:close()
+end
+
+test.describe("dirwatch", function()
+  test.before_each(function(context)
+    temp_root = USERDIR
+      .. PATHSEP .. "dirwatch-tests-"
+      .. system.get_process_id() .. "-"
+      .. math.floor(system.get_time() * 1000000)
+    local ok, err = common.mkdirp(temp_root)
+    test.ok(ok, err)
+    context.temp_root = temp_root
+  end)
+
+  test.after_each(function(context)
+    if context.temp_root and system.get_file_info(context.temp_root) then
+      local ok, err = common.rm(context.temp_root, true)
+      test.ok(ok, err)
+    end
+  end)
+
+  test.test("unwatch clears multiple mode reverse watch mapping", function(context)
+    local path = context.temp_root .. PATHSEP .. "watched.txt"
+    write_file(path, "before\n")
+
+    local watch = DirWatch()
+    if watch.monitor:mode() ~= "multiple" then
+      return
+    end
+
+    watch:watch(path)
+    local watch_id = watch.watched[path]
+    test.type(watch_id, "number")
+    test.equal(watch.reverse_watched[watch_id], path)
+
+    watch:unwatch(path)
+    test.equal(watch.watched[path], nil)
+    test.equal(watch.reverse_watched[watch_id], nil)
+  end)
+end)

--- a/src/api/dirmonitor.c
+++ b/src/api/dirmonitor.c
@@ -58,14 +58,25 @@ static int f_check_dir_callback(int watch_id, const char* path, void* L) {
   // using absolute indices from f_dirmonitor_check (2: callback, 3: error_callback, 4: watch_id notified table)
 
   // Check if we already notified about this watch
-  lua_rawgeti(L, 4, watch_id);
+  if (path) {
+    lua_pushlstring(L, path, watch_id);
+    lua_rawget(L, 4);
+  } else {
+    lua_rawgeti(L, 4, watch_id);
+  }
   bool skip = !lua_isnoneornil(L, -1);
   lua_pop(L, 1);
   if (skip) return 0;
 
   // Set watch as notified
   lua_pushboolean(L, true);
-  lua_rawseti(L, 4, watch_id);
+  if (path) {
+    lua_pushlstring(L, path, watch_id);
+    lua_insert(L, -2);
+    lua_rawset(L, 4);
+  } else {
+    lua_rawseti(L, 4, watch_id);
+  }
 
   // Prepare callback call
   lua_pushvalue(L, 2);
@@ -89,14 +100,17 @@ static int dirmonitor_check_thread(void* data) {
     if (monitor->length == 0) {
       int result = monitor->backend->get_changes(monitor->internal, monitor->buffer, sizeof(monitor->buffer));
       SDL_LockMutex(monitor->mutex);
-      if (monitor->length == 0)
+      if (monitor->length == 0) {
         monitor->length = result;
+        if (result != 0) {
+          CustomEvent event;
+          SDL_zero(event);
+          push_custom_event("dirmonitor", &event);
+        }
+      }
       SDL_UnlockMutex(monitor->mutex);
     }
     SDL_Delay(1);
-    CustomEvent event;
-    SDL_zero(event);
-    push_custom_event("dirmonitor", &event);
   }
   return 0;
 }

--- a/src/api/dirmonitor/fsevents.c
+++ b/src/api/dirmonitor/fsevents.c
@@ -1,5 +1,9 @@
 #include <SDL3/SDL.h>
 #include <CoreServices/CoreServices.h>
+#include <dispatch/dispatch.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "dirmonitor.h"
 
@@ -8,21 +12,19 @@ struct dirmonitor_internal {
   char** changes;
   size_t count;
   FSEventStreamRef stream;
+  dispatch_queue_t queue;
+  CFStringRef path;
+  CFArrayRef paths;
   int fds[2];
 };
 
-CFRunLoopRef main_run_loop;
-
 
 static struct dirmonitor_internal* init_dirmonitor(void) {
-  static bool mainloop_registered = false;
-  if (!mainloop_registered) {
-    main_run_loop = CFRunLoopGetCurrent();
-    mainloop_registered = true;
-  }
-
   struct dirmonitor_internal* monitor = SDL_calloc(1, sizeof(struct dirmonitor_internal));
   monitor->stream = NULL;
+  monitor->queue = NULL;
+  monitor->path = NULL;
+  monitor->paths = NULL;
   monitor->changes = NULL;
   monitor->count = 0;
   monitor->fds[0] = -1;
@@ -50,12 +52,27 @@ static void clear_monitor_changes(struct dirmonitor_internal* monitor) {
 static void stop_monitor_stream(struct dirmonitor_internal* monitor) {
   if (monitor->stream) {
     FSEventStreamStop(monitor->stream);
-    FSEventStreamUnscheduleFromRunLoop(
-      monitor->stream, main_run_loop, kCFRunLoopDefaultMode
-    );
+    if (monitor->queue) {
+      FSEventStreamSetDispatchQueue(monitor->stream, NULL);
+    }
     FSEventStreamInvalidate(monitor->stream);
     FSEventStreamRelease(monitor->stream);
     monitor->stream = NULL;
+  }
+
+  if (monitor->queue) {
+    dispatch_release(monitor->queue);
+    monitor->queue = NULL;
+  }
+
+  if (monitor->paths) {
+    CFRelease(monitor->paths);
+    monitor->paths = NULL;
+  }
+
+  if (monitor->path) {
+    CFRelease(monitor->path);
+    monitor->path = NULL;
   }
 
   if (monitor->fds[1] != -1) {
@@ -183,15 +200,28 @@ static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path)
     .version = 0
   };
 
-  CFStringRef paths[] = {
-    CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8)
-  };
+  monitor->path = CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8);
+  if (!monitor->path) {
+    stop_monitor_stream(monitor);
+    return -1;
+  }
+
+  monitor->paths = CFArrayCreate(
+    NULL,
+    (const void **)&monitor->path,
+    1,
+    &kCFTypeArrayCallBacks
+  );
+  if (!monitor->paths) {
+    stop_monitor_stream(monitor);
+    return -1;
+  }
 
   monitor->stream = FSEventStreamCreate(
     NULL,
     stream_callback,
     &context,
-    CFArrayCreate(NULL, (const void **)&paths, 1, NULL),
+    monitor->paths,
     kFSEventStreamEventIdSinceNow,
     0,
     kFSEventStreamCreateFlagNone
@@ -199,9 +229,17 @@ static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path)
       | kFSEventStreamCreateFlagFileEvents
   );
 
-  FSEventStreamScheduleWithRunLoop(
-    monitor->stream, main_run_loop, kCFRunLoopDefaultMode
-  );
+  if (!monitor->stream) {
+    stop_monitor_stream(monitor);
+    return -1;
+  }
+
+  monitor->queue = dispatch_queue_create("pragtical.dirmonitor.fsevents", NULL);
+  if (!monitor->queue) {
+    stop_monitor_stream(monitor);
+    return -1;
+  }
+  FSEventStreamSetDispatchQueue(monitor->stream, monitor->queue);
 
   if (!FSEventStreamStart(monitor->stream)) {
     stop_monitor_stream(monitor);

--- a/src/api/dirmonitor/inotify.c
+++ b/src/api/dirmonitor/inotify.c
@@ -39,14 +39,20 @@ static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buf
 
 
 static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int length, int (*change_callback)(int, const char*, void*), void* data) {
-  for (struct inotify_event* info = (struct inotify_event*)buffer; (char*)info < buffer + length; info = (struct inotify_event*)((char*)info + sizeof(struct inotify_event)))
+  for (struct inotify_event* info = (struct inotify_event*)buffer; (char*)info < buffer + length; info = (struct inotify_event*)((char*)info + sizeof(struct inotify_event) + info->len))
     change_callback(info->wd, NULL, data);
   return 0;
 }
 
 
 static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
-  return inotify_add_watch(monitor->fd, path, IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MODIFY | IN_MOVED_TO);
+  return inotify_add_watch(
+    monitor->fd,
+    path,
+    IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO
+      | IN_MODIFY | IN_CLOSE_WRITE | IN_ATTRIB
+      | IN_DELETE_SELF | IN_MOVE_SELF | IN_IGNORED
+  );
 }
 
 

--- a/src/api/dirmonitor/kqueue.c
+++ b/src/api/dirmonitor/kqueue.c
@@ -22,14 +22,18 @@ static struct dirmonitor_internal* init_dirmonitor(void) {
 
 
 static void deinit_dirmonitor(struct dirmonitor_internal* monitor) {
-  close(monitor->fd);
+  if (monitor->fd >= 0)
+    close(monitor->fd);
 }
 
 
 static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size) {
   struct timespec ts = { 0, 100 * 1000000 }; // 100 ms
 
-  int nev = kevent(monitor->fd, NULL, 0, (struct kevent*)buffer, buffer_size / sizeof(kevent), &ts);
+  if (monitor->fd < 0)
+    return -1;
+
+  int nev = kevent(monitor->fd, NULL, 0, (struct kevent*)buffer, buffer_size / sizeof(struct kevent), &ts);
   if (nev == -1)
     return -1;
   if (nev <= 0)
@@ -39,28 +43,46 @@ static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buf
 
 
 static int translate_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buffer, int buffer_size, int (*change_callback)(int, const char*, void*), void* data) {
-  for (struct kevent* info = (struct kevent*)buffer; (char*)info < buffer + buffer_size; info = (struct kevent*)(((char*)info) + sizeof(kevent)))
+  for (struct kevent* info = (struct kevent*)buffer; (char*)info < buffer + buffer_size; info = (struct kevent*)(((char*)info) + sizeof(struct kevent)))
     change_callback(info->ident, NULL, data);
   return 0;
 }
 
 
 static int add_dirmonitor(struct dirmonitor_internal* monitor, const char* path) {
-  int fd = open(path, O_RDONLY);
+  if (monitor->fd < 0)
+    return -1;
+
+  int flags = O_RDONLY;
+#ifdef O_EVTONLY
+  flags = O_EVTONLY;
+#endif
+#ifdef O_CLOEXEC
+  flags |= O_CLOEXEC;
+#endif
+
+  int fd = open(path, flags);
+  if (fd < 0)
+    return -1;
+
   struct kevent change;
 
   // a timeout of zero should make kevent return immediately
   struct timespec ts = { 0, 0 }; // 0 s
 
   EV_SET(&change, fd, EVFILT_VNODE, EV_ADD | EV_CLEAR, NOTE_DELETE | NOTE_EXTEND | NOTE_WRITE | NOTE_ATTRIB | NOTE_LINK | NOTE_RENAME, 0, (void*)path);
-  kevent(monitor->fd, &change, 1, NULL, 0, &ts);
+  if (kevent(monitor->fd, &change, 1, NULL, 0, &ts) == -1) {
+    close(fd);
+    return -1;
+  }
 
   return fd;
 }
 
 
 static void remove_dirmonitor(struct dirmonitor_internal* monitor, int fd) {
-  close(fd);
+  if (fd >= 0)
+    close(fd);
 }
 
 

--- a/src/api/dirmonitor/win32.c
+++ b/src/api/dirmonitor/win32.c
@@ -12,7 +12,15 @@ static int get_changes_dirmonitor(struct dirmonitor_internal* monitor, char* buf
   HANDLE handle = monitor->handle;
   if (handle && handle != INVALID_HANDLE_VALUE) {
     DWORD bytes_transferred;
-    if (ReadDirectoryChangesW(handle, buffer, buffer_size, TRUE,  FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME, &bytes_transferred, NULL, NULL) == 0)
+    DWORD filter =
+      FILE_NOTIFY_CHANGE_FILE_NAME
+      | FILE_NOTIFY_CHANGE_DIR_NAME
+      | FILE_NOTIFY_CHANGE_ATTRIBUTES
+      | FILE_NOTIFY_CHANGE_SIZE
+      | FILE_NOTIFY_CHANGE_LAST_WRITE
+      | FILE_NOTIFY_CHANGE_CREATION
+      | FILE_NOTIFY_CHANGE_SECURITY;
+    if (ReadDirectoryChangesW(handle, buffer, buffer_size, TRUE, filter, &bytes_transferred, NULL, NULL) == 0)
       return 0;
     return bytes_transferred;
   }


### PR DESCRIPTION
Fix event handling issues that could cause external file changes to be missed by autoreload, treeview, and SCM integrations. Inotify now parses batched events correctly and watches additional replacement and metadata notifications. Win32 watches content and metadata updates, kqueue handles registration failures safely, and FSEvents releases its CoreFoundation objects correctly.

Tighten DirWatch bookkeeping by clearing reverse watch mappings with the numeric watch id and by matching single-backend parent paths on directory boundaries. Autoreload now also sweeps open documents by timestamp and refreshes watches after replaced files.

Add focused dirmonitor and dirwatch tests, including file replacement and multiple watched-directory scenarios, and keep the tests portable across single and multiple backend modes.