### PR TITLE
Default missing syntax symbols

### DIFF
--- a/data/core/syntax.lua
+++ b/data/core/syntax.lua
@@ -76,6 +76,7 @@ end
 ---@param t core.syntax.syntax Syntax definition to register.
 function syntax.add(t)
   if type(t.space_handling) ~= "boolean" then t.space_handling = true end
+  if type(t.symbols) ~= "table" then t.symbols = {} end
 
   if t.patterns then
     -- do a sanity check on the patterns / regex to make sure they are actually correct


### PR DESCRIPTION
Allow language definitions to omit the symbols table when they only need pattern-based tokenization. The tokenizer already treats symbols as exact text overrides, so an empty table is the correct default.

This prevents fixture and runtime tokenization paths from failing when a syntax provides patterns but no symbol overrides.