### PR TITLE
Open project search results in splits

### DIFF
--- a/data/plugins/projectsearch.lua
+++ b/data/plugins/projectsearch.lua
@@ -5,6 +5,7 @@ local keymap = require "core.keymap"
 local command = require "core.command"
 local config = require "core.config"
 local style = require "core.style"
+local ContextMenu = require "core.contextmenu"
 local DocView = require "core.docview"
 local Widget = require "widget"
 local Button = require "widget.button"
@@ -27,6 +28,7 @@ config.plugins.projectsearch = common.merge({
   },
   live_search = false,
   syntax_highlighting = true,
+  split_direction = "right",
   -- The config specification used by gui generators
   config_spec = {
     name = "Project Search",
@@ -51,6 +53,19 @@ config.plugins.projectsearch = common.merge({
       path = "syntax_highlighting",
       type = "toggle",
       default = true
+    },
+    {
+      label = "Split Direction",
+      description = "Where to open project search results when control-clicked.",
+      path = "split_direction",
+      type = "selection",
+      default = "right",
+      values = {
+        { "Right", "right" },
+        { "Left", "left" },
+        { "Up", "up" },
+        { "Down", "down" }
+      }
     }
   }
 }, config.plugins.projectsearch)
@@ -65,6 +80,10 @@ local threaded_replace_id = 0
 
 ---@class plugins.projectsearch.resultsview : widget
 ---@field results_list widget.searchreplacelist
+---@field context_menu core.contextmenu
+---@field source_view core.view?
+---@field result_split_node core.node?
+---@field result_split_views core.docview[]?
 ---@overload fun(path?:string,text:string,type:'"plain"'|'"regex"',insensitive?:boolean,whole_word?:boolean,replacement?:string):plugins.projectsearch.resultsview
 local ResultsView = Widget:extend()
 
