### PR TITLE
Fix PGO training cleanup and locked-node failure

### DIFF
--- a/scripts/lua/pgo.lua
+++ b/scripts/lua/pgo.lua
@@ -239,6 +239,8 @@ local function input_stress(abs_path)
   end
 
   dv.doc:clear_undo_redo()
+  -- Discard temporary training edits without opening a save prompt.
+  dv.doc:clean()
   command.perform "root:close"
 end
 
@@ -636,7 +638,7 @@ core.add_background_thread(function()
 
   core.log("Draw rect stress")
   coroutine.yield()
-  local node = core.root_view:get_active_node()
+  local node = core.root_view:get_active_node_default()
   local c = Cube()
   node:add_view(c)
   core.set_active_view(c)


### PR DESCRIPTION
Explicitly mark the temporary input-stress document clean before closing it. Clearing undo history no longer resets its text-state change ID, so the document remained dirty and root:close opened a save prompt in a locked node. Adding the cube view then failed and training could not finish unattended.

Use get_active_node_default() for cube insertion so a focused locked panel cannot become its target. Keep the fix in the training script without changing document dirty-state semantics or saving synthetic edits.