### PR TITLE
Fix conditional context menu dividers

### DIFF
--- a/data/core/contextmenu.lua
+++ b/data/core/contextmenu.lua
@@ -92,23 +92,27 @@ end
 ---@return boolean # If true, the context menu is shown.
 function ContextMenu:show(x, y)
   self.items = nil
-  local items_list = { width = 0, height = 0 }
+  local items_list = {}
   for _, items in ipairs(self.itemset) do
     if items.predicate(x, y) then
-      update_items_size(items.items)
-      items_list.width = math.max(items_list.width, items.items.width)
-      items_list.height = items_list.height
       for _, subitems in ipairs(items.items) do
         if not subitems.command or command.is_valid(subitems.command) then
-          local lw, lh = get_item_size(subitems)
-          items_list.height = items_list.height + lh
-          table.insert(items_list, subitems)
+          if subitems ~= DIVIDER
+            or (#items_list > 0 and items_list[#items_list] ~= DIVIDER)
+          then
+            table.insert(items_list, subitems)
+          end
         end
       end
     end
   end
 
+  if items_list[#items_list] == DIVIDER then
+    table.remove(items_list)
+  end
+
   if #items_list > 0 then
+    update_items_size(items_list)
     self.items = items_list
     local w, h = self.items.width, self.items.height
 

--- a/data/plugins/contextmenu.lua
+++ b/data/plugins/contextmenu.lua
@@ -80,7 +80,7 @@ local cmds = {
 }
 
 if config.plugins.scale ~= false and require("plugins.scale") then
-  table.move(cmds, 4, 6, 7)
+  table.move(cmds, 4, #cmds, 7)
   cmds[4] = { text = "Font +",     command = "scale:increase" }
   cmds[5] = { text = "Font -",     command = "scale:decrease" }
   cmds[6] = { text = "Font Reset", command = "scale:reset"    }

--- a/scripts/lua/tests/contextmenu.lua
+++ b/scripts/lua/tests/contextmenu.lua
@@ -1,0 +1,80 @@
+local command = require "core.command"
+local ContextMenu = require "core.contextmenu"
+local style = require "core.style"
+local test = require "core.test"
+
+local visible_command = "contextmenu-test:visible"
+local filtered_command = "contextmenu-test:filtered"
+local previous_commands
+
+local function new_menu(items)
+  local menu = ContextMenu()
+  menu:register(nil, items)
+  test.equal(menu:show(0, 0), true)
+  return menu
+end
+
+test.describe("contextmenu", function()
+  test.before_each(function()
+    previous_commands = {
+      visible = command.map[visible_command],
+      filtered = command.map[filtered_command]
+    }
+    command.add(nil, {
+      [visible_command] = function() end
+    })
+    command.add(function() return false end, {
+      [filtered_command] = function() end
+    })
+  end)
+
+  test.after_each(function()
+    command.map[visible_command] = previous_commands.visible
+    command.map[filtered_command] = previous_commands.filtered
+  end)
+
+  test.test("removes a leading divider after command filtering", function()
+    local menu = new_menu {
+      { text = "A filtered item that is much wider", command = filtered_command },
+      ContextMenu.DIVIDER,
+      { text = "Visible", command = visible_command }
+    }
+
+    test.equal(#menu.items, 1)
+    test.equal(menu.items[1].text, "Visible")
+    test.equal(
+      menu.items.width,
+      style.font:get_width("Visible") + style.padding.x * 2
+    )
+    test.equal(
+      menu.items.height,
+      style.font:get_height() + style.padding.y
+    )
+  end)
+
+  test.test("removes a trailing divider after command filtering", function()
+    local menu = new_menu {
+      { text = "Visible", command = visible_command },
+      ContextMenu.DIVIDER,
+      { text = "Filtered", command = filtered_command }
+    }
+
+    test.equal(#menu.items, 1)
+    test.equal(menu.items[1].text, "Visible")
+  end)
+
+  test.test("collapses consecutive dividers after command filtering", function()
+    local menu = new_menu {
+      { text = "First", command = visible_command },
+      ContextMenu.DIVIDER,
+      { text = "Filtered", command = filtered_command },
+      ContextMenu.DIVIDER,
+      { text = "Last", command = visible_command }
+    }
+
+    test.equal(#menu.items, 3)
+    test.equal(menu.items[1].text, "First")
+    test.equal(menu.items[2], ContextMenu.DIVIDER)
+    test.equal(menu.items[3].text, "Last")
+  end)
+end)

--- a/scripts/lua/tests/markdownview.lua
+++ b/scripts/lua/tests/markdownview.lua
@@ -2503,6 +2503,76 @@ For more detailed instructions visit: https://pragtical.dev/docs/setup/building
     node:close_view(core.root_view.root_node, view)
   end)
 
+  test.test("shows document context items based on markdown support", function(context)
+    local contextmenu = require "plugins.contextmenu"
+    local divider = contextmenu.DIVIDER
+
+    local function shown_items_for(path)
+      write_file(path, "# Context menu\n")
+      local view = core.open_file(path)
+      test.ok(view:extends(DocView))
+      test.equal(contextmenu:show(0, 0), true)
+
+      local items = {}
+      for index, item in ipairs(contextmenu.items) do
+        items[index] = item
+      end
+      contextmenu:hide()
+      return items
+    end
+
+    local function item_index(items, text)
+      for index, item in ipairs(items) do
+        if item ~= divider and item.text == text then
+          return index
+        end
+      end
+    end
+
+    local function assert_normalized(items)
+      test.not_equal(items[1], divider)
+      test.not_equal(items[#items], divider)
+      for index = 2, #items do
+        test.not_ok(
+          items[index - 1] == divider and items[index] == divider,
+          "context menu contains adjacent dividers"
+        )
+      end
+    end
+
+    for _, extension in ipairs { "md", "markdown" } do
+      local items = shown_items_for(
+        context.temp_root .. PATHSEP .. "context-menu." .. extension
+      )
+      local preview_index = item_index(items, "Preview Markdown")
+      local find_index = item_index(items, "Find")
+      local replace_index = item_index(items, "Replace")
+
+      test.not_nil(preview_index)
+      test.not_nil(find_index)
+      test.not_nil(replace_index)
+      test.ok(preview_index < find_index)
+      test.ok(find_index < replace_index)
+      assert_normalized(items)
+    end
+
+    local items = shown_items_for(
+      context.temp_root .. PATHSEP .. "context-menu.txt"
+    )
+    local reset_index = item_index(items, "Font Reset")
+    local find_index = item_index(items, "Find")
+    local replace_index = item_index(items, "Replace")
+
+    test.is_nil(item_index(items, "Preview Markdown"))
+    test.not_nil(reset_index, "Scale context items should be enabled")
+    test.not_nil(find_index)
+    test.not_nil(replace_index)
+    test.equal(items[reset_index + 1], divider)
+    test.equal(find_index, reset_index + 2)
+    test.equal(replace_index, find_index + 1)
+    assert_normalized(items)
+  end)
+
   test.test("previews the active markdown doc", function(context)
     local path = context.temp_root .. PATHSEP .. "preview.md"
     write_file(path, "# Preview\n\nInitial text.\n")


### PR DESCRIPTION
Normalize visible context menu items after predicate and command filtering. This removes orphaned and duplicate dividers and ensures the menu geometry matches the entries that are rendered.

Preserve the complete document command tail when inserting scale controls so Preview Markdown, Find, and Replace remain available. Add coverage for normalized and Markdown-specific menu layouts.

Partially fixes #585