### PR TITLE
Fix SDL3 probes under CMake 4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -325,6 +325,15 @@ if not get_option('source-only')
             'SDL_VENDOR_INFO': 'pragtical'
         })
 
+        if host_machine.system() == 'linux'
+            # SDL_internal.h enables GNU extensions, so CMake's libc probes
+            # need the same feature set. CMake 4 does not pass SDL's
+            # CMAKE_REQUIRED_FLAGS to check_symbol_exists() try-compiles.
+            sdl_options.add_cmake_defines({
+                'CMAKE_REQUIRED_DEFINITIONS': '-D_GNU_SOURCE=1'
+            })
+        endif
+
         if host_machine.system() == 'windows'
             # warn about the implications of missing iconv
             if not cc.find_library('iconv', required: false).found()


### PR DESCRIPTION
Pass _GNU_SOURCE through CMake's required definitions when configuring the SDL3 fallback on Linux. This keeps getresuid and getresgid probes consistent with SDL_internal.h and prevents conflicting fallback declarations.

The failure surfaced after CI picked up the latest CMake alongside Meson and SDL3 v3.4.12. The unpinned CMake setup stopped forwarding SDL's CMAKE_REQUIRED_FLAGS to check_symbol_exists(), although the same latent issue is reproducible with SDL3 v3.4.10 outside Meson.

Verify the corrected probes and SDL_gtk compilation with GCC and Clang.