### PR TITLE
Fix overlapping trailing whitespace markers

### DIFF
--- a/data/plugins/drawwhitespace.lua
+++ b/data/plugins/drawwhitespace.lua
@@ -16,6 +16,8 @@ local config = require "core.config"
 ---@field show_leading boolean
 ---Show white spaces at the end of a line.
 ---@field show_trailing boolean
+---Replace trailing space markers with error-colored blocks.
+---@field show_trailing_error boolean
 ---Show white spaces between words.
 ---@field show_middle boolean
 ---Show white spaces on selected text only.
@@ -46,6 +48,7 @@ config.plugins.drawwhitespace = common.merge({
   enabled = false,
   show_leading = true,
   show_trailing = true,
+  show_trailing_error = false,
   show_middle = true,
   show_selected_only = false,
 
@@ -122,28 +125,6 @@ config.plugins.drawwhitespace = common.merge({
       path = "show_trailing_error",
       type = "toggle",
       default = false,
-      on_apply = function(enabled)
-        local found = nil
-        local substitutions = config.plugins.drawwhitespace.substitutions
-        for i, sub in ipairs(substitutions) do
-          if sub.trailing_error then
-            found = i
-          end
-        end
-        if found == nil and enabled then
-          table.insert(substitutions, {
-            char = " ",
-            sub = "█",
-            show_leading = false,
-            show_middle = false,
-            show_trailing = true,
-            trailing_color = style.error,
-            trailing_error = true
-          })
-        elseif found ~= nil and not enabled then
-          table.remove(substitutions, found)
-        end
-      end
     }
   }
 }, config.plugins.drawwhitespace)
@@ -286,6 +267,11 @@ function DocView:draw_line_text(idx, x, y)
       end
 
       if draw then
+        local marker = sub
+        if char == " " and ae >= line_len
+        and get_option(substitution, "show_trailing_error") then
+          marker, color = "█", style.error
+        end
         -- We need to draw tabs one at a time because they might have a
         -- different size than the substituting character.
         -- This also applies to any other char if we use non-monospace fonts
@@ -293,10 +279,10 @@ function DocView:draw_line_text(idx, x, y)
         if char == "\t" then
           for i = as,ae-1 do
             tx = self:get_col_x_offset(idx, i) + x
-            tx = renderer.draw_text(font, sub, tx, ty, color)
+            tx = renderer.draw_text(font, marker, tx, ty, color)
           end
         else
-          tx = renderer.draw_text(font, string.rep(sub, ae - as), tx, ty, color)
+          tx = renderer.draw_text(font, string.rep(marker, ae - as), tx, ty, color)
         end
 
         end

