### PR TITLE
Allow system.setenv to unset values

### DIFF
--- a/docs/api/system.lua
+++ b/docs/api/system.lua
@@ -415,10 +415,11 @@ function system.path_compare(path1, type1, path2, type2) end
 
 ---
 ---Sets an environment variable.
----The converse of os.getenv.
+---The converse of os.getenv. If no value is provided, or if value is nil,
+---the environment variable is unset.
 ---
 ---@param key string
----@param val string
+---@param val? string
 ---@return boolean ok True if call succeeded
 function system.setenv(key, val) end
 

--- a/scripts/lua/tests/system.lua
+++ b/scripts/lua/tests/system.lua
@@ -103,6 +103,12 @@ test.describe("system", function()
     local key = "PRAGTICAL_SYSTEM_TEST_ENV_" .. pid
     test.ok(system.setenv(key, "ok"))
     test.equal(os.getenv(key), "ok")
+    test.ok(system.setenv(key))
+    test.equal(os.getenv(key), nil)
+    test.ok(system.setenv(key, "ok"))
+    test.equal(os.getenv(key), "ok")
+    test.ok(system.setenv(key, nil))
+    test.equal(os.getenv(key), nil)
 
     local score = system.fuzzy_match("alphabet", "alphabet")
     test.type(score, "number")

--- a/src/api/system.c
+++ b/src/api/system.c
@@ -1282,29 +1282,38 @@ static int f_text_input(lua_State* L) {
 
 static int f_setenv(lua_State* L) {
   const char *key = luaL_checkstring(L, 1);
-  const char *val = luaL_checkstring(L, 2);
+  const char *val = luaL_optstring(L, 2, NULL);
 
 #ifdef _WIN32
   /* On Windows Lua's os.getenv() reads the CRT environment, which SDL's
    * environment helpers do not reliably keep in sync. Update both the CRT and
    * the Win32 process environment so Lua and subprocess creation see the same
    * value. */
-  bool ok = _putenv_s(key, val) == 0;
+  bool ok = _putenv_s(key, val ? val : "") == 0;
   LPWSTR wkey = utfconv_utf8towc(key);
-  LPWSTR wval = utfconv_utf8towc(val);
-  if (!wkey || !wval) {
+  LPWSTR wval = val ? utfconv_utf8towc(val) : NULL;
+  if (!wkey || (val && !wval)) {
     SDL_free(wkey);
     SDL_free(wval);
     lua_pushboolean(L, false);
     return 1;
   }
 
-  ok = SetEnvironmentVariableW(wkey, wval) && ok;
+  if (val) {
+    ok = SetEnvironmentVariableW(wkey, wval) && ok;
+  } else {
+    ok = (SetEnvironmentVariableW(wkey, NULL)
+      || GetLastError() == ERROR_ENVVAR_NOT_FOUND) && ok;
+  }
   SDL_free(wkey);
   SDL_free(wval);
   lua_pushboolean(L, ok);
 #else
-  lua_pushboolean(L, SDL_setenv_unsafe(key, val, 1) == 0);
+  if (val) {
+    lua_pushboolean(L, SDL_setenv_unsafe(key, val, 1) == 0);
+  } else {
+    lua_pushboolean(L, SDL_unsetenv_unsafe(key) == 0);
+  }
 #endif
   return 1;
 }


### PR DESCRIPTION
Treat an omitted or nil value as a request to unset the environment variable. This keeps the existing API while covering the system.unsetenv use case.

Addresses #547