### PR TITLE
Fix vertical movement on wrapped lines

### DIFF
--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -439,6 +439,12 @@ function get_line_col_from_index_and_x(docview, idx, x)
   local doc = docview.doc
   local line, col = get_idx_line_col(docview, idx)
   if idx < 1 then return 1, 1 end
+  local next_line, next_col = get_idx_line_col(docview, idx + 1)
+  local row_end_col = #doc.lines[line]
+  if next_line == line then
+    local _, previous_col = translate.previous_char(doc, line, next_col)
+    row_end_col = previous_col
+  end
   local xoffset, last_i, i = (col ~= 1 and docview.wrapped_line_offsets[line] or 0), col, 1
   if x < xoffset then return line, col end
   local default_font = docview:get_font()
@@ -448,6 +454,7 @@ function get_line_col_from_index_and_x(docview, idx, x)
     local font, w = get_font(default_font, type, indent_size), 0
     for char in common.utf8_chars(text) do
       if i >= col then
+        if i > row_end_col then return line, row_end_col end
         if xoffset >= x then
           return line, (xoffset - x > (w / 2) and last_i or i)
         end
@@ -458,7 +465,7 @@ function get_line_col_from_index_and_x(docview, idx, x)
       i = i + #char
     end
   end
-  return line, #doc.lines[line]
+  return line, row_end_col
 end
 
 

--- a/scripts/lua/tests/linewrapping.lua
+++ b/scripts/lua/tests/linewrapping.lua
@@ -529,4 +529,35 @@ test.describe("linewrapping", function()
     config.plugins.codefold.enabled = previous_codefold
     config.plugins.codefold.hide_tail_on_fold = previous_hide_tail
   end)
+
+  test.test("vertical movement stays within each target wrapped row", function()
+    local previous_mode = config.plugins.linewrapping.mode
+    config.plugins.linewrapping.mode = "word"
+
+    local view = make_view(
+      "short words followed by substantiallylongerwords and more short words\n"
+    )
+    local font = view:get_font()
+    local width = font:get_width("short words")
+    LineWrapping.reconstruct_breaks(view, font, width)
+
+    local count = view:visual_line_count()
+    test.ok(count > 2)
+    local line = view:visual_position_from_row(1)
+    local col = view:get_visual_line_col_from_x(1, width * 2)
+    test.equal(view:visual_row_from_position(line, col), 1)
+
+    view.last_x_offset = {}
+    for expected_row = 2, count do
+      line, col = DocView.translate.next_line(view.doc, line, col, view)
+      test.equal(view:visual_row_from_position(line, col), expected_row)
+    end
+
+    for expected_row = count - 1, 1, -1 do
+      line, col = DocView.translate.previous_line(view.doc, line, col, view)
+      test.equal(view:visual_row_from_position(line, col), expected_row)
+    end
+
+    config.plugins.linewrapping.mode = previous_mode
+  end)
 end)


### PR DESCRIPTION
Limit horizontal position resolution to the requested visual row so preserved offsets cannot map into later wrapped rows. This prevents repeated Up and Down commands from getting stuck on documents with uneven long lines.

Add regression coverage for oversized horizontal offsets and bidirectional movement across all wrapped rows.

Should fix #579 