@@ -155,6 +174,14 @@ function ResultsView:new(path, text, search_type, insensitive, whole_word, repla
   self.results_list.on_item_click = function(this, item, clicks)
     self:open_selected_result()
   end
+  self.context_menu = ContextMenu()
+  self.context_menu:register(function()
+    local item = self.results_list:get_selected()
+    return core.active_view == self and item and item.position
+  end, {
+    { text = "Open", command = "project-search:open-selected" },
+    { text = "Open in Split", command = "project-search:open-selected-split" }
+  })
 
   local function toggle_filters(enabled)
     if enabled then
@@ -1160,12 +1187,102 @@ end
 ---@type core.view?
 local previous_view
 
+local split_directions = {
+  left = true,
+  right = true,
+  up = true,
+  down = true
+}
+local split_click_modifier = PLATFORM == "Mac OS X" and "cmd" or "ctrl"
+
+local function get_split_direction()
+  local direction = config.plugins.projectsearch.split_direction
+  return split_directions[direction] and direction or "right"
+end
+
+local function node_is_in_tree(root, target)
+  if root == target then return true end
+  if root.type ~= "leaf" then
+    return node_is_in_tree(root.a, target)
+      or node_is_in_tree(root.b, target)
+  end
+  return false
+end
+
+local function get_result_split_node(self)
+  local root = core.root_view.root_node
+  local node = self.result_split_node
+  if
+    node and node.type == "leaf" and not node.locked
+    and node_is_in_tree(root, node)
+  then
+    return node
+  end
+
+  -- A collapsed split can preserve these views in the main pane. Do not
+  -- follow them there, since that pane is no longer the result split.
+  self.result_split_node = nil
+  self.result_split_views = {}
+end
+
+local function get_result_split_source_node(self)
+  local root = core.root_view.root_node
+  local node = self.source_view and root:get_node_for_view(self.source_view)
+  if not node then
+    node = root:get_node_for_view(self)
+  end
+  if not node or node.type ~= "leaf" or node.locked then
+    node = core.root_view:get_primary_node()
+  end
+  return node
+end
+
+local function remember_result_split_view(self, node, view)
+  self.result_split_node = node
+  self.result_split_views = self.result_split_views or {}
+  for i = #self.result_split_views, 1, -1 do
+    if self.result_split_views[i] == view then
+      table.remove(self.result_split_views, i)
+    end
+  end
+  table.insert(self.result_split_views, view)
+end
+
+local function open_doc_in_result_split(self, doc)
+  local node = get_result_split_node(self)
+  local view
+  if node then
+    for _, candidate in ipairs(node.views) do
+      if candidate:extends(DocView) and candidate.doc == doc then
+        view = candidate
+        node:set_active_view(view)
+        break
+      end
+    end
+    if not view then
+      view = DocView(doc)
+      node:add_view(view)
+    end
+  else
+    view = DocView(doc)
+    node = get_result_split_source_node(self):split(
+      get_split_direction(), view
+    )
+  end
+  remember_result_split_view(self, node, view)
+  return view
+end
+
 ---Opens a DocView of the user selected match.
-function ResultsView:open_selected_result()
+---@param open_in_split? boolean
+function ResultsView:open_selected_result(open_in_split)
   local item = self.results_list:get_selected()
   if not item or not item.position then return end
   core.try(function()
-    local dv = core.root_view:open_doc(core.open_doc(item.parent.file.path))
+    local doc = core.open_doc(item.parent.file.path)
+    local dv = open_in_split
+      and open_doc_in_result_split(self, doc)
+      or core.root_view:open_doc(doc)
     previous_view = dv
     core.root_view.root_node:update_layout()
     local l, c1, c2 = item.line.line, item.position.col1, item.position.col2+1
@@ -1176,6 +1293,43 @@ function ResultsView:open_selected_result()
     if self.is_global then core.set_active_view(self) end
   end)
   return true
+end
+
+function ResultsView:on_mouse_pressed(button, x, y, clicks)
+  local menu = self.context_menu
+  if menu.show_context_menu then
+    return menu:on_mouse_pressed(button, x, y, clicks)
+  end
+
+  local list = self.results_list
+  if
+    button == "right" and list:mouse_on_top(x, y)
+    and not list:scrollbar_overlaps_point(x, y)
+  then
+    local item = list.items[list.hovered]
+    if item and item.position and not list.hovered_checkbox then
+      list.selected = list.hovered
+      return menu:on_mouse_pressed(button, x, y, clicks)
+    end
+  end
+
+  if
+    button == "left" and keymap.modkeys[split_click_modifier]
+    and list:mouse_on_top(x, y)
+    and not list:scrollbar_overlaps_point(x, y)
+  then
+    local item = list.items[list.hovered]
+    if item and item.position and not list.hovered_checkbox then
+      list.selected = list.hovered
+      return false
+    end
+  end
+  return ResultsView.super.on_mouse_pressed(self, button, x, y, clicks)
+end
+
+function ResultsView:on_mouse_moved(x, y, dx, dy)
+  if self.context_menu:on_mouse_moved(x, y) then return true end
+  return ResultsView.super.on_mouse_moved(self, x, y, dx, dy)
 end
 
 function ResultsView:on_scale_change(new_scale, prev_scale)
@@ -1190,6 +1344,7 @@ end
 
 function ResultsView:update()
   if not ResultsView.super.update(self) then return false end
+  self.context_menu:update()
   self:move_towards("brightness", 0, 0.1)
 
   local px = style.padding.x
@@ -1285,6 +1440,7 @@ end
 
 function ResultsView:draw()
   if self.queue_skip_draw or not ResultsView.super.draw(self) then return false end
+  self.context_menu:draw()
   if not self.total_files_processed then return true end
 
   -- status
@@ -1345,11 +1501,13 @@ end
 ---@return plugins.projectsearch.resultsview?
 local function begin_search(path, text, search_type, insensitive, whole_word, replacement)
   if text == "" then core.error("Expected non-empty string") return end
+  local node = core.root_view:get_active_node_default()
   local rv = ResultsView(
     path, text, search_type, insensitive, whole_word, replacement
   )
+  rv.source_view = node.active_view
   rv:show()
-  core.root_view:get_active_node_default():add_view(rv)
+  node:add_view(rv)
   core.add_thread(function() core.set_active_view(rv) end)
   return rv
 end
@@ -1441,6 +1599,7 @@ local function ensure_global_project_search(path)
 
   global_project_search = ResultsView(path, "", "plain")
   global_project_search.is_global = true
+  global_project_search.source_view = previous_view
   global_project_search:set_size(400 * SCALE)
   global_project_search:show()
   local node, split_direction = nil, "left"
@@ -1504,6 +1663,10 @@ function projectsearch.toggle(options)
     else
       toggle = false
     end
+  end
+
+  if visible and previous_view then
+    global_project_search.source_view = previous_view
   end
 
   global_project_search:apply_options(options, visible)
@@ -1594,9 +1757,11 @@ command.add(nil, {
   end,
 
   ["project-search:open-tab"] = function(path)
+    local node = core.root_view:get_active_node_default()
     local rv = ResultsView(path, "", "plain")
+    rv.source_view = node.active_view
     rv:show()
-    core.root_view:get_active_node_default():add_view(rv)
+    node:add_view(rv)
     core.add_thread(function()
       core.set_active_view(rv)
       rv:swap_active_child(rv.find_text)
@@ -1736,6 +1901,10 @@ command.add(ResultsView, {
     view:open_selected_result()
   end,
 
+  ["project-search:open-selected-split"] = function(view)
+    view:open_selected_result(true)
+  end,
+
   ["project-search:move-to-previous-page"] = function(view)
     view.results_list.scroll.to.y = view.results_list.scroll.to.y - view.results_list.size.y
   end,
@@ -1781,7 +1950,8 @@ keymap.add {
 }
 
 keymap.add {
-  ["return"]             = "project-search:open-selected"
+  ["return"]             = "project-search:open-selected",
+  ["ctrl+lclick"]        = "project-search:open-selected-split"
 }
 
 return projectsearch

--- a/scripts/lua/tests/projectsearch.lua
+++ b/scripts/lua/tests/projectsearch.lua
@@ -1,9 +1,15 @@
 local common = require "core.common"
+local command = require "core.command"
 local config = require "core.config"
 local core = require "core"
+local keymap = require "core.keymap"
 local test = require "core.test"
+local DocView = require "core.docview"
+local Project = require "core.project"
 local projectsearch = require "plugins.projectsearch"
 local SearchReplaceList = require "widget.searchreplacelist"
+
+local split_click_modifier = PLATFORM == "Mac OS X" and "cmd" or "ctrl"
 
 local function join_path(...)
   return table.concat({...}, PATHSEP)
@@ -38,9 +44,78 @@ local function collect_worker_results(tid, workers)
   return files
 end
 
+local function path_is_in_test_root(context, path)
+  if not path then return false end
+  path = common.normalize_path(path)
+  local root = common.normalize_path(context.temp_root)
+  return path == root or common.path_belongs_to(path, root)
+end
+
+local function close_test_views_and_docs(context)
+  local views = core.root_view.root_node:get_children()
+  for i = #views, 1, -1 do
+    local view = views[i]
+    local path = view.path or (view.doc and view.doc.abs_filename)
+    if path_is_in_test_root(context, path) then
+      local node = core.root_view.root_node:get_node_for_view(view)
+      if node and not node.locked then
+        if view:extends(DocView) and view.doc:is_dirty() then
+          view.doc:clean()
+        end
+        node:remove_view(core.root_view.root_node, view)
+      end
+    end
+  end
+
+  for i = #core.docs, 1, -1 do
+    local doc = core.docs[i]
+    if path_is_in_test_root(context, doc.abs_filename) then
+      table.remove(core.docs, i)
+      doc:on_close()
+    end
+  end
+end
+
+
+local function add_result(view, path, text, col1, col2)
+  view.results_list:add_file(path, {
+    {
+      line = 1,
+      text = text,
+      positions = {{ col1 = col1, col2 = col2 }}
+    }
+  }, true)
+  view.results_list.selected = #view.results_list.items
+  return view.results_list:get_selected()
+end
+
+
+local function create_results_view(context)
+  local source = core.open_file(join_path(context.project_a, "main.txt"))
+  local node = core.root_view.root_node:get_node_for_view(source)
+  local view = projectsearch.ResultsView(context.project_a, "needle", "plain")
+  view.source_view = source
+  view:show()
+  node:add_view(view)
+  return view, source
+end
+
+local function get_open_doc_view(path)
+  path = common.normalize_path(path)
+  for _, view in ipairs(core.root_view.root_node:get_children()) do
+    if
+      view:extends(DocView) and view.doc.abs_filename
+      and common.normalize_path(view.doc.abs_filename) == path
+    then
+      return view
+    end
+  end
+end
+
 test.describe("projectsearch", function()
   test.before_each(function(context)
     context.old_projects = core.projects
+    context.old_cwd = system.getcwd() or core.root_project().path
     context.temp_root = join_path(
       USERDIR,
       "projectsearch-tests-" .. system.get_process_id()
@@ -53,14 +128,28 @@ test.describe("projectsearch", function()
     write_file(join_path(context.project_a, "src", "one.txt"), "needle one\n")
     write_file(join_path(context.project_b, "lib", "two.txt"), "needle two\n")
     write_file(join_path(context.project_b, "lib", "skip.txt"), "other\n")
-    core.projects = {
-      { path = context.project_a, name = "alpha" },
-      { path = context.project_b, name = "beta" }
-    }
+    write_file(join_path(context.project_a, "main.txt"), "main document\n")
+    local project_a = Project(context.project_a)
+    local project_b = Project(context.project_b)
+    project_a.name = "alpha"
+    project_b.name = "beta"
+    core.projects = { project_a, project_b }
+    context.old_split_direction = config.plugins.projectsearch.split_direction
+    context.old_ctrl = keymap.modkeys["ctrl"]
+    context.old_split_click_modifier = keymap.modkeys[split_click_modifier]
+    context.locked_nodes = {}
   end)
 
   test.after_each(function(context)
+    keymap.modkeys["ctrl"] = context.old_ctrl
+    keymap.modkeys[split_click_modifier] = context.old_split_click_modifier
+    config.plugins.projectsearch.split_direction = context.old_split_direction
+    for _, node in ipairs(context.locked_nodes) do
+      node.locked = nil
+    end
+    close_test_views_and_docs(context)
     core.projects = context.old_projects
+    system.chdir(context.old_cwd)
     if context.temp_root and system.get_file_info(context.temp_root) then
       local ok, err = common.rm(context.temp_root, true)
       test.ok(ok, err)
@@ -140,6 +229,280 @@ test.describe("projectsearch", function()
 
     test.equal(list.items[1].file.path, absolute_path)
     test.equal(list.items[1].file.display_path, display_path)
+  end)
+
+  test.test("opens split results in every configured direction", function(context)
+    local view = create_results_view(context)
+    add_result(
+      view,
+      join_path(context.project_a, "src", "one.txt"),
+      "needle one", 1, 6
+    )
+
+    local modes = {
+      { value = "right", direction = "right" },
+      { value = "left", direction = "left" },
+      { value = "up", direction = "up" },
+      { value = "down", direction = "down" },
+      { value = "invalid", direction = "right" }
+    }
+    for _, mode in ipairs(modes) do
+      config.plugins.projectsearch.split_direction = mode.value
+      view:open_selected_result(true)
+
+      local result = view.result_split_views[#view.result_split_views]
+      local result_node = core.root_view.root_node:get_node_for_view(result)
+      local parent = result_node:get_parent_node(core.root_view.root_node)
+      local horizontal = mode.direction == "left" or mode.direction == "right"
+      local expected_child = (mode.direction == "left" or mode.direction == "up")
+        and parent.a or parent.b
+      test.equal(parent.type, horizontal and "hsplit" or "vsplit", mode.value)
+      test.equal(expected_child, result_node, mode.value)
+
+      local line1, col1, line2, col2 = result.doc:get_selection(true)
+      test.equal(line1, 1)
+      test.equal(col1, 1)
+      test.equal(line2, 1)
+      test.equal(col2, 7)
+      test.ok(result.doc:is_search_selection(1, 1, 1, 7))
+
+      result_node:remove_view(core.root_view.root_node, result)
+      view.result_split_node = nil
+      view.result_split_views = {}
+    end
+  end)
+
+  test.test("reuses and recreates each search result split", function(context)
+    local view = create_results_view(context)
+    local first_item = add_result(
+      view,
+      join_path(context.project_a, "src", "one.txt"),
+      "needle one", 1, 6
+    )
+    local second_item = add_result(
+      view,
+      join_path(context.project_b, "lib", "two.txt"),
+      "needle two", 1, 6
+    )
+
+    view.results_list.selected = 2
+    view:open_selected_result(true)
+    local first_view = view.result_split_views[#view.result_split_views]
+    local first_node = core.root_view.root_node:get_node_for_view(first_view)
+
+    view.results_list.selected = 4
+    test.equal(view.results_list:get_selected(), second_item)
+    view:open_selected_result(true)
+    local second_view = view.result_split_views[#view.result_split_views]
+    local second_node = core.root_view.root_node:get_node_for_view(second_view)
+    test.equal(second_node, first_node)
+    test.equal(#second_node.views, 2)
+
+    view.results_list.selected = 2
+    test.equal(view.results_list:get_selected(), first_item)
+    view:open_selected_result(true)
+    test.equal(view.result_split_views[#view.result_split_views], first_view)
+    test.equal(#first_node.views, 2)
+    test.equal(core.active_view, first_view)
+
+    first_node:remove_view(core.root_view.root_node, first_view)
+    local remaining_node = core.root_view.root_node:get_node_for_view(second_view)
+    remaining_node:remove_view(core.root_view.root_node, second_view)
+
+    view:open_selected_result(true)
+    local recreated_view = view.result_split_views[#view.result_split_views]
+    local recreated_node = core.root_view.root_node:get_node_for_view(recreated_view)
+    test.not_equal(recreated_node, first_node)
+  end)
+
+  test.test("recreates a split after its source pane collapses", function(context)
+    local root = core.root_view.root_node
+    local view, source = create_results_view(context)
+    local source_node = root:get_node_for_view(source)
+    source_node:remove_view(root, view)
+    local search_node = source_node:split(
+      "left", view, { x = true }, true
+    )
+    table.insert(context.locked_nodes, search_node)
+
+    add_result(
+      view,
+      join_path(context.project_a, "src", "one.txt"),
+      "needle one", 1, 6
+    )
+    add_result(
+      view,
+      join_path(context.project_b, "lib", "two.txt"),
+      "needle two", 1, 6
+    )
+
+    config.plugins.projectsearch.split_direction = "right"
+    view.results_list.selected = 2
+    view:open_selected_result(true)
+    local first_result = view.result_split_views[#view.result_split_views]
+    local original_result_node = root:get_node_for_view(first_result)
+
+    local current_source_node = root:get_node_for_view(source)
+    current_source_node:remove_view(root, source)
+    local surviving_node = root:get_node_for_view(first_result)
+    test.not_equal(surviving_node, original_result_node)
+    test.equal(surviving_node.is_primary_node, true)
+
+    core.set_active_view(view)
+    view.results_list.selected = 4
+    view:open_selected_result(true)
+    local second_result = view.result_split_views[#view.result_split_views]
+    local new_result_node = root:get_node_for_view(second_result)
+    local old_result_node = root:get_node_for_view(first_result)
+    local split_parent = new_result_node:get_parent_node(root)
+
+    test.not_equal(new_result_node, old_result_node)
+    test.equal(split_parent.type, "hsplit")
+    test.equal(split_parent.a, old_result_node)
+    test.equal(split_parent.b, new_result_node)
+    test.equal(view.result_split_node, new_result_node)
+
+    view.results_list.selected = 2
+    view:open_selected_result(true)
+    local reused_result = view.result_split_views[#view.result_split_views]
+    test.equal(root:get_node_for_view(reused_result), new_result_node)
+    test.not_equal(reused_result, first_result)
+  end)
+
+  test.test("routes modifier-left-click through the split command", function(context)
+    local view = create_results_view(context)
+    add_result(
+      view,
+      join_path(context.project_a, "src", "one.txt"),
+      "needle one", 1, 6
+    )
+    local list = view.results_list
+    list:set_position(0, 0)
+    list:set_size(500, 500)
+
+    keymap.modkeys[split_click_modifier] = false
+    list.hovered = 2
+    test.ok(view:on_mouse_pressed("left", 10, 10, 1))
+    test.is_nil(view.result_split_node)
+    local normal_view = core.active_view
+    test.ok(normal_view:extends(DocView))
+    test.equal(
+      core.root_view.root_node:get_node_for_view(normal_view),
+      core.root_view.root_node:get_node_for_view(view)
+    )
+
+    core.set_active_view(view)
+    keymap.modkeys[split_click_modifier] = true
+    list.hovered = 1
+    test.ok(view:on_mouse_pressed("left", 10, 10, 1))
+    test.is_nil(view.result_split_node)
+
+    list.hovered = 2
+    test.not_ok(view:on_mouse_pressed("left", 10, 10, 1))
+    test.ok(command.is_valid("project-search:open-selected-split"))
+    keymap.on_mouse_pressed("left", 10, 10, 1)
+    test.not_nil(view.result_split_node)
+    test.not_equal(
+      core.root_view.root_node:get_node_for_view(core.active_view),
+      core.root_view.root_node:get_node_for_view(view)
+    )
+  end)
+
+  test.test("shows match actions in a right-click context menu", function(context)
+    local view = create_results_view(context)
+    local path = join_path(context.project_a, "src", "one.txt")
+    add_result(view, path, "needle one", 1, 6)
+    local list = view.results_list
+    local menu = view.context_menu
+    list:set_position(0, 0)
+    list:set_size(500, 500)
+    keymap.modkeys["ctrl"] = false
+
+    list.hovered = 1
+    test.ok(view:on_mouse_pressed("right", 10, 10, 1))
+    test.equal(menu.show_context_menu, false)
+
+    list.hovered = 0
+    test.ok(view:on_mouse_pressed("right", 10, 10, 1))
+    test.equal(menu.show_context_menu, false)
+
+    list.hovered = 2
+    test.ok(view:on_mouse_pressed("right", 10, 10, 1))
+    test.equal(menu.show_context_menu, true)
+    test.equal(list.selected, 2)
+    test.equal(#menu.items, 2)
+    test.equal(menu.items[1].text, "Open")
+    test.equal(menu.items[1].command, "project-search:open-selected")
+    test.equal(menu.items[2].text, "Open in Split")
+    test.equal(
+      menu.items[2].command, "project-search:open-selected-split"
+    )
+    test.is_nil(get_open_doc_view(path))
+
+    test.ok(view:on_mouse_moved(
+      menu.position.x + 1, menu.position.y + 1, 0, 0
+    ))
+    test.equal(menu.selected, 1)
+    test.ok(view:on_mouse_moved(-1, -1, 0, 0))
+    test.ok(view:on_mouse_pressed("left", -1, -1, 1))
+    test.equal(menu.show_context_menu, false)
+    test.is_nil(get_open_doc_view(path))
+  end)
+
+  test.test("opens matches from the result context menu", function(context)
+    local view = create_results_view(context)
+    local path = join_path(context.project_a, "src", "one.txt")
+    add_result(view, path, "needle one", 1, 6)
+    local list = view.results_list
+    local menu = view.context_menu
+    list:set_position(0, 0)
+    list:set_size(500, 500)
+    list.hovered = 2
+    keymap.modkeys["ctrl"] = false
+
+    test.ok(view:on_mouse_pressed("right", 10, 10, 1))
+    menu.selected = 1
+    menu:call_selected_item()
+
+    local normal_view = get_open_doc_view(path)
+    test.not_nil(normal_view)
+    test.equal(core.active_view, normal_view)
+    test.equal(
+      core.root_view.root_node:get_node_for_view(normal_view),
+      core.root_view.root_node:get_node_for_view(view)
+    )
+    test.is_nil(view.result_split_node)
+
+    core.set_active_view(view)
+    list.hovered = 2
+    test.ok(view:on_mouse_pressed("right", 10, 10, 1))
+    menu.selected = 2
+    menu:call_selected_item()
+
+    local split_view = view.result_split_views[#view.result_split_views]
+    test.not_nil(split_view)
+    test.equal(core.active_view, split_view)
+    test.not_equal(
+      core.root_view.root_node:get_node_for_view(split_view),
+      core.root_view.root_node:get_node_for_view(view)
+    )
+  end)
+
+  test.test("preserves docked and tabbed search focus behavior", function(context)
+    local view = create_results_view(context)
+    add_result(
+      view,
+      join_path(context.project_a, "src", "one.txt"),
+      "needle one", 1, 6
+    )
+
+    view:open_selected_result(true)
+    test.ok(core.active_view:extends(DocView))
+
+    view.is_global = true
+    view:open_selected_result(true)
+    test.equal(core.active_view, view)
+    view.is_global = false
   end)
 
   test.test("global helpers return the global results view", function(context)


### PR DESCRIPTION
Add a configurable split direction and commands that open project search matches normally or in a reusable side pane. Route Ctrl+left-click from the result view to the split command without changing widget APIs.

Add a match context menu backed by the same commands so results can be opened normally or in the configured split. Reuse result tabs, recreate closed panes, and preserve docked and tabbed search focus behavior.

Treat the result pane as reusable only while its original layout leaf survives. If closing the source collapses that split, leave its tabs in place and create a fresh result pane for the next split action.

Cover command routing, menu actions, split lifecycle, placement, reuse, and match selection.

Implements #389

### Preview

<img width="1920" height="1080" alt="project-search-open-split" src="https://github.com/user-attachments/assets/ffed3b12-8a71-408f-bd48-2dfc26761889" />
