### PR TITLE
Fix LuaJIT 32-bit x86 startup crash by preprocessing the VM asm

### DIFF
--- a/subprojects/packagefiles/luajit/meson.build
+++ b/subprojects/packagefiles/luajit/meson.build
@@ -61,7 +61,9 @@ if system == 'linux' or system == 'darwin' or system == 'windows'
             native: false
         )
         ljvm_mode = 'elfasm'
-        ljvm_bout = 'lj_vm.s'
+        # Capital .S so gcc preprocesses the "#if __PIC__" guards in the VM asm.
+        # A lowercase .s skips the preprocessor and miscompiles on 32-bit x86.
+        ljvm_bout = 'lj_vm.S'
     elif host_machine.system() == 'darwin'
         add_project_arguments(
             '-DLUAJIT_OS=LUAJIT_OS_OSX',
@@ -74,7 +76,7 @@ if system == 'linux' or system == 'darwin' or system == 'windows'
             native: false
         )
         ljvm_mode = 'machasm'
-        ljvm_bout = 'lj_vm.s'
+        ljvm_bout = 'lj_vm.S'  # capital .S to preprocess the VM asm (see linux note)
     elif host_machine.system() == 'windows'
         add_project_arguments(
             '-DLUAJIT_OS=LUAJIT_OS_WINDOWS',


### PR DESCRIPTION
buildvm's elfasm/machasm output wraps its libm math calls in C preprocessor guards:

    #if __PIC__
        call lj_wrap_<fn>      ; PIC-safe internal wrapper
    #else
        call <fn>@PLT          ; direct PLT call
    #endif

The Meson packagefile wrote this output to a lowercase "lj_vm.s", which gcc does not run through the preprocessor. The #if/#else/#endif lines are then treated as assembler comments and both branches are assembled. On 32-bit x86 the resulting <fn>@PLT call goes through the PLT, which requires %ebx to hold the GOT pointer; LuaJIT uses %ebx as its bytecode dispatch register, so the interpreter is corrupted and segfaults in the first interpreted function during luaL_openlibs. (x86-64 is unaffected.)

Name the output "lj_vm.S" (capital) for the elfasm and machasm modes, as upstream's Makefile does, so gcc preprocesses it and, under -fPIC, selects the safe lj_wrap_* path. peobj (Windows) is unchanged.

Fixes #556 