### PR TITLE
Project Search: multi-project support

### DIFF
--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -310,6 +310,12 @@ local function files_search_thread(tid, options)
   local file_size_limit = options.file_size_limit or (10 * 1e6)
   local includes = options.includes
   local excludes = options.excludes
+  local roots = options.roots or {
+    {
+      path = options.path,
+      name = commons.basename(options.path or "")
+    }
+  }
 
   ---Check if the given file path matches against the given list of patterns.
   ---@param file_path string
@@ -395,8 +401,10 @@ local function files_search_thread(tid, options)
     end
 
     local stop = false
-    local filename = filename_channel:wait()
-    while filename ~= "{{stop}}" do
+    local file_entry = filename_channel:wait()
+    while file_entry ~= "{{stop}}" do
+      local filename = type(file_entry) == "table" and file_entry.path or file_entry
+      local display_path = type(file_entry) == "table" and file_entry.display_path or nil
       local results = {}
       local found = false
       local fp = io.open(filename)
@@ -448,7 +456,8 @@ local function files_search_thread(tid, options)
         fp:close()
         table.insert(results, {
           filename,
-          lines
+          lines,
+          display_path
         })
       end
       stop = stop_channel:first() == "stop"
@@ -459,9 +468,9 @@ local function files_search_thread(tid, options)
         results_channel:push(true)
       end
       filename_channel:pop()
-      filename = filename_channel:wait()
-      while filename == nil do
-        filename = filename_channel:first()
+      file_entry = filename_channel:wait()
+      while file_entry == nil do
+        file_entry = filename_channel:first()
       end
     end
     if stop then
@@ -489,9 +498,7 @@ local function files_search_thread(tid, options)
   -- channel to monitor if the finding of should should be stopped.
   local channel_stop = thread.get_channel("projectsearch_stop"..tid)
 
-  local root = path
   local count = 0
-  local directories = {""}
   ---@type thread.Thread[]
   local workers_list = {}
   ---@type thread.Channel[]
@@ -523,55 +530,70 @@ local function files_search_thread(tid, options)
 
   local stop = false
   local current_worker = 1
-  while #directories > 0 do
-    for didx, directory in ipairs(directories) do
-      local dir_path = ""
+  for _, root_data in ipairs(roots) do
+    local root = root_data.path
+    local directories = {""}
+    while #directories > 0 do
+      for didx, directory in ipairs(directories) do
+        local dir_path = ""
 
-      if directory ~= "" then
-        dir_path = root .. pathsep .. directory
-        directory = directory .. pathsep
-      else
-        dir_path = root
-      end
+        if directory ~= "" then
+          dir_path = root .. pathsep .. directory
+          directory = directory .. pathsep
+        else
+          dir_path = root
+        end
 
-      local files = system.list_dir(dir_path)
+        local files = system.list_dir(dir_path)
 
-      if files then
-        for _, file in ipairs(files) do
-          local info = system.get_file_info(
-            dir_path .. pathsep .. file
-          )
-          count = count + 1
-          if
-            info and not commons.match_ignore_rule(
-              directory..file, info, ignore_files
-            ) and (
-              not includes or path_match(directory..file, includes, info)
-            ) and (
-              not excludes or not path_match(directory..file, excludes, info, true)
+        if files then
+          for _, file in ipairs(files) do
+            local info = system.get_file_info(
+              dir_path .. pathsep .. file
             )
-          then
-            if info.type == "dir" then
-              table.insert(directories, directory .. file)
-            elseif info.size <= file_size_limit then
-              filename_channels[current_worker]:push(dir_path .. pathsep .. file)
-              current_worker = current_worker + 1
-              if current_worker > workers then current_worker = 1 end
+            count = count + 1
+            if
+              info and not commons.match_ignore_rule(
+                directory..file, info, ignore_files
+              ) and (
+                not includes or path_match(directory..file, includes, info)
+              ) and (
+                not excludes or not path_match(directory..file, excludes, info, true)
+              )
+            then
+              if info.type == "dir" then
+                table.insert(directories, directory .. file)
+              elseif info.size <= file_size_limit then
+                local file_path = dir_path .. pathsep .. file
+                local display_path
+                if root_data.display_prefix then
+                  display_path = root_data.display_prefix
+                    .. pathsep
+                    .. commons.relative_path(root, file_path)
+                end
+                filename_channels[current_worker]:push({
+                  path = file_path,
+                  display_path = display_path
+                })
+                current_worker = current_worker + 1
+                if current_worker > workers then current_worker = 1 end
+              end
             end
           end
         end
+        table.remove(directories, didx)
+        break
       end
-      table.remove(directories, didx)
-      break
-    end
 
-    stop = channel_stop:first() == "stop"
-    if not stop then
-      channel_status:clear()
-      channel_status:push(count)
-    else
-      break
+      stop = channel_stop:first() == "stop"
+      if not stop then
+        channel_status:clear()
+        channel_status:push(count)
+      else
+        break
+      end
     end
+    if stop then break end
   end
 
   if not stop then
@@ -611,7 +633,7 @@ local function worker_threads_add_results(self, result_channels)
               positions = line[3]
             })
           end
