### PR TITLE
Add extension hints for new files

### DIFF
--- a/data/core/commands/core.lua
+++ b/data/core/commands/core.lua
@@ -10,6 +10,29 @@ local previous_win_mode = "normal"
 local previous_win_pos = core.window_size
 local restore_title_view = false
 
+local function new_doc_extension()
+  local fallback = config.new_file_extension
+  if type(fallback) == "string" then
+    fallback = fallback:match("^%s*(.-)%s*$"):gsub("^%.*", "")
+    if fallback == "" or fallback:find("[/\\]") then fallback = nil end
+  else
+    fallback = nil
+  end
+
+  if config.new_file_extension_mode == "current" then
+    local doc = core.active_view and core.active_view.doc
+    if doc then
+      if doc.suggested_extension then return doc.suggested_extension end
+      local filename = doc.filename or doc.abs_filename
+      if filename then
+        local extension = common.basename(filename):match("^.+%.([^%.]+)$")
+        if extension then return extension end
+      end
+    end
+  end
+  return fallback
+end
+
 local function suggest_directory(text)
   text = common.home_expand(text)
   local basedir = common.dirname(core.root_project().path)
@@ -254,7 +277,9 @@ command.add(nil, {
   end,
 
   ["core:new-doc"] = function()
-    core.root_view:open_doc(core.open_doc())
+    local doc = core.open_doc()
+    doc:set_suggested_extension(new_doc_extension())
+    core.root_view:open_doc(doc)
   end,
 
   ["core:new-named-doc"] = function()

--- a/data/core/commands/doc.lua
+++ b/data/core/commands/doc.lua
@@ -634,6 +634,9 @@ local commands = {
       text = core.normalize_to_project_dir(dirname) .. PATHSEP
       if text == core.root_project().path then text = "" end
     end
+    if not dv.doc.filename and dv.doc.suggested_extension then
+      text = (text or "") .. dv.doc:get_name()
+    end
     core.command_view:enter("Save As", {
       text = text,
       submit = function(filename)

--- a/data/core/config.lua
+++ b/data/core/config.lua
@@ -222,6 +222,25 @@ config.scroll_context_lines = 1
 ---@type boolean
 config.show_line_numbers = true
 
+---The extension assigned to new untitled documents for syntax detection and
+---as the suggested filename when saving. A leading period is optional. An
+---empty string disables the configured extension, but "current" mode can
+---still inherit an extension from the active document.
+---
+---Defaults to an empty string.
+---@type string
+config.new_file_extension = ""
+
+---@alias config.newfileextensionmode
+---| "configured" # Always use `config.new_file_extension`.
+---| "current" # Follow the active document, falling back to the configured extension.
+
+---How the extension for new untitled documents is selected.
+---
+---Defaults to "configured".
+---@type config.newfileextensionmode
+config.new_file_extension_mode = "configured"
+
 ---The number of spaces each level of indentation represents.
 ---
 ---The default is 2.

--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -8,6 +8,7 @@ local common = require "core.common"
 local tokenizer = require "core.tokenizer"
 
 ---@class core.doc : core.object
+---@field suggested_extension? string Extension hint for an untitled document.
 local Doc = Object:extend()
 
 function Doc:__tostring() return "Doc" end
@@ -23,6 +24,7 @@ end
 
 function Doc:new(filename, abs_filename, new_file)
   self.new_file = new_file
+  self.suggested_extension = nil
   self.encoding = nil
   self.bom = nil
   self.binary = false
@@ -77,6 +79,8 @@ function Doc:reset_syntax()
   local path = self.abs_filename
   if not path and self.filename then
     path = core.root_project().path .. PATHSEP .. self.filename
+  elseif not path and self.suggested_extension then
+    path = "unsaved." .. self.suggested_extension
   end
   if path then path = common.normalize_path(path) end
   local syn = syntax.get(path, header)
@@ -90,7 +94,29 @@ end
 function Doc:set_filename(filename, abs_filename)
   self.filename = filename
   self.abs_filename = abs_filename
+  self.suggested_extension = nil
   self:reset_syntax()
+end
+
+
+---Set the extension suggested for an untitled document.
+---A leading period is optional. Empty or path-like values clear the hint.
+---@param extension? string
+function Doc:set_suggested_extension(extension)
+  if type(extension) == "string" then
+    extension = extension:match("^%s*(.-)%s*$")
+    extension = extension:gsub("^%.*", "")
+    if extension == "" or extension:find("[/\\]") then
+      extension = nil
+    end
+  else
+    extension = nil
+  end
+
+  if self.suggested_extension ~= extension then
+    self.suggested_extension = extension
+    self:reset_syntax()
+  end
 end
 
 
@@ -241,7 +267,9 @@ end
 
 
 function Doc:get_name()
-  return self.filename or "unsaved"
+  return self.filename
+    or (self.suggested_extension and "unsaved." .. self.suggested_extension)
+    or "unsaved"
 end
 
 

--- a/data/core/docview.lua
+++ b/data/core/docview.lua
@@ -168,6 +168,7 @@ end
 function DocView:get_state()
   return {
     filename = self.doc.filename,
+    suggested_extension = self.doc.suggested_extension,
     selection = { self.doc:get_selection() },
     scroll = { x = self.scroll.to.x, y = self.scroll.to.y },
     crlf = self.doc.crlf,
@@ -189,6 +190,9 @@ function DocView.from_state(state)
     end
   end
   if dv and dv.doc then
+    if not state.filename then
+      dv.doc:set_suggested_extension(state.suggested_extension)
+    end
     if dv.doc.new_file and state.text then
       dv.doc:insert(1, 1, state.text)
       dv.doc.crlf = state.crlf

--- a/data/plugins/settings.lua
+++ b/data/plugins/settings.lua
@@ -664,6 +664,26 @@ settings.add("Editor",
       end
     },
     {
+      label = "New File Extension",
+      description = "The extension suggested for new untitled documents. "
+        .. "Leave empty for no fallback; a leading period is optional.",
+      path = "new_file_extension",
+      type = settings.type.STRING,
+      default = ""
+    },
+    {
+      label = "New File Extension Mode",
+      description = "Always use the configured extension or follow the active "
+        .. "document and use the configured extension as a fallback.",
+      path = "new_file_extension_mode",
+      type = settings.type.SELECTION,
+      default = "configured",
+      values = {
+        {"Configured Extension", "configured"},
+        {"Follow Current File", "current"}
+      }
+    },
+    {
       label = "Keep Newline Whitespace",
       description = "Do not remove whitespace when pressing enter.",
       path = "keep_newline_whitespace",

--- a/scripts/lua/tests/doc.lua
+++ b/scripts/lua/tests/doc.lua
@@ -1,0 +1,205 @@
+local command = require "core.command"
+local config = require "core.config"
+local core = require "core"
+local Doc = require "core.doc"
+local DocView = require "core.docview"
+local test = require "core.test"
+
+require "plugins.language_lua"
+
+local function track_doc(context, doc)
+  context.docs[#context.docs + 1] = doc
+  return doc
+end
+
+local function perform_new_doc(context)
+  test.ok(command.perform("core:new-doc"))
+  return context.opened_docs[#context.opened_docs]
+end
+
+test.describe("core.doc", function()
+  test.before_each(function(context)
+    context.old_extension = config.new_file_extension
+    context.old_mode = config.new_file_extension_mode
+    context.old_active_view = core.active_view
+    context.old_last_active_view = core.last_active_view
+    context.old_open_doc = core.root_view.open_doc
+    context.old_command_enter = core.command_view.enter
+    context.docs = {}
+    context.opened_docs = {}
+
+    core.root_view.open_doc = function(_, doc)
+      context.opened_docs[#context.opened_docs + 1] = track_doc(context, doc)
+    end
+  end)
+
+  test.after_each(function(context)
+    config.new_file_extension = context.old_extension
+    config.new_file_extension_mode = context.old_mode
+    core.active_view = context.old_active_view
+    core.last_active_view = context.old_last_active_view
+    core.root_view.open_doc = context.old_open_doc
+    core.command_view.enter = context.old_command_enter
+
+    for _, doc in ipairs(context.docs) do
+      for i = #core.docs, 1, -1 do
+        if core.docs[i] == doc then
+          table.remove(core.docs, i)
+        end
+      end
+      doc:on_close()
+    end
+  end)
+
+  test.test("uses a custom extension without naming the document", function(context)
+    config.new_file_extension = ".lua"
+    config.new_file_extension_mode = "configured"
+
+    local doc = perform_new_doc(context)
+
+    test.not_nil(doc)
+    test.is_nil(doc.filename)
+    test.is_nil(doc.abs_filename)
+    test.equal(doc.suggested_extension, "lua")
+    test.equal(doc:get_name(), "unsaved.lua")
+    test.equal(doc.syntax.name, "Lua")
+  end)
+
+  test.test("follows the current extension without a configured fallback", function(context)
+    local source = Doc(nil, nil, true)
+    source:set_filename("source.py", "/source.py")
+    core.active_view = { doc = source }
+    config.new_file_extension = ""
+    config.new_file_extension_mode = "current"
+
+    local doc = perform_new_doc(context)
+
+    test.equal(doc.suggested_extension, "py")
+    test.equal(doc:get_name(), "unsaved.py")
+  end)
+
+  test.test("leaves new documents unhinted without a usable extension", function(context)
+    config.new_file_extension = ""
+
+    config.new_file_extension_mode = "configured"
+    test.is_nil(perform_new_doc(context).suggested_extension)
+
+    config.new_file_extension_mode = "current"
+    core.active_view = {}
+    local doc = perform_new_doc(context)
+    test.is_nil(doc.suggested_extension)
+    test.equal(doc:get_name(), "unsaved")
+  end)
+
+  test.test("follows current extensions and uses the configured fallback", function(context)
+    config.new_file_extension = "lua"
+    config.new_file_extension_mode = "current"
+
+    local source = Doc(nil, nil, true)
+    source:set_filename("src/module.py", "/src/module.py")
+    core.active_view = { doc = source }
+    test.equal(perform_new_doc(context).suggested_extension, "py")
+
+    local hinted = Doc(nil, nil, true)
+    hinted:set_suggested_extension("d.ts")
+    core.active_view = { doc = hinted }
+    test.equal(perform_new_doc(context).suggested_extension, "d.ts")
+
+    core.active_view = {}
+    test.equal(perform_new_doc(context).suggested_extension, "lua")
+
+    local extensionless = Doc(nil, nil, true)
+    extensionless:set_filename("Makefile", "/Makefile")
+    core.active_view = { doc = extensionless }
+    test.equal(perform_new_doc(context).suggested_extension, "lua")
+  end)
+
+  test.test("normalizes and rejects suggested extensions", function()
+    local doc = Doc(nil, nil, true)
+
+    doc:set_suggested_extension("  .tar.gz  ")
+    test.equal(doc.suggested_extension, "tar.gz")
+    test.equal(doc:get_name(), "unsaved.tar.gz")
+
+    doc:set_suggested_extension("folder/lua")
+    test.is_nil(doc.suggested_extension)
+    test.equal(doc:get_name(), "unsaved")
+
+    doc:set_suggested_extension(".")
+    test.is_nil(doc.suggested_extension)
+  end)
+
+  test.test("suggests the hinted name through Save As", function(context)
+    local doc = Doc(nil, nil, true)
+    doc:set_suggested_extension("lua")
+    local view = DocView(doc)
+    local previous = Doc(nil, nil, true)
+    previous:set_filename(
+      "sub" .. PATHSEP .. "source.txt",
+      core.root_project().path .. PATHSEP .. "sub" .. PATHSEP .. "source.txt"
+    )
+    core.active_view = view
+    core.last_active_view = DocView(previous)
+
+    local prompt, options
+    core.command_view.enter = function(_, label, opts)
+      prompt, options = label, opts
+    end
+
+    test.ok(command.perform("doc:save"))
+    test.equal(prompt, "Save As")
+    test.equal(
+      options.text,
+      "sub" .. PATHSEP .. "unsaved.lua"
+    )
+    test.is_nil(doc.filename)
+  end)
+
+  test.test("clears the hint when a real filename is assigned", function()
+    local doc = Doc(nil, nil, true)
+    doc:set_suggested_extension("lua")
+    test.equal(doc.syntax.name, "Lua")
+
+    doc:set_filename("notes.txt", "/notes.txt")
+
+    test.is_nil(doc.suggested_extension)
+    test.equal(doc:get_name(), "notes.txt")
+    test.not_equal(doc.syntax.name, "Lua")
+  end)
+
+  test.test("restores extension hints with untitled document state", function(context)
+    local doc = Doc(nil, nil, true)
+    doc:set_suggested_extension("lua")
+    doc:insert(1, 1, "local answer = 42")
+    doc:set_selection(1, 7)
+    local view = DocView(doc)
+    view.scroll.to.x = 12
+    view.scroll.to.y = 24
+
+    local state = view:get_state()
+    local restored = DocView.from_state(state)
+    track_doc(context, restored.doc)
+
+    test.equal(state.suggested_extension, "lua")
+    test.equal(restored.doc.suggested_extension, "lua")
+    test.equal(restored.doc:get_name(), "unsaved.lua")
+    test.equal(restored.doc.syntax.name, "Lua")
+    test.equal(restored.doc:get_text(1, 1, math.huge, math.huge), "local answer = 42")
+    test.same({ restored.doc:get_selection() }, { 1, 7, 1, 7 })
+    test.equal(restored.scroll.to.x, 12)
+    test.equal(restored.scroll.to.y, 24)
+  end)
+
+  test.test("keeps legacy untitled state unhinted", function(context)
+    local restored = DocView.from_state {
+      selection = { 1, 1, 1, 1 },
+      scroll = { x = 0, y = 0 },
+      crlf = false,
+      text = "legacy"
+    }
+    track_doc(context, restored.doc)
+
+    test.is_nil(restored.doc.suggested_extension)
+    test.equal(restored.doc:get_name(), "unsaved")
+  end)
+end)


### PR DESCRIPTION
Allow untitled documents to carry an extension hint without assigning a real filename. This enables syntax highlighting, descriptive tab names, Save As suggestions, active-document inheritance, and workspace restore without changing save semantics.

### New Configurations

```lua
---The extension assigned to new untitled documents for syntax detection and
---as the suggested filename when saving. A leading period is optional. An
---empty string disables the configured extension, but "current" mode can
---still inherit an extension from the active document.
---
---Defaults to an empty string.
---@type string
config.new_file_extension = ""

---@alias config.newfileextensionmode
---| "configured" # Always use `config.new_file_extension`.
---| "current" # Follow the active document, falling back to the configured extension.

---How the extension for new untitled documents is selected.
---
---Defaults to "configured".
---@type config.newfileextensionmode
config.new_file_extension_mode = "configured"
```

<img width="782" height="358" alt="new-file-settings" src="https://github.com/user-attachments/assets/a58772b7-3f9b-47ab-8387-1d75047bd9a0" />


Implements #26