--- a/scripts/lua/tests/drawwhitespace.lua
+++ b/scripts/lua/tests/drawwhitespace.lua
@@ -1,0 +1,151 @@
+local test = require "core.test"
+local core = require "core"
+local common = require "core.common"
+local config = require "core.config"
+local style = require "core.style"
+local Doc = require "core.doc"
+local DocView = require "core.docview"
+
+local path = debug.getinfo(1, "S").source:gsub("^@", "")
+local root = common.dirname(common.dirname(common.dirname(common.dirname(path))))
+local block = string.char(0xe2, 0x96, 0x88)
+
+local function clear_options()
+  local options = config.plugins.drawwhitespace
+  if type(options) == "table" then
+    for key in pairs(options) do options[key] = nil end
+  end
+end
+
+local function set_error(enabled)
+  local options = config.plugins.drawwhitespace
+  options.show_trailing_error = enabled
+  for _, option in ipairs(options.config_spec) do
+    if option.path == "show_trailing_error" and option.on_apply then
+      option.on_apply(enabled)
+    end
+  end
+end
+
+local function make_view(context, text)
+  local doc = Doc(nil, nil, true)
+  doc.lines = { text }
+  doc.highlighter:reset()
+  context.docs[#context.docs + 1] = doc
+  local view = DocView(doc)
+  view.size.x, view.size.y = 640, 200
+  core.active_view = view
+  return view
+end
+
+local function draw(context, view)
+  context.calls = {}
+  view:draw_line_text(1, 0, 0)
+  return context.calls
+end
+
+test.describe("drawwhitespace", function()
+  test.before_each(function(c)
+    c.options = common.merge(config.plugins.drawwhitespace)
+    c.active_view = core.active_view
+    c.update, c.draw_line_text = DocView.update, DocView.draw_line_text
+    c.draw_text = renderer.draw_text
+    c.docs, c.calls = {}, {}
+    clear_options()
+    DocView.update, DocView.draw_line_text = function() end, function() end
+    dofile(root .. "/data/plugins/drawwhitespace.lua")
+    local options = config.plugins.drawwhitespace
+    options.enabled = true
+    options.show_leading, options.show_middle = false, false
+    options.show_trailing, options.show_selected_only = true, false
+    renderer.draw_text = function(font, text, x, y, color)
+      c.calls[#c.calls + 1] = { text = text, color = color, x = x }
+      return x + font:get_width(text)
+    end
+  end)
+
+  test.after_each(function(c)
+    clear_options()
+    config.plugins.drawwhitespace, core.active_view = c.options, c.active_view
+    DocView.update, DocView.draw_line_text = c.update, c.draw_line_text
+    renderer.draw_text = c.draw_text
+    for _, doc in ipairs(c.docs) do doc:on_close() end
+  end)
+
+  test.test("trailing errors replace space dots rather than overlap them", function(c)
+    set_error(true)
+    local calls = draw(c, make_view(c, "end   \n"))
+    test.equal(#calls, 1)
+    test.equal(calls[1].text, block:rep(3))
+    test.same(calls[1].color, style.error)
+  end)
+
+  test.test("error markers honor the trailing visibility setting", function(c)
+    set_error(true)
+    config.plugins.drawwhitespace.show_trailing = false
+    test.equal(#draw(c, make_view(c, "end   \n")), 0)
+  end)
+
+  test.test("Lua configuration enables errors without a settings callback", function(c)
+    config.plugins.drawwhitespace.show_trailing_error = true
+    local calls = draw(c, make_view(c, "end \n"))
+    test.equal(#calls, 1)
+    test.equal(calls[1].text, block)
+    test.same(calls[1].color, style.error)
+  end)
+
+  test.test("toggling errors restores the configured marker and color", function(c)
+    local options = config.plugins.drawwhitespace
+    options.substitutions[1].sub = "s"
+    options.trailing_color = { 10, 20, 30, 255 }
+    local count = #options.substitutions
+    local view = make_view(c, "end  \n")
+    for _ = 1, 3 do
+      set_error(true)
+      local calls = draw(c, view)
+      test.equal(#calls, 1)
+      test.equal(calls[1].text, block:rep(2))
+      test.equal(#options.substitutions, count)
+      set_error(false)
+      calls = draw(c, view)
+      test.equal(#calls, 1)
+      test.equal(calls[1].text, "ss")
+      test.same(calls[1].color, options.trailing_color)
+    end
+  end)
+
+  test.test("error rendering leaves leading, middle and tab markers unchanged", function(c)
+    local options = config.plugins.drawwhitespace
+    options.show_leading, options.show_middle = true, true
+    local marker, tab = options.substitutions[1].sub, options.substitutions[2].sub
+    set_error(true)
+    local calls = draw(c, make_view(c, "  end body  \n"))
+    test.equal(#calls, 3)
+    test.equal(calls[1].text, marker:rep(2))
+    test.equal(calls[2].text, marker)
+    test.equal(calls[3].text, block:rep(2))
+    calls = draw(c, make_view(c, "end\t\n"))
+    test.equal(#calls, 1)
+    test.equal(calls[1].text, tab)
+    test.same(calls[1].color, options.color)
+  end)
+
+  test.test("selected-only errors are drawn only within the selection", function(c)
+    config.plugins.drawwhitespace.show_selected_only = true
+    set_error(true)
+    local view = make_view(c, "end   \n")
+    view.doc:set_selection(1, 5, 1, 7)
+    view:update()
+    local calls = draw(c, view)
+    test.equal(#calls, 1)
+    test.equal(calls[1].text, block:rep(2))
+    test.same(calls[1].color, style.error)
+  end)
+
+  test.test("whitespace-only lines use error blocks without leading dots", function(c)
+    set_error(true)
+    local calls = draw(c, make_view(c, "   \n"))
+    test.equal(#calls, 1)
+    test.equal(calls[1].text, block:rep(3))
+  end)
+end)


### PR DESCRIPTION
Render trailing-space error blocks in place of normal dots instead of appending an overlapping substitution from the settings callback. Honor trailing-whitespace visibility and read the error option directly so Lua configuration works without invoking the settings UI.

Preserve configured markers and colors when errors are disabled, along with existing leading-space, middle-space, tab and selection behavior. Add seven regression tests covering these cases and repeated toggles.