-          self.results_list:add_file(result[1], lines)
+          self.results_list:add_file(result[1], lines, nil, result[3])
         end
       end
       found = true
@@ -665,6 +687,33 @@ local function parse_filters(self, filters)
   return list
 end
 
+---@param path? string
+---@return table[] roots
+---@return boolean multiple_projects
+---@return string? base_dir
+local function get_search_roots(path)
+  if path then
+    return {{ path = path, name = common.basename(path) }}, false, path
+  end
+
+  local roots = {}
+  for _, project in ipairs(core.projects) do
+    table.insert(roots, {
+      path = project.path,
+      name = project.name or common.basename(project.path)
+    })
+  end
+
+  local multiple_projects = #roots > 1
+  if multiple_projects then
+    for _, root in ipairs(roots) do
+      root.display_prefix = root.name
+    end
+  end
+
+  return roots, multiple_projects, roots[1] and roots[1].path or nil
+end
+
 ---Start the search procedure and worker threads.
 ---@param path? string
 ---@param text string
@@ -685,7 +734,8 @@ function ResultsView:begin_search(path, text, search_type, insensitive, whole_wo
       return
     end
   end
-  path = path or core.root_project().path
+  local roots, multiple_projects, base_dir = get_search_roots(path)
+  if #roots == 0 then return end
 
   self.path = path
   self.stop = false
@@ -695,7 +745,7 @@ function ResultsView:begin_search(path, text, search_type, insensitive, whole_wo
   self.total_files = 0
   self.start_time = system.get_time()
   self.end_time = self.start_time
-  self.results_list.base_dir = path
+  self.results_list.base_dir = multiple_projects and "" or base_dir
 
   threaded_search_id = threaded_search_id + 1
   core.add_thread(function()
@@ -710,7 +760,8 @@ function ResultsView:begin_search(path, text, search_type, insensitive, whole_wo
         search_type = search_type,
         insensitive = insensitive,
         whole_word = whole_word,
-        path = path,
+        path = base_dir,
+        roots = roots,
         pathsep = PATHSEP,
         ignore_files = core.get_ignore_file_rules(),
         workers = workers,
@@ -1271,6 +1322,11 @@ local projectsearch = {}
 
 ---@type plugins.projectsearch.resultsview
 projectsearch.ResultsView = ResultsView
+
+projectsearch._test = {
+  files_search_thread = files_search_thread,
+  get_search_roots = get_search_roots
+}
 
 ---Start a plain text search.
 ---@param text string

--- a/scripts/lua/tests/projectsearch.lua
+++ b/scripts/lua/tests/projectsearch.lua
@@ -1,0 +1,144 @@
+local common = require "core.common"
+local config = require "core.config"
+local core = require "core"
+local test = require "core.test"
+local projectsearch = require "plugins.projectsearch"
+local SearchReplaceList = require "widget.searchreplacelist"
+
+local function join_path(...)
+  return table.concat({...}, PATHSEP)
+end
+
+local function write_file(path, content)
+  local file, err = io.open(path, "wb")
+  test.not_nil(file, err)
+  file:write(content)
+  file:close()
+end
+
+local function collect_worker_results(tid, workers)
+  local files = {}
+  for id = 1, workers do
+    local channel = thread.get_channel("projectsearch_results"..tid..id)
+    local value = channel:first()
+    while value ~= nil do
+      if type(value) == "table" then
+        for _, result in ipairs(value) do
+          files[#files + 1] = {
+            path = result[1],
+            display_path = result[3],
+            lines = result[2]
+          }
+        end
+      end
+      channel:pop()
+      value = channel:first()
+    end
+  end
+  return files
+end
+
+test.describe("projectsearch", function()
+  test.before_each(function(context)
+    context.old_projects = core.projects
+    context.temp_root = join_path(
+      USERDIR,
+      "projectsearch-tests-" .. system.get_process_id()
+        .. "-" .. math.floor(system.get_time() * 1000000)
+    )
+    context.project_a = join_path(context.temp_root, "alpha")
+    context.project_b = join_path(context.temp_root, "beta")
+    test.ok(common.mkdirp(join_path(context.project_a, "src")))
+    test.ok(common.mkdirp(join_path(context.project_b, "lib")))
+    write_file(join_path(context.project_a, "src", "one.txt"), "needle one\n")
+    write_file(join_path(context.project_b, "lib", "two.txt"), "needle two\n")
+    write_file(join_path(context.project_b, "lib", "skip.txt"), "other\n")
+    core.projects = {
+      { path = context.project_a, name = "alpha" },
+      { path = context.project_b, name = "beta" }
+    }
+  end)
+
+  test.after_each(function(context)
+    core.projects = context.old_projects
+    if context.temp_root and system.get_file_info(context.temp_root) then
+      local ok, err = common.rm(context.temp_root, true)
+      test.ok(ok, err)
+    end
+  end)
+
+  test.test("uses all open projects when no path is provided", function(context)
+    local roots, multiple, base_dir = projectsearch._test.get_search_roots()
+
+    test.equal(#roots, 2)
+    test.equal(multiple, true)
+    test.equal(base_dir, context.project_a)
+    test.equal(roots[1].path, context.project_a)
+    test.equal(roots[1].display_prefix, "alpha")
+    test.equal(roots[2].path, context.project_b)
+    test.equal(roots[2].display_prefix, "beta")
+  end)
+
+  test.test("uses one root when an explicit path is provided", function(context)
+    local roots, multiple, base_dir = projectsearch._test.get_search_roots(
+      context.project_b
+    )
+
+    test.equal(#roots, 1)
+    test.equal(multiple, false)
+    test.equal(base_dir, context.project_b)
+    test.equal(roots[1].path, context.project_b)
+    test.equal(roots[1].display_prefix, nil)
+  end)
+
+  test.test("single project default keeps root-project behavior", function(context)
+    core.projects = {{ path = context.project_a, name = "alpha" }}
+
+    local roots, multiple, base_dir = projectsearch._test.get_search_roots()
+
+    test.equal(#roots, 1)
+    test.equal(multiple, false)
+    test.equal(base_dir, context.project_a)
+    test.equal(roots[1].path, context.project_a)
+    test.equal(roots[1].display_prefix, nil)
+  end)
+
+  test.test("worker searches multiple project roots", function(context)
+    local tid = 500000 + system.get_process_id()
+    local workers = 1
+    local roots = projectsearch._test.get_search_roots()
+
+    projectsearch._test.files_search_thread(tid, {
+      text = "needle",
+      search_type = "plain",
+      insensitive = false,
+      whole_word = false,
+      pathsep = PATHSEP,
+      ignore_files = {},
+      workers = workers,
+      file_size_limit = config.file_size_limit * 1e6,
+      roots = roots
+    })
+
+    local files = collect_worker_results(tid, workers)
+    table.sort(files, function(a, b) return a.display_path < b.display_path end)
+
+    test.equal(#files, 2)
+    test.equal(files[1].display_path, "alpha" .. PATHSEP .. "src" .. PATHSEP .. "one.txt")
+    test.equal(files[2].display_path, "beta" .. PATHSEP .. "lib" .. PATHSEP .. "two.txt")
+    test.equal(files[1].lines[1][2], 1)
+    test.equal(files[1].lines[1][3][1].col1, 1)
+    test.equal(files[1].lines[1][3][1].col2, 6)
+  end)
+
+  test.test("result list keeps absolute path and display path", function(context)
+    local list = SearchReplaceList(nil)
+    local absolute_path = join_path(context.project_a, "src", "one.txt")
+    local display_path = "alpha" .. PATHSEP .. "src" .. PATHSEP .. "one.txt"
+
+    list:add_file(absolute_path, {}, true, display_path)
+
+    test.equal(list.items[1].file.path, absolute_path)
+    test.equal(list.items[1].file.display_path, display_path)
+  end)
+end)

--- a/subprojects/widget.wrap
+++ b/subprojects/widget.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/pragtical/widget.git
-revision = c11e78c9f16606f05e73abc3a2b41ee7b548f7d5
+revision = 3047f9a27415fb5f43710848ffa1fc6a30ee09a6
 depth = 1
 patch_directory = widget


### PR DESCRIPTION
Project search now treats an omitted path as a request to search every open project while preserving explicit single-directory searches.

Pass project-prefixed display paths through search results so files from different roots remain distinguishable, and update the widget wrap for that support. Add coverage for root selection, threaded worker results, and result display metadata.

### Preview

<img width="1755" height="1001" alt="projectsearch-multi-project" src="https://github.com/user-attachments/assets/95a7099a-6479-4ba7-b163-28fabea53472" />
