### PR TITLE
Support wrapping in diff views

### DIFF
--- a/data/plugins/diffview.lua
+++ b/data/plugins/diffview.lua
@@ -136,6 +136,8 @@ function DiffView:new(a, b, compare_type, names)
   self.b_gaps = {}
   self.a_changes = {}
   self.b_changes = {}
+  self.diff_layout_generation = 0
+  self.aligned_layout = nil
   self.views_patched = false
 
   self:patch_views()
@@ -188,10 +190,10 @@ function DiffView:update_diff()
     local b_len = #self.doc_view_b.doc.lines
 
     local computing_start = system.get_time()
-    local a_gaps = #self.a_gaps == 0 and self.a_gaps or {}
-    local b_gaps = #self.b_gaps == 0 and self.b_gaps or {}
-    local a_changes = #self.a_changes == 0 and self.a_changes or {}
-    local b_changes = #self.b_changes == 0 and self.b_changes or {}
+    local a_gaps = {}
+    local b_gaps = {}
+    local a_changes = {}
+    local b_changes = {}
     for edit in diff.diff_iter(self.doc_view_a.doc.lines, self.doc_view_b.doc.lines) do
       if edit.tag == "equal" or edit.tag == "modify" then
         -- Assign gaps for this line
@@ -259,6 +261,8 @@ function DiffView:update_diff()
     self.b_gaps = b_gaps
     self.a_changes = a_changes
     self.b_changes = b_changes
+    self.diff_layout_generation = self.diff_layout_generation + 1
+    self.aligned_layout = nil
 
     self.updater_idx = nil
 
@@ -338,6 +342,8 @@ function DiffView:sync(line, target_line, is_a)
 
     common.splice(target_gaps, target_line, 0, gaps_inserts)
   end
+  self.diff_layout_generation = self.diff_layout_generation + 1
+  self.aligned_layout = nil
 end
 
 function DiffView:sync_selected()
@@ -523,8 +529,10 @@ function DiffView:on_mouse_wheel(y, x)
     y = 0
   end
   if y and y ~= 0 then
-    self.doc_view_a.scroll.to.y = self.doc_view_a.scroll.to.y + y * -config.mouse_wheel_scroll
-    self.doc_view_b.scroll.to.y = self.doc_view_b.scroll.to.y + y * -config.mouse_wheel_scroll
+    local delta = y * -config.mouse_wheel_scroll
+    self.scroll.to.y = self.scroll.to.y + delta
+    self.doc_view_a.scroll.to.y = self.doc_view_a.scroll.to.y + delta
+    self.doc_view_b.scroll.to.y = self.doc_view_b.scroll.to.y + delta
   end
   if x and x ~= 0 then
     self.doc_view_a.scroll.to.x = self.doc_view_a.scroll.to.x + x * -config.mouse_wheel_scroll
@@ -545,16 +553,138 @@ function DiffView:on_touch_moved(...)
   self.doc_view_b:on_touch_moved(...)
 end
 
