### PR TITLE
Split codefold toggle commands

### DIFF
--- a/data/plugins/codefold.lua
+++ b/data/plugins/codefold.lua
@@ -1271,6 +1271,11 @@ end
 
 command.add(nil, {
   ["code-folding:toggle"] = function()
+    config.plugins.codefold.enabled = not config.plugins.codefold.enabled
+    core.redraw = true
+  end,
+
+  ["code-folding:toggle-fold"] = function()
     local view = core.active_view
     if not view or not codefold_enabled_for_view(view) or not view.cf_regions then
       return
@@ -1311,8 +1316,8 @@ command.add(nil, {
 ---------------------------------------------------------------------
 
 keymap.add {
-  ["alt+shift+left"] = "code-folding:toggle",
-  ["alt+shift+right"] = "code-folding:toggle",
+  ["alt+shift+left"] = "code-folding:toggle-fold",
+  ["alt+shift+right"] = "code-folding:toggle-fold",
   ["alt+shift+up"] = "code-folding:fold-all",
   ["alt+shift+down"] = "code-folding:unfold-all"
 }

--- a/scripts/lua/tests/test_codefold.lua
+++ b/scripts/lua/tests/test_codefold.lua
@@ -7,6 +7,7 @@ local core = require "core"
 local command = require "core.command"
 local config = require "core.config"
 local common = require "core.common"
+local keymap = require "core.keymap"
 local style = require "core.style"
 local syntax = require "core.syntax"
 
@@ -849,6 +850,76 @@ test.describe("codefold - virtual line mapping", function()
     SCALE = previous_scale
     view:on_scale_change(SCALE, previous_scale * 2)
     config.plugins.codefold.enabled = previous_enabled
+  end)
+
+  test.test("toggle command enables and disables code folding", function()
+    require "plugins.codefold"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    local previous_redraw = core.redraw
+    config.plugins.codefold.enabled = true
+    core.redraw = false
+
+    test.ok(command.perform("code-folding:toggle"))
+    test.equal(config.plugins.codefold.enabled, false)
+    test.equal(core.redraw, true)
+
+    core.redraw = false
+    test.ok(command.perform("code-folding:toggle"))
+    test.equal(config.plugins.codefold.enabled, true)
+    test.equal(core.redraw, true)
+
+    config.plugins.codefold.enabled = previous_enabled
+    core.redraw = previous_redraw
+  end)
+
+  test.test("toggle-fold command toggles the active fold region", function()
+    require "plugins.codefold"
+
+    local previous_enabled = config.plugins.codefold.enabled
+    local previous_active_view = core.active_view
+    config.plugins.codefold.enabled = true
+
+    local view = make_docview({ "a\n", "  b\n", "c\n" })
+    view.cf_regions = { { indent = 0, start = 1, stop = 2 } }
+    view.cf_folded_regions = {}
+    view.cf_folded_region_set = {}
+    view.cf_fold_map = { 1, 2, 3 }
+    view.cf_unfold_map = { 1, 2, 3 }
+    view.cf_first_update = nil
+    view.cf_invalidated = nil
+    view.doc:set_selection(1, 1)
+    core.active_view = view
+
+    test.ok(command.perform("code-folding:toggle-fold"))
+    test.ok(view.cf_folded_region_set[1])
+
+    test.ok(command.perform("code-folding:toggle-fold"))
+    test.is_nil(view.cf_folded_region_set[1])
+
+    config.plugins.codefold.enabled = previous_enabled
+    core.active_view = previous_active_view
+  end)
+
+  test.test("fold keybindings use the fold toggle command", function()
+    require "plugins.codefold"
+
+    local function matches_binding(stroke, key)
+      return stroke:find(key, 1, true)
+        and stroke:find("alt", 1, true)
+        and stroke:find("shift", 1, true)
+    end
+
+    local bindings = keymap.reverse_map["code-folding:toggle-fold"] or {}
+    local left = false
+    local right = false
+    for _, stroke in ipairs(bindings) do
+      if matches_binding(stroke, "left") then left = true end
+      if matches_binding(stroke, "right") then right = true end
+    end
+
+    test.equal(left, true)
+    test.equal(right, true)
   end)
 
   test.test("fold gutter marker visibility and color reflect state", function()


### PR DESCRIPTION
Make code-folding:toggle control whether the plugin is enabled, and move the active-region fold behavior to code-folding:toggle-fold.

Keep the existing Alt+Shift fold keybindings pointed at the fold command so line folding muscle memory is unchanged. Add tests for the command split and keybinding behavior.

Addresses part of #563 