### PR TITLE
Improved multi-cursor performance

### DIFF
--- a/data/core/doc/init.lua
+++ b/data/core/doc/init.lua
@@ -50,6 +50,11 @@ function Doc:reset()
   self.undo_stack = { idx = 1 }
   self.redo_stack = { idx = 1 }
   self.clean_change_id = 1
+  self.change_id = 1
+  self.next_change_id = 1
+  self.edit_depth = 0
+  self.edit_start = nil
+  self.replaying, self.replay_change_id = nil, nil
   self.highlighter = Highlighter(self)
   self.overwrite = false
   self:reset_syntax()
@@ -285,6 +290,7 @@ end
 
 function Doc:clean()
   self.clean_change_id = self:get_change_id()
+  self.undo_stack.force_group = true
 end
 
 
@@ -296,8 +302,11 @@ function Doc:get_indent_info()
 end
 
 
+---Return the text state's identity, restored by undo/redo and never reused
+---for a different edit after undoing back past a saved state.
+---@return integer
 function Doc:get_change_id()
-  return self.undo_stack.idx
+  return self.change_id
 end
 
 local function sort_positions(line1, col1, line2, col2)
@@ -369,7 +378,13 @@ function Doc:set_selections(idx, line1, col1, line2, col2, swap, rm)
   if swap then line1, col1, line2, col2 = line2, col2, line1, col1 end
   line1, col1 = self:sanitize_position(line1, col1)
   line2, col2 = self:sanitize_position(line2 or line1, col2 or col1)
-  common.splice(self.selections, (idx - 1)*4 + 1, rm == nil and 4 or rm, { line1, col1, line2, col2 })
+  local i = (idx - 1) * 4 + 1
+  if rm == nil or rm == 4 then
+    self.selections[i], self.selections[i + 1] = line1, col1
+    self.selections[i + 2], self.selections[i + 3] = line2, col2
+  else
+    common.splice(self.selections, i, rm, { line1, col1, line2, col2 })
+  end
 end
 
 function Doc:add_selection(line1, col1, line2, col2, swap)
@@ -401,6 +416,31 @@ function Doc:set_selection(line1, col1, line2, col2, swap)
 end
 
 function Doc:merge_cursors(idx)