+local function add_layout_side(slots, view, gaps, side_name)
+  local max_slot = 0
+  local gap_total = 0
+  for line = 1, #view.doc.lines do
+    local gap = gaps[line]
+    if gap then gap_total = gap[2] end
+    local slot_index = line - 1 + gap_total
+    local slot = slots[slot_index + 1]
+    if not slot then
+      slot = { index = slot_index }
+      slots[slot_index + 1] = slot
+    end
+    local first_row, row_count = view:visual_rows_for_line(line)
+    slot[side_name .. "_line"] = line
+    slot[side_name .. "_row_count"] = math.max(1, row_count)
+    slot[side_name .. "_native_start"] = first_row or 1
+    max_slot = math.max(max_slot, slot_index)
+  end
+  return max_slot
+end
+
+---Return the cached shared visual-row layout for both comparison panes.
+---@return table layout
+function DiffView:get_aligned_layout()
+  local a_model = self.doc_view_a:get_visual_lines()
+  local b_model = self.doc_view_b:get_visual_lines()
+  local a_line_count = #self.doc_view_a.doc.lines
+  local b_line_count = #self.doc_view_b.doc.lines
+  local a_line_height = self.doc_view_a:get_line_height()
+  local b_line_height = self.doc_view_b:get_line_height()
+  local cached = self.aligned_layout
+
+  if cached
+    and cached.a_model == a_model
+    and cached.b_model == b_model
+    and cached.a_gaps == self.a_gaps
+    and cached.b_gaps == self.b_gaps
+    and cached.a_line_count == a_line_count
+    and cached.b_line_count == b_line_count
+    and cached.a_line_height == a_line_height
+    and cached.b_line_height == b_line_height
+    and cached.generation == self.diff_layout_generation
+  then
+    return cached
+  end
+
+  local slots = {}
+  local max_slot = add_layout_side(slots, self.doc_view_a, self.a_gaps, "a")
+  max_slot = math.max(
+    max_slot,
+    add_layout_side(slots, self.doc_view_b, self.b_gaps, "b")
+  )
+
+  local layout = {
+    a_model = a_model,
+    b_model = b_model,
+    a_gaps = self.a_gaps,
+    b_gaps = self.b_gaps,
+    a_line_count = a_line_count,
+    b_line_count = b_line_count,
+    a_line_height = a_line_height,
+    b_line_height = b_line_height,
+    line_height = a_line_height,
+    generation = self.diff_layout_generation,
+    slots = slots,
+    a = { starts = {}, heights = {}, row_counts = {}, native_starts = {} },
+    b = { starts = {}, heights = {}, row_counts = {}, native_starts = {} },
+  }
+
+  local row = 0
+  for slot_index = 0, max_slot do
+    local slot = slots[slot_index + 1] or { index = slot_index }
+    slots[slot_index + 1] = slot
+    local height = math.max(
+      1,
+      slot.a_row_count or 0,
+      slot.b_row_count or 0
+    )
+    slot.start = row
+    slot.height = height
+    if slot.a_line then
+      layout.a.starts[slot.a_line] = row
+      layout.a.heights[slot.a_line] = height
+      layout.a.row_counts[slot.a_line] = slot.a_row_count
+      layout.a.native_starts[slot.a_line] = slot.a_native_start
+    end
+    if slot.b_line then
+      layout.b.starts[slot.b_line] = row
+      layout.b.heights[slot.b_line] = height
+      layout.b.row_counts[slot.b_line] = slot.b_row_count
+      layout.b.native_starts[slot.b_line] = slot.b_native_start
+    end
+    row = row + height
+  end
+  layout.total_rows = math.max(1, row)
+  self.aligned_layout = layout
+  return layout
+end
+
+local function get_layout_side(layout, is_a)
+  return is_a and layout.a or layout.b
+end
+
+---Resolve an aligned zero-based visual row to a line and native visual row.
+local function position_from_aligned_row(layout, is_a, aligned_row)
+  local side = get_layout_side(layout, is_a)
+  local line_count = is_a and layout.a_line_count or layout.b_line_count
+  local low, high, line = 1, line_count, 1
+  while low <= high do
+    local mid = math.floor((low + high) / 2)
+    if (side.starts[mid] or 0) <= aligned_row then
+      line = mid
+      low = mid + 1
+    else
+      high = mid - 1
+    end
+  end
+  local local_row = common.clamp(
+    aligned_row - (side.starts[line] or 0),
+    0,
+    (side.row_counts[line] or 1) - 1
+  )
+  return line, (side.native_starts[line] or 1) + local_row
+end
+
 function DiffView:get_scrollable_size()
-  local a_lines, b_lines = #self.doc_view_a.doc.lines, #self.doc_view_b.doc.lines
-  local a_gaps = (self.a_gaps[a_lines] and self.a_gaps[a_lines][2] or 0)
-  local b_gaps = (self.b_gaps[b_lines] and self.b_gaps[b_lines][2] or 0)
-  local lc = math.max(a_lines + a_gaps, b_lines + b_gaps)
+  local layout = self:get_aligned_layout()
   if not config.scroll_past_end then
     local _, _, _, h_scroll = self.h_scrollbar:get_track_rect()
-    return self.doc_view_a:get_line_height() * (lc) + style.padding.y * 2 + h_scroll
+    return layout.line_height * layout.total_rows + style.padding.y * 2 + h_scroll
   end
-  return self.doc_view_a:get_line_height() * (lc - 1) + self.size.y
+  return layout.line_height * (layout.total_rows - 1) + self.size.y
 end
 
 ---@param parent core.diffview
@@ -564,8 +694,8 @@ end
 ---@param y number
 ---@param changes diff.changes[]
 local function draw_line_text_override(parent, self, line, x, y, changes)
-  y = y + self:get_line_text_y_offset()
-  local h = self:get_line_height()
+  local lh = self:get_line_height()
+  local h = self:get_line_visual_height(line)
   local change = changes[line]
   if change and change.tag ~= "equal" then
     local delete_bg = style.diff_delete_background
@@ -599,26 +729,45 @@ local function draw_line_text_override(parent, self, line, x, y, changes)
         end
         ---@type diff.changes[]
         local mods = change.changes
-        local text = ""
-        local deletes = 0
-        for i, edit in ipairs(mods) do
+        local col = 1
+        for _, edit in ipairs(mods) do
           if edit.tag == "insert" then
-            text = text .. edit.val
-            local tx = self:get_col_x_offset(line, i - deletes)
-            local w = self:get_font():get_width(edit.val);
+            local tx, ty = self:get_line_screen_position(line, col)
+            local w = self:get_font():get_width(edit.val)
             renderer.draw_rect(
-              x + tx, y, w, h,
+              tx, ty, w, lh,
               changes == parent.a_changes
                 and delete_inline
                 or insert_inline
             )
+            col = col + #edit.val
           elseif edit.tag == "delete" then
-            deletes = deletes + 1
+            -- Deleted characters are absent from the line being drawn.
+          else
+            col = col + #edit.val
           end
         end
       end
     end
   end