+  -- Most selections have ordered heads. Compact these without a quadratic
+  -- duplicate search; reversed or overlapping ranges retain the general path.
+  if not idx then
+    local s, ordered = self.selections, true
+    for i = 5, #s, 4 do
+      if s[i] < s[i - 4] or s[i] == s[i - 4] and s[i + 1] < s[i - 3] then
+        ordered = false
+        break
+      end
+    end
+    if ordered then
+      local write, last = 1, self.last_selection
+      for read = 1, #s, 4 do
+        if write == 1 or s[read] ~= s[write - 4] or s[read + 1] ~= s[write - 3] then
+          for j = 0, 3 do s[write + j] = s[read + j] end
+          write = write + 4
+        elseif (read + 3) / 4 <= self.last_selection then
+          last = last - 1
+        end
+      end
+      for i = #s, write, -1 do s[i] = nil end
+      self.last_selection = last
+      return
+    end
+  end
   local table_index = idx and (idx - 1) * 4 + 1
   for i = (table_index or (#self.selections - 3)), (table_index or 5), -4 do
     for j = 1, i - 4, 4 do
@@ -517,43 +557,88 @@ function Doc:get_char(line, col)
 end
 
 
-local function push_undo(undo_stack, time, type, ...)
-  undo_stack[undo_stack.idx] = { type = type, time = time, ... }
-  undo_stack[undo_stack.idx - config.max_undos] = nil
-  undo_stack.idx = undo_stack.idx + 1
+local function copy_selections(selections)
+  local copy = {}
+  for i = 1, #selections do copy[i] = selections[i] end
+  return copy
 end
 
 
-local function pop_undo(self, undo_stack, redo_stack, modified)
-  -- pop command
-  local cmd = undo_stack[undo_stack.idx - 1]
-  if not cmd then return end
-  undo_stack.idx = undo_stack.idx - 1
-
-  -- handle command
-  if cmd.type == "insert" then
-    local line, col, text = table.unpack(cmd)
-    self:raw_insert(line, col, text, redo_stack, cmd.time)
-  elseif cmd.type == "remove" then
-    local line1, col1, line2, col2 = table.unpack(cmd)
-    self:raw_remove(line1, col1, line2, col2, redo_stack, cmd.time)
-  elseif cmd.type == "selection" then
-    self.selections = { table.unpack(cmd) }
-    self:sanitize_selection()
+local function push_undo(self, stack, time, kind, ...)
+  local persistent = stack == self.undo_stack or stack == self.redo_stack
+  local previous = stack[stack.idx - 1]
+  local continuing = persistent and (self.replaying
+    or self.edit_start == stack.last and self.edit_start ~= nil)
+  if not stack.last or stack.force_group or not continuing
+    and math.abs(time - previous.time) >= config.undo_merge_timeout
+  then
+    -- Keep primitive records flat for raw-edit hooks, but retain and evict
+    -- whole timeout groups. Only the group's first edit copies the cursors.
+    local group = copy_selections(self.selections)
+    group.type, group.time = "selection", time
+    group.last_selection = self.last_selection
+    group.previous = stack.last
+    if stack.last then stack[stack.last].next = stack.idx end
+    stack.last = stack.idx
+    stack.first = stack.first or stack.idx
+    stack.count = (stack.count or 0) + 1
+    stack[stack.idx] = group
+    stack.idx = stack.idx + 1
+    stack.force_group = nil
+    while stack.count > math.max(1, config.max_undos) do
+      local first = stack.first
+      stack.first = stack[first].next
+      for i = first, stack.first - 1 do stack[i] = nil end
+      stack[stack.first].previous = nil
+      stack.count = stack.count - 1
+    end
   end
-
-  modified = modified or (cmd.type ~= "selection")
-
-  -- if next undo command is within the merge timeout then treat as a single
-  -- command and continue to execute it
-  local next = undo_stack[undo_stack.idx - 1]
-  if next and math.abs(cmd.time - next.time) < config.undo_merge_timeout then
-    return pop_undo(self, undo_stack, redo_stack, modified)
+  stack[stack.idx] = {
+    type = kind, time = time, change_id = self.change_id, ...
+  }
+  stack.idx = stack.idx + 1
+  -- Preview plugins supply throwaway stacks; these must not change the
+  -- document's saved-state identity or consume persistent change IDs.
+  if not persistent then return end
+  if self.edit_depth > 0 then self.edit_start = stack.last end
+  if self.replay_change_id then
+    self.change_id = self.replay_change_id
+  else
+    self.next_change_id = self.next_change_id + 1
+    self.change_id = self.next_change_id
   end
+end
 
-  if modified then
-    self:on_text_change("undo")
-  end
+
+local function pop_undo(self, source, destination)
+  local start = source.last
+  if not start then return end
+  local group = source[start]
+  destination.force_group = true
+  self.replaying = true
+  local ok, err = pcall(function()
+    for i = source.idx - 1, start + 1, -1 do
+      local cmd = source[i]
+      self.replay_change_id = cmd.change_id
+      if cmd.type == "insert" then
+        self:raw_insert(cmd[1], cmd[2], cmd[3], destination, cmd.time)
+      elseif cmd.type == "remove" then
+        self:raw_remove(cmd[1], cmd[2], cmd[3], cmd[4], destination, cmd.time)
+      end
+      source[i] = nil
+      source.idx = i
+    end
+  end)
+  self.replaying, self.replay_change_id = nil, nil
+  if not ok then error(err, 0) end
+  source[start], source.idx = nil, start
+  source.last, source.count = group.previous, source.count - 1
+  if source.last then source[source.last].next = nil else source.first = nil end
+  self.selections = copy_selections(group)
+  self.last_selection = group.last_selection
+  self:sanitize_selection()
+  source.force_group, destination.force_group = true, true
+  self:on_text_change("undo")
 end
 
 local function update_clean_lines(self, line1, line2)
@@ -588,6 +673,8 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
   -- split text into lines and merge with line at insertion point
   local lines = split_lines(text)
   local len = #lines[#lines]
+  push_undo(self, undo_stack, time, "remove",
+    line, col, line + #lines - 1, #lines == 1 and col + len or len + 1)
   local before = self.lines[line]:sub(1, col - 1)
   local after = self.lines[line]:sub(col)
   for i = 1, #lines - 1 do
@@ -601,31 +688,35 @@ function Doc:raw_insert(line, col, text, undo_stack, time)
 
   update_clean_lines(self, line, ((line + #lines - 1) == line) and line or #self.lines)
 
-  -- keep cursors where they should be
-  for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
-    if cline1 < line then break end
-    local line_addition = (line < cline1 or col < ccol1) and #lines - 1 or 0
-    local column_addition = line == cline1 and ccol1 > col and len or 0
-    self:set_selections(idx, cline1 + line_addition, ccol1 + column_addition, cline2 + line_addition, ccol2 + column_addition)
+  local same_line = #lines == 1 and not self.binary
+  if same_line then
+    local s = self.selections
+    for i = 1, #s, 2 do
+      if s[i] == line and s[i + 1] > col then
+        s[i + 1] = s[i + 1] + len
+      end
+    end
+  else
+    -- keep cursors where they should be
+    for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
+      if cline1 < line then break end
+      local line_addition = (line < cline1 or col < ccol1) and #lines - 1 or 0
+      local column_addition = line == cline1 and ccol1 > col and len or 0
+      self:set_selections(idx, cline1 + line_addition, ccol1 + column_addition, cline2 + line_addition, ccol2 + column_addition)
+    end
   end
-
-  -- push undo
-  local line2, col2 = self:position_offset(line, col, #text)
-  push_undo(undo_stack, time, "selection", table.unpack(self.selections))
-  push_undo(undo_stack, time, "remove", line, col, line2, col2)
 
   -- update highlighter and assure selection is in bounds
   self.highlighter:insert_notify(line, #lines - 1)
   self:clear_cache(line, #lines - 1)
-  self:sanitize_selection()
+  if not same_line then self:sanitize_selection() end
 end
 
 
 function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   -- push undo
   local text = self:get_text(line1, col1, line2, col2)
-  push_undo(undo_stack, time, "selection", table.unpack(self.selections))
-  push_undo(undo_stack, time, "insert", line1, col1, text)
+  push_undo(self, undo_stack, time, "insert", line1, col1, text)
 
   -- get line content before/after removed text
   local before = self.lines[line1]:sub(1, col1 - 1)
@@ -640,38 +731,50 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   update_clean_lines(self, line1, line2 == line1 and line2 or #self.lines)
 
   local merge = false
-
-  -- keep selections in correct positions: each pair (line, col)
-  -- * remains unchanged if before the deleted text
-  -- * is set to (line1, col1) if in the deleted text
-  -- * is set to (line1, col - col_removal) if on line2 but out of the deleted text
-  -- * is set to (line - line_removal, col) if after line2
-  for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
-    if cline2 < line1 then break end
-    local l1, c1, l2, c2 = cline1, ccol1, cline2, ccol2
-
-    if cline1 > line1 or (cline1 == line1 and ccol1 > col1) then
-      if cline1 > line2 then
-        l1 = l1 - line_removal
-      else
-        l1 = line1
-        c1 = (cline1 == line2 and ccol1 > col2) and c1 - col_removal or col1
+  local same_line = line1 == line2 and not self.binary
+  if same_line then
+    local s, heads_at_start = self.selections, 0
+    for i = 1, #s, 2 do
+      if s[i] == line1 and s[i + 1] > col1 then
+        s[i + 1] = math.max(col1, s[i + 1] - col_removal)
+      end
+      if i % 4 == 1 and s[i] == line1 and s[i + 1] == col1 then
+        heads_at_start = heads_at_start + 1
       end
     end
+    merge = heads_at_start > 1
+  else
+    -- keep selections in correct positions: each pair (line, col)
+    -- * remains unchanged if before the deleted text
+    -- * is set to (line1, col1) if in the deleted text
+    -- * is set to (line1, col - col_removal) if on line2 but out of the deleted text
+    -- * is set to (line - line_removal, col) if after line2
+    for idx, cline1, ccol1, cline2, ccol2 in self:get_selections(true, true) do
+      if cline2 < line1 then break end
+      local l1, c1, l2, c2 = cline1, ccol1, cline2, ccol2
 
-    if cline2 > line1 or (cline2 == line1 and ccol2 > col1) then
-      if cline2 > line2 then
-        l2 = l2 - line_removal
-      else
-        l2 = line1
-        c2 = (cline2 == line2 and ccol2 > col2) and c2 - col_removal or col1
+      if cline1 > line1 or (cline1 == line1 and ccol1 > col1) then
+        if cline1 > line2 then
+          l1 = l1 - line_removal
+        else
+          l1 = line1
+          c1 = (cline1 == line2 and ccol1 > col2) and c1 - col_removal or col1
+        end
       end
-    end
 
-    if l1 == line1 and c1 == col1 then merge = true end
-    self:set_selections(idx, l1, c1, l2, c2)
+      if cline2 > line1 or (cline2 == line1 and ccol2 > col1) then
+        if cline2 > line2 then
+          l2 = l2 - line_removal
+        else
+          l2 = line1
+          c2 = (cline2 == line2 and ccol2 > col2) and c2 - col_removal or col1
+        end
+      end
+
+      if l1 == line1 and c1 == col1 then merge = true end
+      self:set_selections(idx, l1, c1, l2, c2)
+    end
   end
-
   if merge then
     self:merge_cursors()
   end
@@ -679,16 +782,13 @@ function Doc:raw_remove(line1, col1, line2, col2, undo_stack, time)
   -- update highlighter and assure selection is in bounds
   self.highlighter:remove_notify(line1, line_removal)
   self:clear_cache(line1, line_removal)
-  self:sanitize_selection()
+  if not same_line then self:sanitize_selection() end
 end
 
 
 function Doc:insert(line, col, text)
+  if text == "" then return end
   self.redo_stack = { idx = 1 }
-  -- Reset the clean id when we're pushing something new before it
-  if self:get_change_id() < self.clean_change_id then
-    self.clean_change_id = -1
-  end
   line, col = self:sanitize_position(line, col)
   self:raw_insert(line, col, text, self.undo_stack, system.get_time())
   self:on_text_change("insert")
@@ -696,22 +796,23 @@ end
 
 
 function Doc:remove(line1, col1, line2, col2)
-  self.redo_stack = { idx = 1 }
   line1, col1 = self:sanitize_position(line1, col1)
   line2, col2 = self:sanitize_position(line2, col2)
   line1, col1, line2, col2 = sort_positions(line1, col1, line2, col2)
+  if line1 == line2 and col1 == col2 then return end
+  self.redo_stack = { idx = 1 }
   self:raw_remove(line1, col1, line2, col2, self.undo_stack, system.get_time())
   self:on_text_change("remove")
 end
 
 
 function Doc:undo()
-  pop_undo(self, self.undo_stack, self.redo_stack, false)
+  pop_undo(self, self.undo_stack, self.redo_stack)
 end
 
 
 function Doc:redo()
-  pop_undo(self, self.redo_stack, self.undo_stack, false)
+  pop_undo(self, self.redo_stack, self.undo_stack)
 end
 
 
@@ -956,5 +1057,22 @@ function Doc:clear_search_selections()
   self.search_selections = {}
 end
 
+
+-- Existing Doc operations supply private synchronous boundaries. Separate
+-- plugin calls still use the normal timeout, without requiring a grouping API.
+for _, name in ipairs {
+  "text_input", "ime_text_editing", "delete_to_cursor", "replace_cursor",
+  "replace", "indent_text"
+} do
+  local edit = Doc[name]
+  Doc[name] = function(self, ...)
+    self.edit_depth = self.edit_depth + 1
+    local result = table.pack(pcall(edit, self, ...))
+    self.edit_depth = self.edit_depth - 1
+    if self.edit_depth == 0 then self.edit_start = nil end
+    if not result[1] then error(result[2], 0) end
+    return table.unpack(result, 2, result.n)
+  end
+end
 
 return Doc


### PR DESCRIPTION
Avoid repeated selection splices and full cursor sanitization for single-line edits. Update affected endpoints directly and compact ordered duplicate cursor heads in linear time, retaining the fallback.

Store one selection snapshot per undo group and replay iteratively. Retain and evict complete groups under the existing max_undos setting so large multi-cursor edits no longer discard part of their undo history. Keep existing Doc edit methods atomic through private synchronous boundaries; separate plugin calls retain timeout-based grouping. No new public API or command/plugin adaptations are required.

Track saved text-state identities across undo, redo and edit branches. Preserve raw edit hooks and primitive record layouts. Scratch stacks used by preview plugins do not affect persistent IDs or active groups. Empty edits leave redo history intact.

Benchmark against master cfaf566d: select all 441 occurrences of "core" in data/core/init.lua with Ctrl+Shift+L twice, original autoinsert, the same local executable and SDL dummy. Seven repetitions, median ms:

```
  Operation                    Master       This change
  First typed replacement       644.153           9.262
  Following character           225.722           4.708
  Undo 12-character burst       5229.495          57.121
  Delete selected words         274.163           4.970
  Undo selected-word deletion   438.092           3.405
  Backspace                     272.966           5.626
  Undo Backspace                448.567           3.325
  Delete                        328.226           4.680
  Undo Delete                   373.128           3.164
```
Typing is roughly 48-70x faster; Backspace undo is about 135x faster. Master's burst undo loses earlier text; this version restores it fully. These are input CPU timings, not rendered-frame or global-profile times.

Validated with 16 focused Doc regressions and the full Lua test suite (379 passed), including undo/redo, history limits and scratch-stack use.