+end
+
+local function draw_plain_line_text(self, line, x, y, color)
+  local starts = self:get_line_wraps(line) or { 1 }
+  local text = self.doc.lines[line]
+  local lh = self:get_line_height()
+  local text_y_offset = self:get_line_text_y_offset()
+  if text:sub(-1) == "\n" then text = text:sub(1, -2) end
+  for row, col in ipairs(starts) do
+    local next_col = starts[row + 1] or (#text + 1)
+    local segment = text:sub(col, next_col - 1)
+    local tx = x + self:get_col_x_offset(line, col)
+    renderer.draw_text(
+      self:get_font(), segment, tx, y + (row - 1) * lh + text_y_offset,
+      color, { tab_offset = tx - x }
+    )
+  end
+  return math.max(1, #starts) * lh
 end
 
 function DiffView:patch_views()
@@ -663,13 +812,9 @@ function DiffView:patch_views()
         end)
       end
       if has_changes and config.plugins.diffview.plain_text then
-        renderer.draw_text(
-          self:get_font(),
-          self.doc.lines[line],
-          x, y + self:get_line_text_y_offset(),
-          config.plugins.diffview.plain_text_color
+        return draw_plain_line_text(
+          self, line, x, y, config.plugins.diffview.plain_text_color
         )
-        return self:get_line_height()
       else
         return orig(self, line, x, y)
       end
@@ -681,10 +826,14 @@ function DiffView:patch_views()
   local function wrap_get_line_screen_position(doc_view, is_a)
     doc_view.get_line_screen_position = function(self, line, col)
       local x, y = self:get_content_offset()
-      local lh = self:get_line_height()
-      local gaps = is_a and parent.a_gaps or parent.b_gaps
-      local gap_y = (gaps[line] and gaps[line][2] or 0) * lh
-      y = y + (line - 1) * lh + gap_y + style.padding.y
+      local layout = parent:get_aligned_layout()
+      local side = get_layout_side(layout, is_a)
+      local row = side.starts[line] or 0
+      if col then
+        local native_row = self:visual_row_from_position(line, col)
+        row = row + native_row - (side.native_starts[line] or native_row)
+      end
+      y = y + row * layout.line_height + style.padding.y
       if col then
         return x + self:get_gutter_width() + self:get_col_x_offset(line, col), y
       else
@@ -697,29 +846,17 @@ function DiffView:patch_views()
   ---@param is_a boolean
   local function wrap_resolve_screen_position(doc_view, is_a)
     doc_view.resolve_screen_position = function(self, x, y)
-      local lines = self.doc.lines
-      local lh = self:get_line_height()
-      local gaps = is_a and parent.a_gaps or parent.b_gaps
-
-      for i = 1, #lines do
-        local line_x, line_y = self:get_line_screen_position(i)
-        local next_y
-        if i < #lines then
-          local _
-          _, next_y = self:get_line_screen_position(i + 1)
-        else
-          next_y = line_y + lh + ((gaps[i] and gaps[i][1] or 0) * lh)
-        end
-
-        if (y >= line_y or i == 1) and y < next_y then
-          local col = self:get_x_offset_col(i, x - line_x)
-          return i, col
-        end
-      end
-
-      local last = #lines
-      local line_x, _ = self:get_line_screen_position(last)
-      return last, self:get_x_offset_col(last, x - line_x)
+      local layout = parent:get_aligned_layout()
+      local ox, oy = self:get_content_offset()
+      local gw = self:get_gutter_width()
+      local aligned_row = math.floor(
+        (y - oy - style.padding.y) / layout.line_height
+      )
+      local line, native_row = position_from_aligned_row(
+        layout, is_a, aligned_row
+      )
+      local col = self:get_visual_line_col_from_x(native_row, x - ox - gw)
+      return line, col
     end
   end
 
@@ -728,35 +865,20 @@ function DiffView:patch_views()
   local function wrap_get_visible_line_range(doc_view, is_a)
     doc_view.get_visible_line_range = function(self)
       local _, oy, _, y2 = self:get_content_bounds()
-      local lh = self:get_line_height()
-      local lines = self.doc.lines
-      local minline, maxline = 1, #lines
-      local gaps = is_a and parent.a_gaps or parent.b_gaps
-
-      local y = style.padding.y
-      for i = 1, #lines do
-        local gap = (gaps[i] and gaps[i][2] or 0) * lh
-        local h = lh
-        local total = y + h
-        y = total
-        if total + gap > oy then
-          minline = i
-          break
-        end
-      end
-
-      for i = minline, #lines do
-        local gap = (gaps[i] and gaps[i][2] or 0) * lh
-        local h = lh
-        local total = y + h
-        y = total
-        if total + gap > y2 then
-          maxline = i
-          break
-        end
-      end
-
-      return minline, maxline
+      local layout = parent:get_aligned_layout()
+      local first_aligned = math.floor(
+        (oy - style.padding.y) / layout.line_height
+      )
+      local last_aligned = math.floor(
+        (y2 - style.padding.y) / layout.line_height
+      ) + 1
+      local _, first_row = position_from_aligned_row(
+        layout, is_a, first_aligned
+      )
+      local _, last_row = position_from_aligned_row(
+        layout, is_a, last_aligned
+      )
+      return first_row, last_row
     end
   end
 
@@ -764,14 +886,13 @@ function DiffView:patch_views()
   ---@param is_a boolean
   local function wrap_get_scrollable_size(doc_view, is_a)
     doc_view.get_scrollable_size = function(self)
-      local gaps = is_a and parent.a_gaps or parent.b_gaps
-      local lc = #self.doc.lines
-      lc = lc + (gaps[lc] and gaps[lc][2] or 0)
+      local layout = parent:get_aligned_layout()
       if not config.scroll_past_end then
         local _, _, _, h_scroll = self.h_scrollbar:get_track_rect()
-        return self:get_line_height() * (lc) + style.padding.y * 2 + h_scroll
+        return layout.line_height * layout.total_rows
+          + style.padding.y * 2 + h_scroll
       end
-      return self:get_line_height() * (lc - 1) + self.size.y
+      return layout.line_height * (layout.total_rows - 1) + self.size.y
     end
   end
 
@@ -801,21 +922,32 @@ function DiffView:patch_views()
       self:get_font():set_tab_size(indent_size)
 
       local minline, maxline = self:get_visible_line_range()
-      local lh = self:get_line_height()
 
       local gw, gpad = self:get_gutter_width()
-      for i = minline, maxline do
-        local _, y = self:get_line_screen_position(i)
-        self:draw_line_gutter(i, self.position.x, y, gpad and gw - gpad or gw)
+      local drawn_gutters = {}
+      for row = minline, maxline do
+        local line = self:visual_position_from_row(row)
+        if line and self.doc.lines[line] and not drawn_gutters[line] then
+          local _, y = self:get_line_screen_position(line)
+          self:draw_line_gutter(
+            line, self.position.x, y, gpad and gw - gpad or gw
+          )
+          drawn_gutters[line] = true
+        end
       end
 
       local pos = self.position
       -- the clip below ensure we don't write on the gutter region. On the
       -- right side it is redundant with the Node's clip.
       core.push_clip_rect(pos.x + gw, pos.y, self.size.x - gw, self.size.y)
-      for i = minline, maxline do
-        local x, y = self:get_line_screen_position(i)
-        y = y + (self:draw_line_body(i, x, y) or lh)
+      local drawn_lines = {}
+      for row = minline, maxline do
+        local line = self:visual_position_from_row(row)
+        if line and self.doc.lines[line] and not drawn_lines[line] then
+          local x, y = self:get_line_screen_position(line)
+          self:draw_line_body(line, x, y)
+          drawn_lines[line] = true
+        end
       end
       self:draw_overlay()
       core.pop_clip_rect()
@@ -1021,8 +1153,9 @@ end
 function DiffView:draw_scrollbar()
   DiffView.super.draw_scrollbar(self)
 
+  local layout = self:get_aligned_layout()
   local parent_scrollable = self:get_scrollable_size()
-  local parent_lh = self.doc_view_a:get_line_height()
+  local parent_lh = layout.line_height
   local parent_x, parent_y, parent_w, parent_h = get_scrollbar_marker_lane(
     self.v_scrollbar
   )
@@ -1031,17 +1164,17 @@ function DiffView:draw_scrollbar()
     {
       view = self.doc_view_a,
       changes = self.a_changes,
-      gaps = self.a_gaps
+      layout_side = layout.a
     },
     {
       view = self.doc_view_b,
       changes = self.b_changes,
-      gaps = self.b_gaps
+      layout_side = layout.b
     },
   } do
     local view = side.view
     local changes = side.changes
-    local gaps = side.gaps
+    local layout_side = side.layout_side
     local scrollbar = view.v_scrollbar
     local scrollable = view:get_scrollable_size()
     local lh = view:get_line_height()
@@ -1076,10 +1209,9 @@ function DiffView:draw_scrollbar()
         or tag == "modify" and style.diff_modify
 
       if color then
-        local start_gap = gaps[start_line] and gaps[start_line][2] or 0
-        local end_gap = gaps[end_line] and gaps[end_line][2] or start_gap
-        local start_row = start_line - 1 + start_gap
-        local end_row = end_line + end_gap
+        local start_row = layout_side.starts[start_line] or 0
+        local end_row = (layout_side.starts[end_line] or start_row)
+          + (layout_side.heights[end_line] or 1)
         local marker_y, marker_h = get_scrollbar_marker_rect(
           y, h, start_row, end_row, scrollable, lh, style.padding.y
         )
@@ -1120,6 +1252,19 @@ function DiffView:update()
 
   self.doc_view_a:update()
   self.doc_view_b:update()
+
+  local source = self
+  if self.doc_view_a:scrollbar_dragging() or core.active_view == self.doc_view_a then
+    source = self.doc_view_a
+  elseif self.doc_view_b:scrollbar_dragging() or core.active_view == self.doc_view_b then
+    source = self.doc_view_b
+  end
+  for _, view in ipairs { self, self.doc_view_a, self.doc_view_b } do
+    if view ~= source then
+      view.scroll.y = source.scroll.y
+      view.scroll.to.y = source.scroll.to.y
+    end
+  end
 end
 
 function DiffView:draw()

--- a/data/plugins/linewrapping.lua
+++ b/data/plugins/linewrapping.lua
@@ -792,25 +792,50 @@ function translate.start_of_line(doc, line, col)
   return line, ncol2 + 1
 end
 
+---Enable or disable wrapping for a document view.
+---@param docview core.docview
+---@param enabled boolean
+function LineWrapping.set_enabled(docview, enabled)
+  if not docview or not docview.doc then return end
+  docview.wrapping_enabled = enabled
+  if enabled then
+    LineWrapping.update_docview_breaks(docview)
+  else
+    LineWrapping.reconstruct_breaks(docview, docview:get_font(), math.huge)
+  end
+end
+
+local function each_command_view(fn)
+  local view = core.active_view
+  if not view or not view.doc then return end
+  local parent = view.diff_view_parent
+  if parent then
+    fn(parent.doc_view_a)
+    fn(parent.doc_view_b)
+  else
+    fn(view)
+  end
+end
+
 command.add(nil, {
   ["line-wrapping:enable"] = function()
-    if core.active_view and core.active_view.doc then
-      core.active_view.wrapping_enabled = true
-      LineWrapping.update_docview_breaks(core.active_view)
-    end
+    each_command_view(function(view) LineWrapping.set_enabled(view, true) end)
   end,
   ["line-wrapping:disable"] = function()
-    if core.active_view and core.active_view.doc then
-      core.active_view.wrapping_enabled = false
-      LineWrapping.reconstruct_breaks(core.active_view, core.active_view:get_font(), math.huge)
-    end
+    each_command_view(function(view) LineWrapping.set_enabled(view, false) end)
   end,
   ["line-wrapping:toggle"] = function()
-    if core.active_view and core.active_view.doc and core.active_view.wrapped_settings then
-      command.perform("line-wrapping:disable")
+    local view = core.active_view
+    if not view or not view.doc then return end
+    local parent = view.diff_view_parent
+    local enabled
+    if parent then
+      enabled = parent.doc_view_a.wrapping_enabled
+        and parent.doc_view_b.wrapping_enabled
     else
-      command.perform("line-wrapping:enable")
+      enabled = view.wrapping_enabled
     end
+    each_command_view(function(item) LineWrapping.set_enabled(item, not enabled) end)
   end
 })
 

--- a/docs/memories/LINE_WRAPPING.md
+++ b/docs/memories/LINE_WRAPPING.md
@@ -1,0 +1,37 @@
+# Line Wrapping
+
+## 2026-08-14: Vertical movement must stay row-local
+
+`DocView.translate.previous_line` and `next_line` preserve the caret's
+horizontal offset by resolving that offset within the target visual row. The
+linewrapping override of `get_visual_line_col_from_x` must therefore stop at
+the requested wrapped row's final character. Scanning into a later wrapped row
+can return a position whose `visual_row_from_position` is the current or a
+subsequent row, making repeated Up or Down movement appear stuck.
+
+For a soft wrap, the exact boundary column belongs to the following visual
+row because document positions do not carry visual-row affinity. The maximum
+position for the preceding row is consequently the start of its final UTF-8
+character, obtained with `translate.previous_char`, rather than the next
+row's starting column.
+
+## 2026-08-31: DiffView alignment uses shared visual slots
+
+DiffView cannot align wrapped panes by adding its logical-line gap totals to
+each pane's independent visual-row number. Each logical diff slot must instead
+have a shared height equal to the larger wrapped-row count on its two sides;
+the shorter side leaves blank padding below its text. The existing cumulative
+gap totals still identify which logical lines occupy the same slot.
+
+The aligned layout is cached from the child visual-line model identities, gap
+table identities/generation, document sizes, and line heights. Diff updates
+must build fresh gap tables and publish them only when complete; mutating an
+initially exposed empty table would leave an identity-based cache looking valid
+while a long asynchronous diff is still filling that table. Direct gap edits
+performed by sync operations explicitly invalidate the layout generation.
+
+Screen hit testing maps aligned padding and missing-side slots to the nearest
+preceding document line and clamps to that line's last actual wrapped row. This
+preserves the old DiffView gap behavior without inventing document positions
+for blank padding. F10 intentionally synchronizes wrapping across both children;
+when their enabled states differ, toggling enables both.

--- a/scripts/lua/tests/diffview.lua
+++ b/scripts/lua/tests/diffview.lua
@@ -1,0 +1,359 @@
+local test = require "core.test"
+local core = require "core"
+local command = require "core.command"
+local config = require "core.config"
+local keymap = require "core.keymap"
+local style = require "core.style"
+local LineWrapping = require "plugins.linewrapping"
+local DiffView = require "plugins.diffview"
+
+local previous_active_view
+local previous_width_override
+local previous_scroll_past_end
+local previous_plain_text
+
+local function set_diff(view, a_gaps, b_gaps, a_changes, b_changes)
+  view.a_gaps = a_gaps
+  view.b_gaps = b_gaps
+  view.a_changes = a_changes
+  view.b_changes = b_changes
+  view.diff_layout_generation = view.diff_layout_generation + 1
+  view.aligned_layout = nil
+end
+
+local function configure_view(view, width, height)
+  view.position.x = 0
+  view.position.y = 0
+  view.size.x = width or 800
+  view.size.y = height or 160
+
+  view.doc_view_a.position.x = 0
+  view.doc_view_a.position.y = 0
+  view.doc_view_a.size.x = (width or 800) / 2 - 40
+  view.doc_view_a.size.y = height or 160
+
+  view.doc_view_b.position.x = (width or 800) / 2 + 40
+  view.doc_view_b.position.y = 0
+  view.doc_view_b.size.x = (width or 800) / 2 - 40
+  view.doc_view_b.size.y = height or 160
+
+  for _, child in ipairs { view.doc_view_a, view.doc_view_b } do
+    child.indentguide_indents = {}
+    child.indentguide_indent_active = {}
+  end
+
+  LineWrapping.set_enabled(view.doc_view_a, false)
+  LineWrapping.set_enabled(view.doc_view_b, false)
+end
+
+local function make_aligned_diff(height)
+  local a = "abcdefghijklmnop\nonly on a\ntail"
+  local b = "abcd\ntail"
+  local view = DiffView.string_to_string(a, b, "a", "b", true)
+  configure_view(view, 800, height)
+  set_diff(
+    view,
+    { {0, 0}, {0, 0}, {0, 0} },
+    { {0, 0}, {1, 1} },
+    {
+      { tag = "modify" },
+      { tag = "delete" },
+      { tag = "equal" },
+    },
+    {
+      { tag = "modify" },
+      { tag = "equal" },
+    }
+  )
+  config.plugins.linewrapping.width_override = view.doc_view_a:get_font():get_width("abcd")
+  LineWrapping.set_enabled(view.doc_view_a, true)
+  LineWrapping.set_enabled(view.doc_view_b, true)
+  return view
+end
+
+local function with_renderer_calls(fn)
+  local old_rect = renderer.draw_rect
+  local old_text = renderer.draw_text
+  local old_defer = core.root_view.defer_draw
+  local rects, texts = {}, {}
+  renderer.draw_rect = function(x, y, w, h, color)
+    rects[#rects + 1] = { x = x, y = y, w = w, h = h, color = color }
+  end
+  renderer.draw_text = function(font, text, x, y, color, options)
+    texts[#texts + 1] = {
+      font = font, text = text, x = x, y = y, color = color, options = options
+    }
+    return x + font:get_width(text, options)
+  end
+  core.root_view.defer_draw = function() end
+
+  local ok, err = pcall(fn, rects, texts)
+  renderer.draw_rect = old_rect
+  renderer.draw_text = old_text
+  core.root_view.defer_draw = old_defer
+  if not ok then error(err, 0) end
+end
+
+test.describe("diffview line wrapping", function()
+  test.before_each(function()
+    previous_active_view = core.active_view
+    previous_width_override = config.plugins.linewrapping.width_override
+    previous_scroll_past_end = config.scroll_past_end
+    previous_plain_text = config.plugins.diffview.plain_text
+    config.plugins.diffview.plain_text = false
+  end)
+
+  test.after_each(function()
+    config.plugins.linewrapping.width_override = previous_width_override
+    config.scroll_past_end = previous_scroll_past_end
+    config.plugins.diffview.plain_text = previous_plain_text
+    if previous_active_view then core.set_active_view(previous_active_view) end
+  end)
+
+  test.test("F10 behavior toggles both panes from either side", function()
+    local view = make_aligned_diff()
+    LineWrapping.set_enabled(view.doc_view_a, false)
+    LineWrapping.set_enabled(view.doc_view_b, false)
+
+    core.set_active_view(view.doc_view_a)
+    test.ok(keymap.on_key_pressed("f10"))
+    test.not_nil(view.doc_view_a.wrapped_settings)
+    test.not_nil(view.doc_view_b.wrapped_settings)
+
+    core.set_active_view(view.doc_view_b)
+    test.ok(keymap.on_key_pressed("f10"))
+    test.is_nil(view.doc_view_a.wrapped_settings)
+    test.is_nil(view.doc_view_b.wrapped_settings)
+
+    LineWrapping.set_enabled(view.doc_view_a, true)
+    LineWrapping.set_enabled(view.doc_view_b, false)
+    core.set_active_view(view.doc_view_a)
+    test.ok(keymap.on_key_pressed("f10"))
+    test.not_nil(view.doc_view_a.wrapped_settings)
+    test.not_nil(view.doc_view_b.wrapped_settings)
+  end)
+
+  test.test("aligned slots keep following lines level without overlap", function()
+    local view = make_aligned_diff()
+    local a, b = view.doc_view_a, view.doc_view_b
+    local layout = view:get_aligned_layout()
+    test.ok(layout.a.row_counts[1] > layout.b.row_counts[1])
+
+    local _, ay = a:get_line_screen_position(3)
+    local _, by = b:get_line_screen_position(2)
+    test.equal(ay, by)
+
+    local _, first_y = a:get_line_screen_position(1)
+    local _, deleted_y = a:get_line_screen_position(2)
+    test.ok(deleted_y >= first_y + a:get_line_visual_height(1))
+    test.ok(ay >= deleted_y + a:get_line_visual_height(2))
+  end)
+
+  test.test("wrapped-row hit testing and visible ranges use aligned rows", function()
+    local view = make_aligned_diff(40)
+    local a, b = view.doc_view_a, view.doc_view_b
+    local target_col = 7
+    local x, y = a:get_line_screen_position(1, target_col)
+    local line, col = a:resolve_screen_position(
+      x + a:get_font():get_width("a") / 4,
+      y + a:get_line_height() / 2
+    )
+    test.equal(line, 1)
+    test.equal(
+      a:visual_row_from_position(line, col),
+      a:visual_row_from_position(1, target_col)
+    )
+
+    local layout = view:get_aligned_layout()
+    local tail_row = layout.a.starts[3]
+    a.scroll.y = tail_row * layout.line_height + style.padding.y
+    b.scroll.y = a.scroll.y
+    local a_first = a:get_visible_line_range()
+    local b_first = b:get_visible_line_range()
+    test.equal(a:visual_position_from_row(a_first), 3)
+    test.equal(b:visual_position_from_row(b_first), 2)
+  end)
+
+  test.test("all scrollable extents share the aligned visual height", function()
+    local view = make_aligned_diff(60)
+    for _, scroll_past_end in ipairs { false, true } do
+      config.scroll_past_end = scroll_past_end
+      local parent_size = view:get_scrollable_size()
+      test.equal(view.doc_view_a:get_scrollable_size(), parent_size)
+      test.equal(view.doc_view_b:get_scrollable_size(), parent_size)
+    end
+
+    core.set_active_view(view.doc_view_a)
+    view.doc_view_a.scroll.y = 10
+    view.doc_view_a.scroll.to.y = 10
+    view.doc_view_b.scroll.y = 0
+    view.doc_view_b.scroll.to.y = 0
+    view:update()
+    test.equal(view.scroll.y, view.doc_view_a.scroll.y)
+    test.equal(view.doc_view_b.scroll.y, view.doc_view_a.scroll.y)
+
+    core.set_active_view(view)
+    view:on_mouse_wheel(-1, 0)
+    view:update()
+    test.equal(view.doc_view_a.scroll.y, view.scroll.y)
+    test.equal(view.doc_view_b.scroll.y, view.scroll.y)
+  end)
+
+  test.test("change bands and inline changes follow wrapped rows", function()
+    local view = make_aligned_diff()
+    local a = view.doc_view_a
+    local changes = {}
+    for char in ("abcde"):gmatch(".") do
+      changes[#changes + 1] = { tag = "equal", val = char }
+    end
+    changes[#changes + 1] = { tag = "insert", val = "f" }
+    view.a_changes[1] = { tag = "modify", changes = changes }
+
+    local x, y = a:get_line_screen_position(1)
+    local _, inline_y = a:get_line_screen_position(1, 6)
+    with_renderer_calls(function(rects)
+      a:draw_line_text(1, x, y)
+      local background, inline
+      for _, call in ipairs(rects) do
+        if call.color == style.diff_delete_background then background = call end
+        if call.color == style.diff_delete_inline then inline = call end
+      end
+      test.not_nil(background)
+      test.equal(background.y, y)
+      test.equal(background.h, a:get_line_visual_height(1))
+      test.not_nil(inline)
+      test.equal(inline.y, inline_y)
+      test.equal(inline.h, a:get_line_height())
+    end)
+  end)
+
+  test.test("sync arrows and scrollbar markers use aligned positions", function()
+    local view = make_aligned_diff(60)
+    local a = view.doc_view_a
+    view.a_changes = {
+      { tag = "equal" },
+      { tag = "equal" },
+      { tag = "modify" },
+    }
+    view.b_changes = { { tag = "equal" }, { tag = "equal" } }
+
+    local old_defer = core.root_view.defer_draw
+    local old_push = core.push_clip_rect
+    local old_pop = core.pop_clip_rect
+    core.root_view.defer_draw = function(_, fn) fn() end
+    core.push_clip_rect = function() end
+    core.pop_clip_rect = function() end
+    local ok, err = pcall(function()
+      local x, y = a:get_line_screen_position(3)
+      with_renderer_calls(function(_, texts)
+        core.root_view.defer_draw = function(_, fn) fn() end
+        a:draw_line_text(3, x, y)
+        local arrow
+        for _, call in ipairs(texts) do
+          if call.text == ">" then arrow = call end
+        end
+        test.not_nil(arrow)
+        local expected_y = y + a:get_line_height() / 2
+          - style.icon_font:get_height() / 2
+        test.equal(arrow.y, expected_y)
+      end)
+    end)
+    core.root_view.defer_draw = old_defer
+    core.push_clip_rect = old_push
+    core.pop_clip_rect = old_pop
+    if not ok then error(err, 0) end
+
+    view:update_scrollbar()
+    a:update_scrollbar()
+    view.doc_view_b:update_scrollbar()
+    local layout = view:get_aligned_layout()
+    local _, track_y, _, track_h = a.v_scrollbar:get_track_rect()
+    local scrollable = a:get_scrollable_size()
+    local start_y = style.padding.y + layout.a.starts[3] * layout.line_height
+    local expected_marker_y = track_y
+      + math.min(1, start_y / math.max(1, scrollable)) * track_h
+    with_renderer_calls(function(rects)
+      view:draw_scrollbar()
+      local found = false
+      for _, call in ipairs(rects) do
+        if call.color == style.diff_modify
+          and math.abs(call.y - expected_marker_y) < 0.001
+        then
+          found = true
+          break
+        end
+      end
+      test.ok(found)
+    end)
+  end)
+
+  test.test("layout cache tracks visual models and gap replacements", function()
+    local view = make_aligned_diff()
+    local first = view:get_aligned_layout()
+    test.equal(view:get_aligned_layout(), first)
+
+    config.plugins.linewrapping.width_override = view.doc_view_a:get_font():get_width("ab")
+    LineWrapping.reconstruct_breaks(
+      view.doc_view_a,
+      view.doc_view_a:get_font(),
+      config.plugins.linewrapping.width_override
+    )
+    local second = view:get_aligned_layout()
+    test.ok(second ~= first)
+    test.ok(second.total_rows > first.total_rows)
+
+    view.a_gaps = { {0, 0}, {1, 1}, {1, 1} }
+    local third = view:get_aligned_layout()
+    test.ok(third ~= second)
+  end)
+
+  test.test("wrapping is shared by file and mixed comparison modes", function()
+    local path = USERDIR .. PATHSEP .. "diffview-wrapping-"
+      .. system.get_process_id() .. ".txt"
+    local file, err = io.open(path, "wb")
+    test.not_nil(file, err)
+    local text = "abcdefghijklmnop\ntail"
+    file:write(text)
+    file:close()
+
+    local ok, run_err = pcall(function()
+      local views = {
+        DiffView.file_to_file(path, path, true),
+        DiffView.file_to_string(path, text, "string", true),
+        DiffView.string_to_file(text, path, "string", true),
+      }
+      for _, view in ipairs(views) do
+        configure_view(view, 800, 80)
+        config.plugins.linewrapping.width_override =
+          view.doc_view_a:get_font():get_width("abcd")
+        core.set_active_view(view.doc_view_b)
+        command.perform("line-wrapping:enable")
+        test.not_nil(view.doc_view_a.wrapped_settings)
+        test.not_nil(view.doc_view_b.wrapped_settings)
+        test.ok(view:get_aligned_layout().total_rows > 2)
+      end
+    end)
+    os.remove(path)
+    if not ok then error(run_err, 0) end
+  end)
+
+  test.test("computed diff gaps preserve wrapped alignment", function()
+    local view = DiffView.string_to_string(
+      "abcdefghijklmnop\nonly on a\ntail",
+      "abcd\ntail",
+      "a", "b", true
+    )
+    configure_view(view, 800, 80)
+    config.plugins.linewrapping.width_override =
+      view.doc_view_a:get_font():get_width("abcd")
+    LineWrapping.set_enabled(view.doc_view_a, true)
+    LineWrapping.set_enabled(view.doc_view_b, true)
+
+    while view.updater_idx ~= nil do coroutine.yield(0.01) end
+
+    local _, ay = view.doc_view_a:get_line_screen_position(3)
+    local _, by = view.doc_view_b:get_line_screen_position(2)
+    test.equal(ay, by)
+    test.ok(view:get_aligned_layout().total_rows > 3)
+  end)
+end)

--- a/scripts/lua/tests/diffview.lua
+++ b/scripts/lua/tests/diffview.lua
@@ -7,11 +7,6 @@ local style = require "core.style"
 local LineWrapping = require "plugins.linewrapping"
 local DiffView = require "plugins.diffview"
 
-local previous_active_view
-local previous_width_override
-local previous_scroll_past_end
-local previous_plain_text
-
 local function set_diff(view, a_gaps, b_gaps, a_changes, b_changes)
   view.a_gaps = a_gaps
   view.b_gaps = b_gaps
@@ -95,19 +90,23 @@ local function with_renderer_calls(fn)
 end
 
 test.describe("diffview line wrapping", function()
-  test.before_each(function()
-    previous_active_view = core.active_view
-    previous_width_override = config.plugins.linewrapping.width_override
-    previous_scroll_past_end = config.scroll_past_end
-    previous_plain_text = config.plugins.diffview.plain_text
+  test.before_each(function(context)
+    context.previous_active_view = core.active_view
+    context.previous_cwd = system.getcwd()
+    context.previous_width_override = config.plugins.linewrapping.width_override
+    context.previous_scroll_past_end = config.scroll_past_end
+    context.previous_plain_text = config.plugins.diffview.plain_text
     config.plugins.diffview.plain_text = false
   end)
 
-  test.after_each(function()
-    config.plugins.linewrapping.width_override = previous_width_override
-    config.scroll_past_end = previous_scroll_past_end
-    config.plugins.diffview.plain_text = previous_plain_text
-    if previous_active_view then core.set_active_view(previous_active_view) end
+  test.after_each(function(context)
+    config.plugins.linewrapping.width_override = context.previous_width_override
+    config.scroll_past_end = context.previous_scroll_past_end
+    config.plugins.diffview.plain_text = context.previous_plain_text
+    if context.previous_active_view then
+      core.set_active_view(context.previous_active_view)
+    end
+    system.chdir(context.previous_cwd)
   end)
 
   test.test("F10 behavior toggles both panes from either side", function()


### PR DESCRIPTION
Synchronize line wrapping across both DiffView panes and align their wrapped visual rows with existing diff gaps.

Cache the shared layout for positioning, hit testing, scrolling, change backgrounds, sync arrows, and scrollbar markers. Add regression coverage for every comparison mode, mixed wrap states, and computed diff gaps.

Fixes #587